### PR TITLE
Refactor of asksource/config process so that variable defs are written to .defs files

### DIFF
--- a/Server/bin/asksource.sh
+++ b/Server/bin/asksource.sh
@@ -1293,7 +1293,6 @@ setdefaults() {
         DEFS="${DEFS} -DHAS_OPENSSL"
      fi
   fi
-  DEFS="DEFS = ${DEFS}"
 }
 
 ###################################################################
@@ -1463,92 +1462,60 @@ setlibs() {
       echo "Compiling with system pcre library..."
       MORELIBS="${MORELIBS} -lpcre"
    fi
-   MORELIBS="MORELIBS = ${MORELIBS}"
 }
 
 ###################################################################
 # UPDATEMAKEFILE - Update the makefile with the changes
 ###################################################################
 updatemakefile() {
-   echo "Updating the DEFS section of the Makefile now.  Please wait..."
-   cat ../src/Makefile|sed "s/$(grep ^DEF ../src/Makefile|sed "s/\//\\\\\//g")/${DEFS}/g" > /tmp/$$CONF$$
-   mv -f ../src/Makefile ../src/Makefile.${DATE} 2>/dev/null
-   mv -f /tmp/$$CONF$$ ../src/Makefile 2>/dev/null
-   rm -f /tmp/$$CONF$$ 2>/dev/null
+   echo 'Updating the DEFS section of the Makefile now.  Please wait...'
+   echo "DEFS = ${DEFS}" > ../src/make.defs
 
-#  Let's do the door additions here
-   if [ "${XB[2]}" = "X" ]
+   echo '# Begin Door Configurations' >> ../src/make.defs
+   if [ "${XB[2]}" = 'X' ]
    then
-      cat ../src/Makefile|sed "s/^#DR_DEF/DR_DEF/g" > /tmp/$$CONF$$
-      mv -f /tmp/$$CONF$$ ../src/Makefile 2>/dev/null
-      rm -f /tmp/$$CONF$$ 2>/dev/null
+      echo 'DR_DEF = -DENABLE_DOORS -DEXAMPLE_DOOR_CODE' >> ../src/make.defs
       if [ "${XD[1]}" = "X" ]
       then
-         cat ../src/Makefile|sed "s/^#DRMUSH/DRMUSH/g" > /tmp/$$CONF$$
-      else
-         cat ../src/Makefile|sed "s/^DRMUSH/#DRMUSH/g" > /tmp/$$CONF$$
+         echo 'DRMUSHSRC = door_mush.c' >> ../src/make.defs
+         echo 'DRMUSHOBJ = door_mush.o' >> ../src/make.defs
       fi
-      mv -f /tmp/$$CONF$$ ../src/Makefile 2>/dev/null
-      rm -f /tmp/$$CONF$$ 2>/dev/null
       if [ "${XD[2]}" = "X" ]
       then
-         cat ../src/Makefile|sed "s/^#DREMPIRE/DREMPIRE/g"|sed "s/^#DR_HDR/DR_HDR/g" > /tmp/$$CONF$$
-      else
-         cat ../src/Makefile|sed "s/^DREMPIRE/#DREMPIRE/g"|sed "s/^DR_HDR/#DR_HDR/g" > /tmp/$$CONF$$
+         echo 'DREMPIRESRC = empire.c' >> ../src/make.defs
+         echo 'DREMPIREOBJ = empire.o' >> ../src/make.defs
+         echo 'DREMPIREHDR = empire.h' >> ../src/make.defs
       fi
-      mv -f /tmp/$$CONF$$ ../src/Makefile 2>/dev/null
-      rm -f /tmp/$$CONF$$ 2>/dev/null
       if [ "${XD[3]}" = "X" ]
       then
-         cat ../src/Makefile|sed "s/^#DRMAIL/DRMAIL/g" > /tmp/$$CONF$$
-      else
-         cat ../src/Makefile|sed "s/^DRMAIL/#DRMAIL/g" > /tmp/$$CONF$$
+         echo 'DRMAILSRC = door_mail.c' >> ../src/make.defs
+         echo 'DRMAILOBJ = door_mail.o' >> ../src/make.defs
       fi
-      mv -f /tmp/$$CONF$$ ../src/Makefile 2>/dev/null
-      rm -f /tmp/$$CONF$$ 2>/dev/null
-   else
-      cat ../src/Makefile|sed "s/^DR_DEF/#DR_DEF/g"|sed "s/^DRMUSH/#DRMUSH/g"| \
-         sed "s/^DREMPIRE/#DREMPIRE/g"|sed "s/^DRMAIL/#DRMAIL/g" > /tmp/$$CONF$$
-      mv -f /tmp/$$CONF$$ ../src/Makefile 2>/dev/null
-      rm -f /tmp/$$CONF$$ 2>/dev/null
    fi
+   echo '# End Door Configurations' >> ../src/make.defs
+
    if [ "${XB[5]}" = "X" ]
    then
       echo "Compiling to QDBM database."
-      sed "s~^$(grep "^LIBS " ../src/Makefile)~LIBS = -L./qdbm/ -lqdbm~g" ../src/Makefile > /tmp/$$CONF$$
-      mv -f /tmp/$$CONF$$ ../src/Makefile
-      rm -f /tmp/$$CONF$$
-      sed "s~^$(grep "^COMP=" ../src/do_compile.sh)~COMP=qdbm~g" ../src/do_compile.sh > /tmp/$$CONF$$
-      mv -f /tmp/$$CONF$$ ../src/do_compile.sh
-      chmod 755 ../src/do_compile.sh
-      rm -f /tmp/$$CONF$$
+      echo '# Use QDBM. See also do_compile.defs' >> ../src/make.defs
+      echo 'LIBS = -L./qdbm/ -lqdbm' >> ../src/make.defs
+      echo 'COMP=qdbm' > ../src/do_compile.defs
    else
       echo "Compiling to GDBM database (default)."
-      sed "s~^$(grep "^LIBS " ../src/Makefile)~LIBS = -L./gdbm-1.8.3/.libs/ -lgdbm_compat -L./gdbm-1.8.3/ -lgdbm~g" ../src/Makefile > /tmp/$$CONF$$
-      mv -f /tmp/$$CONF$$ ../src/Makefile
-      rm -f /tmp/$$CONF$$
-      sed "s~^$(grep "^COMP=" ../src/do_compile.sh)~COMP=gdbm~g" ../src/do_compile.sh > /tmp/$$CONF$$
-      mv -f /tmp/$$CONF$$ ../src/do_compile.sh
-      chmod 755 ../src/do_compile.sh
-      rm -f /tmp/$$CONF$$
+      echo '# Use (default) GDBM. See also do_compile.defs' >> ../src/make.defs
+      echo 'LIBS = -L./gdbm-1.8.3/.libs/ -lgdbm_compat -L./gdbm-1.8.3/ -lgdbm' >> ../src/make.defs
+      echo 'COMP=gdbm' > ../src/do_compile.defs
    fi
    # add CFLAGS for low memory
    if [ "${X[23]}" = "X" ]
    then
       echo "Adding CFLAG option for low memory compile..."
-      cat ../src/Makefile|sed "s/^#CFLAG/CFLAG/g" > /tmp/$$CONF$$
-   else
-      cat ../src/Makefile|sed "s/^CFLAG/#CFLAG/g" > /tmp/$$CONF$$
+      echo '# Low-memory compile' >> ../src/make.defs
+      echo 'CFLAGS = --param ggc-min-expand=0 --param ggc-min-heapsize=8192' >> ../src/make.defs
    fi
-   mv -f /tmp/$$CONF$$ ../src/Makefile 2>/dev/null
-   rm -f /tmp/$$CONF$$ 2>/dev/null
    echo "...completed."
    echo "Updating the MORELIBS section of the Makefile now.  Please wait..."
-   cat ../src/Makefile|sed "s/$(grep ^MORELIBS ../src/Makefile| \
-       sed "s/\//\\\\\//g")/${MORELIBS}/g" > /tmp/$$CONF$$
-   mv -f ../src/Makefile ../src/Makefile.${DATE} 2>/dev/null
-   mv -f /tmp/$$CONF$$ ../src/Makefile 2>/dev/null
-   rm -f /tmp/$$CONF$$ 2>/dev/null
+   echo "MORELIBS = ${MORELIBS}" >> ../src/make.defs
    echo "...completed."
 }
 

