### PR TITLE
Less escaping needed in regexp $-command parser

### DIFF
--- a/Server/src/game.c
+++ b/Server/src/game.c
@@ -315,12 +315,8 @@ atr_match1(dbref thing, dbref parent, dbref player, char type,
            memset(buff2, '\0', sizeof(buff2));
            s2 = buff2;
            while ( *s3 ) {
-              if ( *s3 == '(' ) 
-                 i_inparen++;
-              if ( *s3 == ')' ) 
-                 i_inparen--;
-              if ( (*s3 == '\\') && (i_inparen > 0) ) {
-                 if ( *(s3+1) && (*(s3+1) != '.') && (*(s3+1) != '+') && (*(s3+1) != '*') )
+              if ( (*s3 == '\\') ) {
+                 if ( *(s3+1) && ((*(s3+1) == '\') || (*(s3+1) == ':')) )
                     s3++;
               } 
               *s2 = *s3;


### PR DESCRIPTION
Don't require doubling backslashes in regexp $-commands. Currently, most regexps require doubling backslashes. For instance:

$^foo (\\w+)$:

After this, you should be able to write a normal, unescaped regexp, like:

$^foo (\w+)$: