### PR TITLE
Fix for mid lbuf reuse issue

### DIFF
--- a/Server/src/functions.c
+++ b/Server/src/functions.c
@@ -14376,6 +14376,11 @@ FUNCTION(fun_mid)
        return;
     }
 
+    if( l > strlen( strip_ansi( fargs[0] ) ) ) {
+       safe_str( "", buff, bufcx );
+       return;
+    }
+
     initialize_ansisplitter(outsplit, LBUF_SIZE);
     outbuff = alloc_lbuf("fun_mid");
     split_ansi(strip_ansi(fargs[0]), outbuff, outsplit);


### PR DESCRIPTION
Something odd with mid, I'm not sure what the root cause is. This patch does not address the root cause, but it does fix the issue with mid.

The symptom is this: Occasionally, mid() called with a starting position beyond the length of the string will return recognizable text from older LBUFs. I've added a check to mid() to handle this case. Steps to reproduce on a completely clean environment:
1. @dol [lnum(10)]=th [iter(lnum(1000),lnum(1000),,%r)]
2. th [mid(abc,50,50)]