--- a/Server/src/Makefile
+++ b/Server/src/Makefile
@@ -4,6 +4,8 @@
 # Search for the text 'CONFIGURATION SECTION' and make any changes needed
 # there.
 
+include make.defs
+
 SHELL=/bin/sh
 srcdir = .
 bindir = ../bin
@@ -17,13 +19,12 @@ else
 endif
 # CPP = gcc -E	# This is broken in autoconf.  Sigh.
 CPP = $(CC) -E
-# Sometime, LIBS won't allow '-lndbm' here.  If so, remove it.
-# If using CYGWIN, comment out the whole line.
-LIBS = -L./gdbm-1.8.3/.libs/ -lgdbm_compat -L./gdbm-1.8.3/ -lgdbm 
-#LIBS = -L./qdbm/ -lqdbm
+
+# LIBS is now written to make.defs by asksource.sh
+
 LIBOBJS = 
-# for compiling on lowmem systems use this
-#CFLAGS = --param ggc-min-expand=0 --param ggc-min-heapsize=8192
+
+# CFLAGS (used only to enable low-mem compile) is now written to make.defs by asksource.sh
 
 # If you wish to debug the code, run under this
 OPTIM = -g
@@ -47,18 +48,10 @@ UDB_INC	= udb.h udb_defs.h
 COM_SRC	=
 COM_OBJ	=
 
