### PR TITLE
Timer fixes

### DIFF
--- a/Server/src/bsd.c
+++ b/Server/src/bsd.c
@@ -85,6 +85,7 @@ extern CF_HAND(cf_site);
 extern double NDECL(next_timer);
 
 extern int FDECL(alarm_msec, (double));
+extern int NDECL(alarm_stop);
 
 int signal_depth;
 
@@ -2245,7 +2246,7 @@ sighandler(int sig)
                 }
              }
           }
-          alarm_msec(0); 
+          alarm_stop();
           ignore_signals();
           raw_broadcast(0, 0, "Game: Restarting due to signal SIGUSR1.");
           raw_broadcast(0, 0, "Game: Your connection will pause, but will remain connected.");

--- a/Server/src/bsd.c
+++ b/Server/src/bsd.c
@@ -82,7 +82,7 @@ int FDECL(process_input, (DESC *));
 extern void FDECL(broadcast_monitor, (dbref, int, char *, char *, char *, int, int, int, char *));
 extern int FDECL(lookup, (char *, char *));
 extern CF_HAND(cf_site);
-extern int NDECL(next_timer);
+extern double NDECL(next_timer);
 
 extern int FDECL(alarm_msec, (double));
 

--- a/Server/src/game.c
+++ b/Server/src/game.c
@@ -77,6 +77,7 @@ static void NDECL(init_rlimit);
 
 extern double FDECL(time_ng, (double*));
 extern int FDECL(alarm_msec, (double));
+extern int NDECL(alarm_stop);
 
 int reserved;
 
@@ -1281,7 +1282,7 @@ do_reboot(dbref player, dbref cause, int key)
      }
   }
 
-  alarm_msec(0);
+  alarm_stop();
   mudstate.dumpstatechk=1;
   ignore_signals();
   port = mudconf.port;

--- a/Server/src/timer.c
+++ b/Server/src/timer.c
@@ -31,6 +31,8 @@ extern void		NDECL(pcache_trim);
 */
 int alarm_msec(double time)
 {
+  // This function will _never_ stop the timer; use alarm_stop() for that.
+  time = (time <= 0 ? 0.1 : time );
 struct itimerval it_val;
 double time_rounded;
   time_rounded = roundf(time * 10) / 10; // Round to one decimal place
@@ -41,8 +43,18 @@ double time_rounded;
 /* Debugging
   fprintf(stderr, "Timer Triggered");
  */
-  /* we actually need to trigger the alarm() signal to reset states, since setitimer doesn't do it */
-  alarm(1);
+  mudstate.alarm_triggered = 0;
+  return setitimer(ITIMER_REAL,&it_val,NULL);
+}
+
+int alarm_stop()
+{
+struct itimerval it_val;
+  it_val.it_value.tv_sec = 0;
+  it_val.it_value.tv_usec = 0;
+  it_val.it_interval.tv_sec = 0; // both set to '0' so the timer is one-shot
+  it_val.it_interval.tv_usec = 0;
+
   mudstate.alarm_triggered = 0;
   return setitimer(ITIMER_REAL,&it_val,NULL);
 }

--- a/Server/src/timer.c
+++ b/Server/src/timer.c
@@ -92,7 +92,7 @@ double	result;
 		result = mudstate.rwho_counter;
 	if (mudstate.mstats_counter < result)
 		result = mudstate.mstats_counter;
-  	result = -(mudstate.nowmsec);
+  	result = result-(mudstate.nowmsec);
 	if (result <= 0)
 		result = 0.1;
 	return result;


### PR DESCRIPTION
Uncovered what was causing the timer freezes; next_timer was declared to return int, so its actual double return value was getting cast to int, which meant that values <1 went to zero.

Also, some fixes to alarm_msec so that no consumer of this function can ever cause this problem again.

Also, fix an ancient bug in next_timer.