### PR TITLE
macOS Catalina build fix

### DIFF
--- a/Server/src/qdbm/Makefile.in
+++ b/Server/src/qdbm/Makefile.in
@@ -495,7 +495,17 @@ libqdbm.so.$(LIBVER).$(LIBREV).0 : $(MYLIBOBJS)
 	  then \
 	    $(CC) -shared -Wl,-G,-h,libqdbm.so.$(LIBVER) -o $@ $(MYLIBOBJS) $(LIBLDFLAGS) ; \
 	  else \
-	    $(CC) -shared -Wl,-soname,libqdbm.so.$(LIBVER) -o $@ $(MYLIBOBJS) $(LIBLDFLAGS) ; \
+	    if uname -a | egrep -i 'Darwin' > /dev/null ; \
+	    then \
+	      if test $$(xcodebuild -version | head -n 1 | sed "s,Xcode \([0-9]*\)\..*,\1,") -gt 10 ; \
+	      then \
+	        $(CC) -shared -Wl,-install_name,libqdbm.so.$(LIBVER) -o $@ $(MYLIBOBJS) $(LIBLDFLAGS) ; \
+	      else \
+	        $(CC) -shared -Wl,-soname,libqdbm.so.$(LIBVER) -o $@ $(MYLIBOBJS) $(LIBLDFLAGS) ; \
+	      fi \
+	    else \
+	      $(CC) -shared -Wl,-soname,libqdbm.so.$(LIBVER) -o $@ $(MYLIBOBJS) $(LIBLDFLAGS) ; \
+	    fi \
 	  fi
 
 


### PR DESCRIPTION
Patch qdbm link for Darwin/macOS, checking xcode version and using the right linker argument accordingly