-# Door Configurations
-#DRMUSHSRC = door_mush.c
-#DRMUSHOBJ = door_mush.o
-#DREMPIRESRC = empire.c
-#DREMPIREOBJ = empire.o
-#DREMPIREHDR = empire.h
-#DRMAILSRC = door_mail.c
-#DRMAILOBJ = door_mail.o
+# Door Configurations -- "Options" now written to make.defs by asksource.sh
 DR_SRC = $(DRMUSHSRC) $(DREMPIRESRC) $(DRMAILSRC)
 DR_OBJ = $(DRMUSHOBJ) $(DREMPIREOBJ) $(DRMAILOBJ)
 DR_HDR = $(DREMPIREHDR)
-#DR_DEF = -DENABLE_DOORS -DEXAMPLE_DOOR_CODE
 
 # Everything needed to use the database in standalone mode.
 SA_SRC	= sa-db.c sa-db_rw.c sa-boolexp.c sa-unparse.c sa-compress.c \
@@ -156,7 +149,6 @@ VER_FLG	= -DMUSH_BUILD_DATE="\"`cat date.txt`\"" \
 # SYS_MALLOC - Used if malloc.h is in a borked spot.
 ###########################################################################################################
 
-DEFS = -DBROKEN_NDBM -DBROKEN_ERRNO_SYS -DSQLITE -DSBUF64 -DSECURE_SIDEEFFECT -DOLD_SETQ -DBANGS -DMARKER_FLAGS -DZENTY_ANSI -DEXPANDED_QREGS -DREALITY_LEVELS -DATTR_HACK -DPROG_LIKEMUX -DPLUSHELP -DUSECRYPT -DSOFTCOM -DMUX_INCDEC -DTINY_U -DUSE_SIDEEFFECT -Wall -DHAS_OPENSSL 
 #
 # Rhost supports two encryption schemes SHS (SHA-1), and the 
 # unix crypt() function (DES).
@@ -212,7 +204,8 @@ DEFS = -DBROKEN_NDBM -DBROKEN_ERRNO_SYS -DSQLITE -DSBUF64 -DSECURE_SIDEEFFECT -D
 #
 #CYGWIN = -I/usr/local/include -DCYGWIN -DBROKEN_ERRNO_SYS -DBROKEN_NDBM\
 #         -DSYSWAIT -DNODEBUGMONITOR -g 
- 
+
+# IMPORTANT: MORELIBS is now written to make.defs by asksource.sh
 # Libraries.  
 # The following extra libraries are required based on what system you have.
 # #1 - This is used for most libc5 distributions.  This includes Slackware 7.0
@@ -241,8 +234,6 @@ DEFS = -DBROKEN_NDBM -DBROKEN_ERRNO_SYS -DSQLITE -DSBUF64 -DSECURE_SIDEEFFECT -D
 #MORELIBS  = -lresolv -lsocket -lnsl -lm -lrt
 ################################################################  #5
 #MORELIBS  = -lm -lrt -L/usr/local/lib -lcygipc
-
-MORELIBS = -lm -lrt -lnsl -lresolv -lcrypt -lssl
 
 # Set this to the directory where the MUSH game lives.
 # This is not really used much

--- a/Server/src/do_compile.sh
+++ b/Server/src/do_compile.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 #
-COMP=gdbm
-case ${COMP} in
+
+[ -f ../src/do_compile.defs ] && . ../src/do_compile.defs
+
+# ${COMP:=gdbm} uses COMP or, if COMP is unset, sets COMP to gdbm and uses gdbm
+
+case ${COMP:=gdbm} in
    gdbm) gdbmdir=./gdbm-1.8.3
          ;;
    qdbm) gdbmdir=./qdbm


### PR DESCRIPTION
Server/src/make.defs is included in MAkefile; and similarly for do_compile.defs / Server/src/do_compile.sh.

This increases the reliability of the asksource.sh config process by not needing to do in-file pattern replacement with sed.

(This became a problem when using mysql_config to generate build parameters for MySQL, part of refactoring MySQL support to be more robust.)