### PR TITLE
Amb db config

### DIFF
--- a/Server/bin/asksource.ambrosia
+++ b/Server/bin/asksource.ambrosia
@@ -1,0 +1,1 @@
+../minimal-DBs/Amb-MinimalRhost/bin/asksource.save0

--- a/Server/bin/asksource.ambrosia.mark
+++ b/Server/bin/asksource.ambrosia.mark
@@ -1,0 +1,1 @@
+Ambrosia Minimal DB Configuration

--- a/Server/bin/asksource.sh
+++ b/Server/bin/asksource.sh
@@ -705,8 +705,9 @@ info() {
          echo "a case, select this option to disable OpenSSL from compiling."
          ;;
      25) echo "The system dependant PCRE Library will be much  much faster"
-         echo "than the one included with the source.  However, if you find"
-         echo "issues with it compiling with this enabled, disable it."
+         echo "than the one included with the source.  In case of compilation"
+         echo "issues, unselect this option to instead use the un-optimized"
+	 echo "PCRE Library included with RhostMUSH." 
          ;;
      26) echo "This option encrypts your passwords using a random seed and"
          echo "the SHA512 encryption method.  It will fall back to standard"

--- a/Server/bin/asksource.sh
+++ b/Server/bin/asksource.sh
@@ -448,7 +448,7 @@ echo "[${XB[4]}] B4. SQLite Support     [${XB[5]}] B5. QDBM DB Support    [#] B6
 echo "------------------------------------------------------------------------------"
 echo ""
 echo "Keys: [h]elp [i]nfo [s]ave [l]oad [d]elete [c]lear [m]ark [b]rowse [r]un [q]uit"
-echo "      [x]tra default cores (MUX, TinyMUSH3, Penn, Rhost-Default)"
+echo "      [x]tra default cores (MUX, TinyMUSH3, Penn, Rhost-Default, AmbrosiaDB)"
 echo "      Or, you may select a numer to toggle on/off"
 echo "      '#' means you may drill down into that option for a sub-menu."
 echo ""
@@ -1235,7 +1235,7 @@ xtraopts() {
    while [ ${LOOPIE} -eq 1 ]
    do
       CNTR=0
-      for i in mux penn tm3 default
+      for i in mux penn tm3 default ambrosia
       do
          CNTR=$(expr $CNTR + 1)
          if [ -f asksource.${i}.mark ]
@@ -1275,6 +1275,8 @@ xtraopts() {
          3) DUMPFILE=asksource.tm3
             ;;
          4) DUMPFILE=asksource.default
+            ;;
+	 5) DUMPFILE=asksource.ambrosia
             ;;
          Q) DUMPFILE="/"
             ;;

--- a/Server/game/txt/help.txt
+++ b/Server/game/txt/help.txt
@@ -14384,7 +14384,7 @@
   BNT    Brunei Darussalam Time              Asia             UTC + 8 hours
   BOT    Bolivia Time                        South America    UTC - 4 hours
   BRST   Brasilia Summer Time                South America    UTC - 2 hours
-  BRT    Brasília time                       South America    UTC - 3 hours
+  BRT    Brasilia time                       South America    UTC - 3 hours
   BST    Bangladesh Standard Time            Asia             UTC + 6 hours
   BST1   British Summer Time                 Europe           UTC + 1 hour
   BTT    Bhutan Time                         Asia             UTC + 6 hours
@@ -14474,17 +14474,17 @@
   GST    Gulf Standard Time                  Asia             UTC + 4 hours
   GYT    Guyana Time                         South America    UTC - 4 hours
   H      Hotel Time Zone                     Military         UTC + 8 hours
-  HAA    Heure Avancée de l'Atlantique       North America    UTC - 3 hours
-  HAA1   Heure Avancée de l'Atlantique       Atlantic         UTC - 3 hours
-  HAC    Heure Avancée du Centre             North America    UTC - 5 hours
+  HAA    Heure Avancee de l'Atlantique       North America    UTC - 3 hours
+  HAA1   Heure Avancee de l'Atlantique       Atlantic         UTC - 3 hours
+  HAC    Heure Avancee du Centre             North America    UTC - 5 hours
   HADT   Hawaii-Aleutian Daylight Time       North America    UTC - 9 hours
-  HAE    Heure Avancée de l'Est              North America    UTC - 4 hours
-  HAE1   Heure Avancée de l'Est              Caribbean        UTC - 4 hours
-  HAP    Heure Avancée du Pacifique          North America    UTC - 7 hours
-  HAR    Heure Avancée des Rocheuses         North America    UTC - 6 hours
+  HAE    Heure Avancee de l'Est              North America    UTC - 4 hours
+  HAE1   Heure Avancee de l'Est              Caribbean        UTC - 4 hours
+  HAP    Heure Avancee du Pacifique          North America    UTC - 7 hours
+  HAR    Heure Avancee des Rocheuses         North America    UTC - 6 hours
   HAST   Hawaii-Aleutian Standard Time       North America    UTC - 10 hours
-  HAT    Heure Avancée de Terre-Neuve        North America    UTC - 2:30 hours
-  HAY    Heure Avancée du Yukon              North America    UTC - 8 hours
+  HAT    Heure Avancee de Terre-Neuve        North America    UTC - 2:30 hours
+  HAY    Heure Avancee du Yukon              North America    UTC - 8 hours
   
 { timezone list6 to continue }    5 of 12
 
@@ -14590,7 +14590,7 @@
   PONT   Pohnpei Standard Time               Pacific          UTC + 11 hours
   PST    Pacific Standard Time               North America    UTC - 8 hours
   PST1   Pitcairn Standard Time              Pacific          UTC - 8 hours
-  PT     Tiempo del Pacífico                 North America    UTC - 8 hours
+  PT     Tiempo del Pacifico                 North America    UTC - 8 hours
   PWT    Palau Time                          Pacific          UTC + 9 hours
   PYST   Paraguay Summer Time                South America    UTC - 3 hours
   PYT    Paraguay Time                       South America    UTC - 4 hours

--- a/Server/readme/help.html
+++ b/Server/readme/help.html
@@ -1,6 +1,6 @@
 <HTML><HEAD><TITLE>RhostMUSH Help File [HTML Version]</TITLE></HEAD><BODY>
 <H1>RhostMUSH Help File [HTML Version]</H1>
-Generated: Wed Jan 13 04:15:48 2016
+Generated: Mon Mar 15 08:33:40 2021
 <HR><A NAME="topic index"><H2>Topic Index</H2></A><PRE>
 <A HREF="#QUOTE">&quot;</A>                         <A HREF="##">#</A>                         <A HREF="##lambda">#LAMBDA</A>
 <A HREF="#DOLARMINUScommands">$-commands</A>                <A HREF="#%">%</A>                         <A HREF="#%BANG">%!</A>
@@ -8,85 +8,106 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#%MINUS">%-</A>                        <A HREF="#%0">%0</A>                        <A HREF="#%1">%1</A>
 <A HREF="#%2">%2</A>                        <A HREF="#%3">%3</A>                        <A HREF="#%4">%4</A>
 <A HREF="#%5">%5</A>                        <A HREF="#%6">%6</A>                        <A HREF="#%7">%7</A>
-<A HREF="#%8">%8</A>                        <A HREF="#%9">%9</A>                        <A HREF="#%LT">%&lt;</A>
-<A HREF="#%?">%?</A>                        <A HREF="#%@">%@</A>                        <A HREF="#%_">%_</A>
+<A HREF="#%8">%8</A>                        <A HREF="#%9">%9</A>                        <A HREF="#%:">%:</A>
+<A HREF="#%LT">%&lt;</A>                        <A HREF="#%?">%?</A>                        <A HREF="#%@">%@</A>
+<A HREF="#%_">%_</A>                        <A HREF="#%_2">%_2</A>                       <A HREF="#%_vars">%_vars</A>
 <A HREF="#%a">%a</A>                        <A HREF="#%b">%b</A>                        <A HREF="#%c">%c</A>
 <A HREF="#%d">%d</A>                        <A HREF="#%f">%f</A>                        <A HREF="#%i">%i</A>
 <A HREF="#%k">%k</A>                        <A HREF="#%l">%l</A>                        <A HREF="#%m">%m</A>
 <A HREF="#%n">%n</A>                        <A HREF="#%o">%o</A>                        <A HREF="#%p">%p</A>
-<A HREF="#%q">%q</A>                        <A HREF="#%r">%r</A>                        <A HREF="#%s">%s</A>
-<A HREF="#%t">%t</A>                        <A HREF="#%v">%v</A>                        <A HREF="#%w">%w</A>
-<A HREF="#%x">%x</A>                        <A HREF="#AMPER">&amp;</A>                         <A HREF="#PLUSchannel">+channel</A>
+<A HREF="#%q">%q</A>                        <A HREF="#%qLT">%q&lt;</A>                       <A HREF="#%r">%r</A>
+<A HREF="#%s">%s</A>                        <A HREF="#%t">%t</A>                        <A HREF="#%v">%v</A>
+<A HREF="#%w">%w</A>                        <A HREF="#%x">%x</A>                        <A HREF="#AMPER">&amp;</A>
+<A HREF="#AMPERmailfilter">&amp;MAILFILTER</A>               <A HREF="#AMPERmailnotify">&amp;MAILNOTIFY</A>               <A HREF="#AMPERoutpageformat">&amp;OUTPAGEFORMAT</A>
+<A HREF="#AMPERpageformat">&amp;PAGEFORMAT</A>               <A HREF="#AMPERpageformat2">&amp;pageformat2</A>              <A HREF="#PLUSchannel">+channel</A>
 <A HREF="#PLUSchannel2">+channel2</A>                 <A HREF="#PLUShelp">+help</A>                     <A HREF="#PLUSuptime">+uptime</A>
-<A HREF="#1.0.0p0">1.0.0p0</A>                   <A HREF="#1.5.0p0">1.5.0p0</A>                   <A HREF="#2.0.0p0">2.0.0p0</A>
-<A HREF="#3.0.0p0">3.0.0p0</A>                   <A HREF="#3.2.0p0">3.2.0p0</A>                   <A HREF="#3.2.4p0">3.2.4p0</A>
-<A HREF="#3.2.4p1">3.2.4p1</A>                   <A HREF="#3.2.4p10">3.2.4p10</A>                  <A HREF="#3.2.4p11">3.2.4p11</A>
-<A HREF="#3.2.4p12">3.2.4p12</A>                  <A HREF="#3.2.4p13">3.2.4p13</A>                  <A HREF="#3.2.4p14">3.2.4p14</A>
-<A HREF="#3.2.4p15">3.2.4p15</A>                  <A HREF="#3.2.4p16">3.2.4p16</A>                  <A HREF="#3.2.4p17">3.2.4p17</A>
-<A HREF="#3.2.4p18">3.2.4p18</A>                  <A HREF="#3.2.4p2">3.2.4p2</A>                   <A HREF="#3.2.4p3">3.2.4p3</A>
-<A HREF="#3.2.4p4">3.2.4p4</A>                   <A HREF="#3.2.4p5">3.2.4p5</A>                   <A HREF="#3.2.4p6">3.2.4p6</A>
-<A HREF="#3.2.4p7">3.2.4p7</A>                   <A HREF="#3.2.4p8">3.2.4p8</A>                   <A HREF="#3.2.4p9">3.2.4p9</A>
-<A HREF="#3.9.0p0">3.9.0p0</A>                   <A HREF="#3.9.0p1">3.9.0p1</A>                   <A HREF="#3.9.0p2">3.9.0p2</A>
-<A HREF="#3.9.1p0">3.9.1p0</A>                   <A HREF="#3.9.1p1">3.9.1p1</A>                   <A HREF="#3.9.1p2">3.9.1p2</A>
-<A HREF="#3.9.2p0">3.9.2p0</A>                   <A HREF="#3.9.2p1">3.9.2p1</A>                   <A HREF="#3.9.3p0">3.9.3p0</A>
-<A HREF="#3.9.3p1">3.9.3p1</A>                   <A HREF="#3.9.3p2">3.9.3p2</A>                   <A HREF="#3.9.3p3">3.9.3p3</A>
-<A HREF="#3.9.4p0">3.9.4p0</A>                   <A HREF="#3.9.4p1">3.9.4p1</A>                   <A HREF="#3.9.4p2">3.9.4p2</A>
-<A HREF="#3.9.4p3">3.9.4p3</A>                   <A HREF="#3.9.4p4">3.9.4p4</A>                   <A HREF="#3.9.4p5">3.9.4p5</A>
-<A HREF="#3.9.5p0">3.9.5p0</A>                   <A HREF="#3.9.5p1">3.9.5p1</A>                   <A HREF="#3.9.5p2">3.9.5p2</A>
-<A HREF="#3.9.5p3">3.9.5p3</A>                   <A HREF="#:">:</A>                         <A HREF="#;">;</A>
-<A HREF="#GT">&gt;</A>                         <A HREF="#@@">@@</A>                        <A HREF="#@@()">@@()</A>
-<A HREF="#@aahear">@aahear</A>                   <A HREF="#@aclone">@aclone</A>                   <A HREF="#@aconnect">@aconnect</A>
-<A HREF="#@adescribe">@adescribe</A>                <A HREF="#@adfail">@adfail</A>                   <A HREF="#@adisconnect">@adisconnect</A>
-<A HREF="#@adrop">@adrop</A>                    <A HREF="#@aefail">@aefail</A>                   <A HREF="#@aenter">@aenter</A>
-<A HREF="#@afail">@afail</A>                    <A HREF="#@agfail">@agfail</A>                   <A HREF="#@ahear">@ahear</A>
-<A HREF="#@akill">@akill</A>                    <A HREF="#@aleave">@aleave</A>                   <A HREF="#@alfail">@alfail</A>
-<A HREF="#@alias">@alias</A>                    <A HREF="#@amhear">@amhear</A>                   <A HREF="#@amove">@amove</A>
-<A HREF="#@ansiname">@ansiname</A>                 <A HREF="#@apay">@apay</A>                     <A HREF="#@arfail">@arfail</A>
-<A HREF="#@asfail">@asfail</A>                   <A HREF="#@assert">@assert</A>                   <A HREF="#@asuccess">@asuccess</A>
-<A HREF="#@atfail">@atfail</A>                   <A HREF="#@atofail">@atofail</A>                  <A HREF="#@atport">@atport</A>
-<A HREF="#@attach">@attach</A>                   <A HREF="#@aufail">@aufail</A>                   <A HREF="#@ause">@ause</A>
-<A HREF="#@away">@away</A>                     <A HREF="#@break">@break</A>                    <A HREF="#@caption">@caption</A>
-<A HREF="#@channel">@channel</A>                  <A HREF="#@channel2">@channel2</A>                 <A HREF="#@charges">@charges</A>
-<A HREF="#@chown">@chown</A>                    <A HREF="#@clone">@clone</A>                    <A HREF="#@clone2">@clone2</A>
-<A HREF="#@cluster">@cluster</A>                  <A HREF="#@cluster action">@cluster action</A>           <A HREF="#@cluster action func">@cluster action func</A>
-<A HREF="#@cluster add">@cluster add</A>              <A HREF="#@cluster clear">@cluster clear</A>            <A HREF="#@cluster cut">@cluster cut</A>
-<A HREF="#@cluster del">@cluster del</A>              <A HREF="#@cluster edit">@cluster edit</A>             <A HREF="#@cluster func">@cluster func</A>
-<A HREF="#@cluster func action">@cluster func action</A>      <A HREF="#@cluster grep">@cluster grep</A>             <A HREF="#@cluster list">@cluster list</A>
-<A HREF="#@cluster new">@cluster new</A>              <A HREF="#@cluster reaction">@cluster reaction</A>         <A HREF="#@cluster repair">@cluster repair</A>
-<A HREF="#@cluster set">@cluster set</A>              <A HREF="#@cluster threshhold">@cluster threshhold</A>       <A HREF="#@cluster trigger">@cluster trigger</A>
-<A HREF="#@cluster wipe">@cluster wipe</A>             <A HREF="#@conformat">@conformat</A>                <A HREF="#@cost">@cost</A>
-<A HREF="#@cpattr">@CPATTR</A>                   <A HREF="#@create">@create</A>                   <A HREF="#@decompile">@decompile</A>
-<A HREF="#@describe">@describe</A>                 <A HREF="#@destroy">@destroy</A>                  <A HREF="#@dfail">@dfail</A>
-<A HREF="#@dig">@dig</A>                      <A HREF="#@doing">@doing</A>                    <A HREF="#@dolist">@dolist</A>
-<A HREF="#@dolist2 ">@dolist2 </A>                 <A HREF="#@door">@door</A>                     <A HREF="#@drain">@drain</A>
-<A HREF="#@drop">@drop</A>                     <A HREF="#@ealias">@ealias</A>                   <A HREF="#@edit">@edit</A>
-<A HREF="#@efail">@efail</A>                    <A HREF="#@emit">@emit</A>                     <A HREF="#@enter">@enter</A>
-<A HREF="#@entrances">@entrances</A>                <A HREF="#@eval">@eval</A>                     <A HREF="#@exitformat">@exitformat</A>
-<A HREF="#@exitto">@exitto</A>                   <A HREF="#@extansi">@extansi</A>                  <A HREF="#@fail">@fail</A>
-<A HREF="#@femit">@femit</A>                    <A HREF="#@filter">@filter</A>                   <A HREF="#@find">@find</A>
-<A HREF="#@force">@force</A>                    <A HREF="#@forwardlist">@forwardlist</A>              <A HREF="#@fpose">@fpose</A>
-<A HREF="#@fsay">@fsay</A>                     <A HREF="#@gfail">@gfail</A>                    <A HREF="#@grep">@GREP</A>
-<A HREF="#@guild">@guild</A>                    <A HREF="#@halt">@halt</A>                     <A HREF="#@hide">@hide</A>
-<A HREF="#@idesc">@idesc</A>                    <A HREF="#@idle">@idle</A>                     <A HREF="#@if">@if</A>
-<A HREF="#@ifelse">@ifelse</A>                   <A HREF="#@include">@include</A>                  <A HREF="#@include2 ">@include2 </A>
-<A HREF="#@infilter">@infilter</A>                 <A HREF="#@inprefix">@inprefix</A>                 <A HREF="#@kill">@kill</A>
-<A HREF="#@lalias">@Lalias</A>                   <A HREF="#@last">@last</A>                     <A HREF="#@leave">@leave</A>
-<A HREF="#@lemit">@lemit</A>                    <A HREF="#@lfail">@lfail</A>                    <A HREF="#@lfunction">@lfunction</A>
-<A HREF="#@lfunction2">@lfunction2</A>               <A HREF="#@link">@link</A>                     <A HREF="#@link2">@link2</A>
-<A HREF="#@list">@list</A>                     <A HREF="#@list2 ">@list2 </A>                   <A HREF="#@listen">@listen</A>
-<A HREF="#@listmotd">@listmotd</A>                 <A HREF="#@lock">@lock</A>                     <A HREF="#@lock attribute">@lock attribute</A>
-<A HREF="#@lock attribute2">@lock attribute2</A>          <A HREF="#@lock carry">@lock carry</A>               <A HREF="#@lock compound">@lock compound</A>
-<A HREF="#@lock evaluation">@lock evaluation</A>          <A HREF="#@lock evaluation2">@lock evaluation2</A>         <A HREF="#@lock indirect">@lock indirect</A>
-<A HREF="#@lock is">@lock is</A>                  <A HREF="#@lock keys">@Lock keys</A>                <A HREF="#@lock locks">@lock locks</A>
-<A HREF="#@lock locks2">@lock locks2</A>              <A HREF="#@lock locks3">@lock locks3</A>              <A HREF="#@lock normal">@lock normal</A>
-<A HREF="#@lock ownership">@lock ownership</A>           <A HREF="#@lock type chownlock">@lock type ChownLock</A>      <A HREF="#@lock type darklock">@lock type DarkLock</A>
-<A HREF="#@lock type defaultlock">@lock type DefaultLock</A>    <A HREF="#@lock type droplock">@lock type DropLock</A>       <A HREF="#@lock type droptolock">@lock type DropToLock</A>
-<A HREF="#@lock type enterlock">@lock type EnterLock</A>      <A HREF="#@lock type getfromlock">@lock type GetFromLock</A>    <A HREF="#@lock type givelock">@lock type GiveLock</A>
-<A HREF="#@lock type givetolock">@lock type GiveToLock</A>     <A HREF="#@lock type leavelock">@lock type LeaveLock</A>      <A HREF="#@lock type linklock">@lock type LinkLock</A>
-<A HREF="#@lock type openlock">@lock type OpenLock</A>       <A HREF="#@lock type pagelock">@lock type PageLock</A>       <A HREF="#@lock type parentlock">@lock type ParentLock</A>
-<A HREF="#@lock type receivelock">@lock type ReceiveLock</A>    <A HREF="#@lock type speechlock">@lock type SpeechLock</A>     <A HREF="#@lock type teloutlock">@lock type TeloutLock</A>
-<A HREF="#@lock type tportlock">@lock type TportLock</A>      <A HREF="#@lock type twinklock">@lock type TwinkLock</A>      <A HREF="#@lock type uselock">@lock type UseLock</A>
-<A HREF="#@lock type userlock">@lock type UserLock</A>       <A HREF="#@lock type zonetolock">@lock type ZoneToLock</A>     <A HREF="#@lock type zonewizlock">@lock type ZoneWizLock</A>
+<A HREF="#MINUS">-</A>                         <A HREF="#1.0.0p0">1.0.0p0</A>                   <A HREF="#1.5.0p0">1.5.0p0</A>
+<A HREF="#2.0.0p0">2.0.0p0</A>                   <A HREF="#3.0.0p0">3.0.0p0</A>                   <A HREF="#3.2.0p0">3.2.0p0</A>
+<A HREF="#3.2.4p0">3.2.4p0</A>                   <A HREF="#3.2.4p1">3.2.4p1</A>                   <A HREF="#3.2.4p10">3.2.4p10</A>
+<A HREF="#3.2.4p11">3.2.4p11</A>                  <A HREF="#3.2.4p12">3.2.4p12</A>                  <A HREF="#3.2.4p13">3.2.4p13</A>
+<A HREF="#3.2.4p14">3.2.4p14</A>                  <A HREF="#3.2.4p15">3.2.4p15</A>                  <A HREF="#3.2.4p16">3.2.4p16</A>
+<A HREF="#3.2.4p17">3.2.4p17</A>                  <A HREF="#3.2.4p18">3.2.4p18</A>                  <A HREF="#3.2.4p2">3.2.4p2</A>
+<A HREF="#3.2.4p3">3.2.4p3</A>                   <A HREF="#3.2.4p4">3.2.4p4</A>                   <A HREF="#3.2.4p5">3.2.4p5</A>
+<A HREF="#3.2.4p6">3.2.4p6</A>                   <A HREF="#3.2.4p7">3.2.4p7</A>                   <A HREF="#3.2.4p8">3.2.4p8</A>
+<A HREF="#3.2.4p9">3.2.4p9</A>                   <A HREF="#3.9.0p0">3.9.0p0</A>                   <A HREF="#3.9.0p1">3.9.0p1</A>
+<A HREF="#3.9.0p2">3.9.0p2</A>                   <A HREF="#3.9.1p0">3.9.1p0</A>                   <A HREF="#3.9.1p1">3.9.1p1</A>
+<A HREF="#3.9.1p2">3.9.1p2</A>                   <A HREF="#3.9.2p0">3.9.2p0</A>                   <A HREF="#3.9.2p1">3.9.2p1</A>
+<A HREF="#3.9.3p0">3.9.3p0</A>                   <A HREF="#3.9.3p1">3.9.3p1</A>                   <A HREF="#3.9.3p2">3.9.3p2</A>
+<A HREF="#3.9.3p3">3.9.3p3</A>                   <A HREF="#3.9.4p0">3.9.4p0</A>                   <A HREF="#3.9.4p1">3.9.4p1</A>
+<A HREF="#3.9.4p2">3.9.4p2</A>                   <A HREF="#3.9.4p3">3.9.4p3</A>                   <A HREF="#3.9.4p4">3.9.4p4</A>
+<A HREF="#3.9.4p5">3.9.4p5</A>                   <A HREF="#3.9.5p0">3.9.5p0</A>                   <A HREF="#3.9.5p1">3.9.5p1</A>
+<A HREF="#3.9.5p2">3.9.5p2</A>                   <A HREF="#3.9.5p3">3.9.5p3</A>                   <A HREF="#3.9.5p4">3.9.5p4</A>
+<A HREF="#4.0.0p0">4.0.0p0</A>                   <A HREF="#4.0.0p1">4.0.0p1</A>                   <A HREF="#4.0.0p2">4.0.0p2</A>
+<A HREF="#4.0.0p3">4.0.0p3</A>                   <A HREF="#4.0.0p4">4.0.0p4</A>                   <A HREF="#4.1.0p0">4.1.0p0</A>
+<A HREF="#4.1.0p1">4.1.0p1</A>                   <A HREF="#4.1.0p2">4.1.0p2</A>                   <A HREF="#:">:</A>
+<A HREF="#;">;</A>                         <A HREF="#GT">&gt;</A>                         <A HREF="#@@">@@</A>
+<A HREF="#@@()">@@()</A>                      <A HREF="#@aahear">@aahear</A>                   <A HREF="#@aclone">@aclone</A>
+<A HREF="#@aconnect">@aconnect</A>                 <A HREF="#@adescribe">@adescribe</A>                <A HREF="#@adfail">@adfail</A>
+<A HREF="#@adisconnect">@adisconnect</A>              <A HREF="#@adrop">@adrop</A>                    <A HREF="#@aefail">@aefail</A>
+<A HREF="#@aenter">@aenter</A>                   <A HREF="#@afail">@afail</A>                    <A HREF="#@agfail">@agfail</A>
+<A HREF="#@ahear">@ahear</A>                    <A HREF="#@akill">@akill</A>                    <A HREF="#@aleave">@aleave</A>
+<A HREF="#@alfail">@alfail</A>                   <A HREF="#@alias">@alias</A>                    <A HREF="#@amhear">@amhear</A>
+<A HREF="#@amove">@amove</A>                    <A HREF="#@ansiname">@ansiname</A>                 <A HREF="#@apay">@apay</A>
+<A HREF="#@arfail">@arfail</A>                   <A HREF="#@asfail">@asfail</A>                   <A HREF="#@assert">@assert</A>
+<A HREF="#@asuccess">@asuccess</A>                 <A HREF="#@atfail">@atfail</A>                   <A HREF="#@atofail">@atofail</A>
+<A HREF="#@atport">@atport</A>                   <A HREF="#@attach">@attach</A>                   <A HREF="#@aufail">@aufail</A>
+<A HREF="#@ause">@ause</A>                     <A HREF="#@away">@away</A>                     <A HREF="#@break">@break</A>
+<A HREF="#@caption">@caption</A>                  <A HREF="#@channel">@channel</A>                  <A HREF="#@channel2">@channel2</A>
+<A HREF="#@charges">@charges</A>                  <A HREF="#@chown">@chown</A>                    <A HREF="#@clone">@clone</A>
+<A HREF="#@clone2">@clone2</A>                   <A HREF="#@cluster">@cluster</A>                  <A HREF="#@cluster action">@cluster action</A>
+<A HREF="#@cluster action func">@cluster action func</A>      <A HREF="#@cluster add">@cluster add</A>              <A HREF="#@cluster clear">@cluster clear</A>
+<A HREF="#@cluster cut">@cluster cut</A>              <A HREF="#@cluster del">@cluster del</A>              <A HREF="#@cluster edit">@cluster edit</A>
+<A HREF="#@cluster func">@cluster func</A>             <A HREF="#@cluster func action">@cluster func action</A>      <A HREF="#@cluster grep">@cluster grep</A>
+<A HREF="#@cluster list">@cluster list</A>             <A HREF="#@cluster new">@cluster new</A>              <A HREF="#@cluster owner">@cluster owner</A>
+<A HREF="#@cluster preserve">@cluster preserve</A>         <A HREF="#@cluster reaction">@cluster reaction</A>         <A HREF="#@cluster regexp">@cluster regexp</A>
+<A HREF="#@cluster repair">@cluster repair</A>           <A HREF="#@cluster set">@cluster set</A>              <A HREF="#@cluster threshhold">@cluster threshhold</A>
+<A HREF="#@cluster trigger">@cluster trigger</A>          <A HREF="#@cluster wipe">@cluster wipe</A>             <A HREF="#@conformat">@conformat</A>
+<A HREF="#@cost">@cost</A>                     <A HREF="#@cpattr">@CPATTR</A>                   <A HREF="#@cpattr2">@CPATTR2</A>
+<A HREF="#@cpattr3">@CPATTR3</A>                  <A HREF="#@create">@create</A>                   <A HREF="#@decompile">@decompile</A>
+<A HREF="#@descformat">@descformat</A>               <A HREF="#@describe">@describe</A>                 <A HREF="#@destroy">@destroy</A>
+<A HREF="#@dfail">@dfail</A>                    <A HREF="#@dig">@dig</A>                      <A HREF="#@doing">@doing</A>
+<A HREF="#@dolist">@dolist</A>                   <A HREF="#@dolist2 ">@dolist2 </A>                 <A HREF="#@door">@door</A>
+<A HREF="#@drain">@drain</A>                    <A HREF="#@drop">@drop</A>                     <A HREF="#@ealias">@ealias</A>
+<A HREF="#@edit">@edit</A>                     <A HREF="#@efail">@efail</A>                    <A HREF="#@emit">@emit</A>
+<A HREF="#@enter">@enter</A>                    <A HREF="#@entrances">@entrances</A>                <A HREF="#@eval">@eval</A>
+<A HREF="#@exitformat">@exitformat</A>               <A HREF="#@exitto">@exitto</A>                   <A HREF="#@extansi">@extansi</A>
+<A HREF="#@fail">@fail</A>                     <A HREF="#@femit">@femit</A>                    <A HREF="#@filter">@filter</A>
+<A HREF="#@find">@find</A>                     <A HREF="#@force">@force</A>                    <A HREF="#@forwardlist">@forwardlist</A>
+<A HREF="#@fpose">@fpose</A>                    <A HREF="#@fsay">@fsay</A>                     <A HREF="#@gfail">@gfail</A>
+<A HREF="#@goto">@goto</A>                     <A HREF="#@grep">@GREP</A>                     <A HREF="#@guild">@guild</A>
+<A HREF="#@halt">@halt</A>                     <A HREF="#@hide">@hide</A>                     <A HREF="#@idesc">@idesc</A>
+<A HREF="#@idle">@idle</A>                     <A HREF="#@if">@if</A>                       <A HREF="#@ifelse">@ifelse</A>
+<A HREF="#@include">@include</A>                  <A HREF="#@include2 ">@include2 </A>                <A HREF="#@infilter">@infilter</A>
+<A HREF="#@inprefix">@inprefix</A>                 <A HREF="#@invformat">@invformat</A>                <A HREF="#@jump">@jump</A>
+<A HREF="#@kill">@kill</A>                     <A HREF="#@label">@label</A>                    <A HREF="#@labelMINUSexample">@label-example</A>
+<A HREF="#@labelMINUSexample2">@label-example2</A>           <A HREF="#@labelMINUSexample3">@label-example3</A>           <A HREF="#@label2">@label2</A>
+<A HREF="#@label3">@label3</A>                   <A HREF="#@label4">@label4</A>                   <A HREF="#@lalias">@Lalias</A>
+<A HREF="#@last">@last</A>                     <A HREF="#@leave">@leave</A>                    <A HREF="#@lemit">@lemit</A>
+<A HREF="#@lfail">@lfail</A>                    <A HREF="#@lfunction">@lfunction</A>                <A HREF="#@lfunction2">@lfunction2</A>
+<A HREF="#@link">@link</A>                     <A HREF="#@link2">@link2</A>                    <A HREF="#@list">@list</A>
+<A HREF="#@list2 ">@list2 </A>                   <A HREF="#@listen">@listen</A>                   <A HREF="#@listmotd">@listmotd</A>
+<A HREF="#@lock">@lock</A>                     <A HREF="#@lock attribute">@lock attribute</A>           <A HREF="#@lock attribute2">@lock attribute2</A>
+<A HREF="#@lock carry">@lock carry</A>               <A HREF="#@lock compound">@lock compound</A>            <A HREF="#@lock evaluation">@lock evaluation</A>
+<A HREF="#@lock evaluation2">@lock evaluation2</A>         <A HREF="#@lock indirect">@lock indirect</A>            <A HREF="#@lock is">@lock is</A>
+<A HREF="#@lock keys">@Lock keys</A>                <A HREF="#@lock locks">@lock locks</A>               <A HREF="#@lock locks2">@lock locks2</A>
+<A HREF="#@lock locks3">@lock locks3</A>              <A HREF="#@lock normal">@lock normal</A>              <A HREF="#@lock ownership">@lock ownership</A>
+<A HREF="#@lock type chownlock">@lock type ChownLock</A>      <A HREF="#@lock type darklock">@lock type DarkLock</A>       <A HREF="#@lock type defaultlock">@lock type DefaultLock</A>
+<A HREF="#@lock type droplock">@lock type DropLock</A>       <A HREF="#@lock type droptolock">@lock type DropToLock</A>     <A HREF="#@lock type enterlock">@lock type EnterLock</A>
+<A HREF="#@lock type getfromlock">@lock type GetFromLock</A>    <A HREF="#@lock type givelock">@lock type GiveLock</A>       <A HREF="#@lock type givetolock">@lock type GiveToLock</A>
+<A HREF="#@lock type leavelock">@lock type LeaveLock</A>      <A HREF="#@lock type linklock">@lock type LinkLock</A>       <A HREF="#@lock type openlock">@lock type OpenLock</A>
+<A HREF="#@lock type pagelock">@lock type PageLock</A>       <A HREF="#@lock type parentlock">@lock type ParentLock</A>     <A HREF="#@lock type receivelock">@lock type ReceiveLock</A>
+<A HREF="#@lock type speechlock">@lock type SpeechLock</A>     <A HREF="#@lock type teloutlock">@lock type TeloutLock</A>     <A HREF="#@lock type tportlock">@lock type TportLock</A>
+<A HREF="#@lock type twinklock">@lock type TwinkLock</A>      <A HREF="#@lock type uselock">@lock type UseLock</A>        <A HREF="#@lock type userlock">@lock type UserLock</A>
+<A HREF="#@lock type zonetolock">@lock type ZoneToLock</A>     <A HREF="#@lock type zonewizlock">@lock type ZoneWizLock</A>    <A HREF="#@lock/chownlock">@lock/chownlock</A>
+<A HREF="#@lock/darklock">@lock/darklock</A>            <A HREF="#@lock/defaultlock">@lock/defaultlock</A>         <A HREF="#@lock/droplock">@lock/droplock</A>
+<A HREF="#@lock/droptolock">@lock/droptolock</A>          <A HREF="#@lock/enterlock">@lock/enterlock</A>           <A HREF="#@lock/getfromlock">@lock/getfromlock</A>
+<A HREF="#@lock/givelock">@lock/givelock</A>            <A HREF="#@lock/givetolock">@lock/givetolock</A>          <A HREF="#@lock/leavelock">@lock/leavelock</A>
+<A HREF="#@lock/linklock">@lock/linklock</A>            <A HREF="#@lock/openlock">@lock/openlock</A>            <A HREF="#@lock/pagelock">@lock/pagelock</A>
+<A HREF="#@lock/parentlock">@lock/parentlock</A>          <A HREF="#@lock/receivelock">@lock/receivelock</A>         <A HREF="#@lock/speechlock">@lock/speechlock</A>
+<A HREF="#@lock/teloutlock">@lock/teloutlock</A>          <A HREF="#@lock/tportlock">@lock/tportlock</A>           <A HREF="#@lock/twinklock">@lock/twinklock</A>
+<A HREF="#@lock/uselock">@lock/uselock</A>             <A HREF="#@lock/userlock">@lock/userlock</A>            <A HREF="#@lock/zonetolock">@lock/zonetolock</A>
+<A HREF="#@lock/zonewizlock">@lock/zonewizlock</A>         <A HREF="#@lset">@lset</A>                     <A HREF="#@ltag">@ltag</A>
+<A HREF="#@mail">@mail</A>                     <A HREF="#@mailfilter">@MAILFILTER</A>               <A HREF="#@mailnotify">@MAILNOTIFY</A>
 <A HREF="#@mailsig">@mailsig</A>                  <A HREF="#@moniker">@moniker</A>                  <A HREF="#@move">@move</A>
 <A HREF="#@mvattr">@mvattr</A>                   <A HREF="#@name">@name</A>                     <A HREF="#@nameformat">@nameformat</A>
 <A HREF="#@notify">@notify</A>                   <A HREF="#@odescribe">@odescribe</A>                <A HREF="#@odfail">@odfail</A>
@@ -96,15 +117,19 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#@omove">@omove</A>                    <A HREF="#@opay">@opay</A>                     <A HREF="#@open">@open</A>
 <A HREF="#@orfail">@orfail</A>                   <A HREF="#@osuccess">@osuccess</A>                 <A HREF="#@otfail">@otfail</A>
 <A HREF="#@otofail">@otofail</A>                  <A HREF="#@otport">@otport</A>                   <A HREF="#@oufail">@oufail</A>
-<A HREF="#@ouse">@ouse</A>                     <A HREF="#@oxenter">@oxenter</A>                  <A HREF="#@oxleave">@oxleave</A>
-<A HREF="#@oxtport">@oxtport</A>                  <A HREF="#@parent">@parent</A>                   <A HREF="#@password">@password</A>
-<A HREF="#@pay">@pay</A>                      <A HREF="#@pemit">@pemit</A>                    <A HREF="#@pemit2">@pemit2</A>
-<A HREF="#@pipe">@pipe</A>                     <A HREF="#@prefix">@prefix</A>                   <A HREF="#@progprompt">@progprompt</A>
-<A HREF="#@program">@program</A>                  <A HREF="#@program2 ">@program2 </A>                <A HREF="#@program3">@program3</A>
-<A HREF="#@protect">@protect</A>                  <A HREF="#@ps">@ps</A>                       <A HREF="#@quitprogram">@quitprogram</A>
-<A HREF="#@quota">@quota</A>                    <A HREF="#@quota alternate">@quota alternate</A>          <A HREF="#@quota standard">@quota standard</A>
-<A HREF="#@race">@race</A>                     <A HREF="#@register">@register</A>                 <A HREF="#@reject">@reject</A>
-<A HREF="#@remit">@remit</A>                    <A HREF="#@rfail">@rfail</A>                    <A HREF="#@robot">@robot</A>
+<A HREF="#@ouse">@ouse</A>                     <A HREF="#@outpageformat">@OUTPAGEFORMAT</A>            <A HREF="#@oxenter">@oxenter</A>
+<A HREF="#@oxleave">@oxleave</A>                  <A HREF="#@oxtport">@oxtport</A>                  <A HREF="#@pageformat">@PAGEFORMAT</A>
+<A HREF="#@pageformat2">@pageformat2</A>              <A HREF="#@parent">@parent</A>                   <A HREF="#@password">@password</A>
+<A HREF="#@pay">@pay</A>                      <A HREF="#@pcreate">@pcreate</A>                  <A HREF="#@pemit">@pemit</A>
+<A HREF="#@pemit2">@pemit2</A>                   <A HREF="#@pipe">@pipe</A>                     <A HREF="#@prefix">@prefix</A>
+<A HREF="#@progprompt">@progprompt</A>               <A HREF="#@program">@program</A>                  <A HREF="#@program2 ">@program2 </A>
+<A HREF="#@program3">@program3</A>                 <A HREF="#@protect">@protect</A>                  <A HREF="#@protect2">@protect2</A>
+<A HREF="#@ps">@ps</A>                       <A HREF="#@quitprogram">@quitprogram</A>              <A HREF="#@quota">@quota</A>
+<A HREF="#@quota alternate">@quota alternate</A>          <A HREF="#@quota standard">@quota standard</A>           <A HREF="#@race">@race</A>
+<A HREF="#@register">@register</A>                 <A HREF="#@reject">@reject</A>                   <A HREF="#@remit">@remit</A>
+<A HREF="#@retry">@retry</A>                    <A HREF="#@rfail">@rfail</A>                    <A HREF="#@robot">@robot</A>
+<A HREF="#@rollback">@rollback</A>                 <A HREF="#@rollback2">@rollback2</A>                <A HREF="#@rollback3">@rollback3</A>
+<A HREF="#@rollback4">@rollback4</A>                <A HREF="#@rollback5">@rollback5</A>                <A HREF="#@rollback6">@rollback6</A>
 <A HREF="#@runout">@runout</A>                   <A HREF="#@salisten">@salisten</A>                 <A HREF="#@sasmell">@sasmell</A>
 <A HREF="#@sataste">@sataste</A>                  <A HREF="#@satouch">@satouch</A>                  <A HREF="#@saystring">@saystring</A>
 <A HREF="#@search">@search</A>                   <A HREF="#@selfboot">@SELFBOOT</A>                 <A HREF="#@set">@set</A>
@@ -117,13 +142,15 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#@sudo">@sudo</A>                     <A HREF="#@sweep">@sweep</A>                    <A HREF="#@switch">@switch</A>
 <A HREF="#@switch2">@switch2</A>                  <A HREF="#@teleport">@teleport</A>                 <A HREF="#@teleport2">@teleport2</A>
 <A HREF="#@tfail">@tfail</A>                    <A HREF="#@titlecaption">@titlecaption</A>             <A HREF="#@tofail">@tofail</A>
-<A HREF="#@toggle">@toggle</A>                   <A HREF="#@tport">@tport</A>                    <A HREF="#@trigger">@trigger</A>
-<A HREF="#@ufail">@ufail</A>                    <A HREF="#@unlink">@unlink</A>                   <A HREF="#@unlock">@unlock</A>
-<A HREF="#@uptime">@uptime</A>                   <A HREF="#@use">@use</A>                      <A HREF="#@verb">@verb</A>
-<A HREF="#@verb2">@verb2</A>                    <A HREF="#@verb3">@verb3</A>                    <A HREF="#@version">@version</A>
-<A HREF="#@wait">@wait</A>                     <A HREF="#@wait2">@wait2</A>                    <A HREF="#@wall">@wall</A>
-<A HREF="#@whereall">@whereall</A>                 <A HREF="#@whereis">@whereis</A>                  <A HREF="#@wipe">@wipe</A>
-<A HREF="#@zone">@zone</A>                     <A HREF="#\\">\\</A>                        <A HREF="#]">]</A>
+<A HREF="#@toggle">@toggle</A>                   <A HREF="#@totem">@totem</A>                    <A HREF="#@tport">@tport</A>
+<A HREF="#@trigger">@trigger</A>                  <A HREF="#@ufail">@ufail</A>                    <A HREF="#@unlink">@unlink</A>
+<A HREF="#@unlock">@unlock</A>                   <A HREF="#@uptime">@uptime</A>                   <A HREF="#@use">@use</A>
+<A HREF="#@verb">@verb</A>                     <A HREF="#@verb2">@verb2</A>                    <A HREF="#@verb3">@verb3</A>
+<A HREF="#@version">@version</A>                  <A HREF="#@wait">@wait</A>                     <A HREF="#@wait2">@wait2</A>
+<A HREF="#@wall">@wall</A>                     <A HREF="#@whereall">@whereall</A>                 <A HREF="#@whereis">@whereis</A>
+<A HREF="#@wipe">@wipe</A>                     <A HREF="#@zone">@zone</A>                     <A HREF="#\*">\*</A>
+<A HREF="#\?">\?</A>                        <A HREF="#\\">\\</A>                        <A HREF="#]">]</A>
+<A HREF="#^MINUScommand">^-command</A>                 <A HREF="#^MINUSlisten">^-listen</A>                  <A HREF="#_">_</A>
 <A HREF="#abode">ABODE</A>                     <A HREF="#abs()">ABS()</A>                     <A HREF="#accent()">ACCENT()</A>
 <A HREF="#accent2">ACCENT2</A>                   <A HREF="#accent3">ACCENT3</A>                   <A HREF="#accent4">ACCENT4</A>
 <A HREF="#accents toggle">ACCENTS TOGGLE</A>            <A HREF="#acos()">ACOS()</A>                    <A HREF="#add()">ADD()</A>
@@ -132,37 +159,43 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#alphamax()">ALPHAMAX()</A>                <A HREF="#alphamin()">ALPHAMIN()</A>                <A HREF="#alt inventories">ALT INVENTORIES</A>
 <A HREF="#altnames">ALTNAMES</A>                  <A HREF="#ancestors">ANCESTORS</A>                 <A HREF="#and()">AND()</A>
 <A HREF="#andchr()">ANDCHR()</A>                  <A HREF="#andflag()">ANDFLAG()</A>                 <A HREF="#andflags()">ANDFLAGS()</A>
-<A HREF="#ansi">ANSI</A>                      <A HREF="#ansi functions">ansi functions</A>            <A HREF="#ansi quirks">ANSI QUIRKS</A>
+<A HREF="#andtotem()">ANDTOTEM()</A>                <A HREF="#andtotems()">ANDTOTEMS()</A>               <A HREF="#ansi">ANSI</A>
+<A HREF="#ansi functions">ansi functions</A>            <A HREF="#ansi quirks">ANSI QUIRKS</A>               <A HREF="#ansi usage">ANSI USAGE</A>
 <A HREF="#ansi()">ANSI()</A>                    <A HREF="#ansi2">ANSI2</A>                     <A HREF="#ansi3">ANSI3</A>
 <A HREF="#ansi4">ANSI4</A>                     <A HREF="#ansicolor">ANSICOLOR</A>                 <A HREF="#ansinames">ANSINAMES</A>
+<A HREF="#ansipos()">ANSIPOS()</A>                 <A HREF="#api">API</A>                       <A HREF="#api return">API RETURN</A>
 <A HREF="#aposs()">APOSS()</A>                   <A HREF="#arbitrary commands">ARBITRARY COMMANDS</A>        <A HREF="#arbitrary2">arbitrary2</A>
 <A HREF="#architect">ARCHITECT</A>                 <A HREF="#arithmetic functions">arithmetic functions</A>      <A HREF="#array()">ARRAY()</A>
-<A HREF="#art()">ART()</A>                     <A HREF="#asc()">ASC()</A>                     <A HREF="#asin()">ASIN()</A>
-<A HREF="#atan()">ATAN()</A>                    <A HREF="#atan2()">ATAN2()</A>                   <A HREF="#attrcnt()">ATTRCNT()</A>
-<A HREF="#attribute flag architect">ATTRIBUTE FLAG ARCHITECT</A>  <A HREF="#attribute flag atrlock">ATTRIBUTE FLAG ATRLOCK</A>    <A HREF="#attribute flag councilor">ATTRIBUTE FLAG COUNCILOR</A>
-<A HREF="#attribute flag dark">ATTRIBUTE FLAG DARK</A>       <A HREF="#attribute flag default">ATTRIBUTE FLAG DEFAULT</A>    <A HREF="#attribute flag god">ATTRIBUTE FLAG GOD</A>
-<A HREF="#attribute flag guildmaster">ATTRIBUTE FLAG GUILDMASTER</A><A HREF="#attribute flag hidden">ATTRIBUTE FLAG HIDDEN</A>     <A HREF="#attribute flag immortal">ATTRIBUTE FLAG IMMORTAL</A>
-<A HREF="#attribute flag lock">ATTRIBUTE FLAG LOCK</A>       <A HREF="#attribute flag logged">ATTRIBUTE FLAG LOGGED</A>     <A HREF="#attribute flag mdark">ATTRIBUTE FLAG MDARK</A>
-<A HREF="#attribute flag no_clone">ATTRIBUTE FLAG NO_CLONE</A>   <A HREF="#attribute flag no_command">ATTRIBUTE FLAG NO_COMMAND</A> <A HREF="#attribute flag no_inherit">ATTRIBUTE FLAG NO_INHERIT</A>
-<A HREF="#attribute flag no_parse">ATTRIBUTE FLAG NO_PARSE</A>   <A HREF="#attribute flag noprog">ATTRIBUTE FLAG NOPROG</A>     <A HREF="#attribute flag pinvisible">ATTRIBUTE FLAG PINVISIBLE</A>
-<A HREF="#attribute flag private">ATTRIBUTE FLAG PRIVATE</A>    <A HREF="#attribute flag regexp">ATTRIBUTE FLAG REGEXP</A>     <A HREF="#attribute flag royalty">ATTRIBUTE FLAG ROYALTY</A>
-<A HREF="#attribute flag safe">ATTRIBUTE FLAG SAFE</A>       <A HREF="#attribute flag singlethread">ATTRIBUTE FLAG SINGLETHREAD</A><A HREF="#attribute flag uselock">ATTRIBUTE FLAG USELOCK</A>
-<A HREF="#attribute flag visual">ATTRIBUTE FLAG VISUAL</A>     <A HREF="#attribute flag wizard">ATTRIBUTE FLAG WIZARD</A>     <A HREF="#attribute flags">ATTRIBUTE FLAGS</A>
-<A HREF="#attribute flags2">ATTRIBUTE FLAGS2</A>          <A HREF="#attribute ownership">ATTRIBUTE OWNERSHIP</A>       <A HREF="#attribute ownership2">attribute ownership2</A>
+<A HREF="#array2">array2</A>                    <A HREF="#art()">ART()</A>                     <A HREF="#asc()">ASC()</A>
+<A HREF="#asin()">ASIN()</A>                    <A HREF="#atan()">ATAN()</A>                    <A HREF="#atan2()">ATAN2()</A>
+<A HREF="#attrcnt()">ATTRCNT()</A>                 <A HREF="#attrib formatting">ATTRIB FORMATTING</A>         <A HREF="#attribute flag architect">ATTRIBUTE FLAG ARCHITECT</A>
+<A HREF="#attribute flag atrlock">ATTRIBUTE FLAG ATRLOCK</A>    <A HREF="#attribute flag councilor">ATTRIBUTE FLAG COUNCILOR</A>  <A HREF="#attribute flag dark">ATTRIBUTE FLAG DARK</A>
+<A HREF="#attribute flag default">ATTRIBUTE FLAG DEFAULT</A>    <A HREF="#attribute flag god">ATTRIBUTE FLAG GOD</A>        <A HREF="#attribute flag guildmaster">ATTRIBUTE FLAG GUILDMASTER</A>
+<A HREF="#attribute flag hidden">ATTRIBUTE FLAG HIDDEN</A>     <A HREF="#attribute flag immortal">ATTRIBUTE FLAG IMMORTAL</A>   <A HREF="#attribute flag lock">ATTRIBUTE FLAG LOCK</A>
+<A HREF="#attribute flag logged">ATTRIBUTE FLAG LOGGED</A>     <A HREF="#attribute flag mdark">ATTRIBUTE FLAG MDARK</A>      <A HREF="#attribute flag no_clone">ATTRIBUTE FLAG NO_CLONE</A>
+<A HREF="#attribute flag no_command">ATTRIBUTE FLAG NO_COMMAND</A> <A HREF="#attribute flag no_inherit">ATTRIBUTE FLAG NO_INHERIT</A> <A HREF="#attribute flag no_parse">ATTRIBUTE FLAG NO_PARSE</A>
+<A HREF="#attribute flag noprog">ATTRIBUTE FLAG NOPROG</A>     <A HREF="#attribute flag pinvisible">ATTRIBUTE FLAG PINVISIBLE</A> <A HREF="#attribute flag private">ATTRIBUTE FLAG PRIVATE</A>
+<A HREF="#attribute flag regexp">ATTRIBUTE FLAG REGEXP</A>     <A HREF="#attribute flag royalty">ATTRIBUTE FLAG ROYALTY</A>    <A HREF="#attribute flag safe">ATTRIBUTE FLAG SAFE</A>
+<A HREF="#attribute flag singlethread">ATTRIBUTE FLAG SINGLETHREAD</A><A HREF="#attribute flag uselock">ATTRIBUTE FLAG USELOCK</A>    <A HREF="#attribute flag visual">ATTRIBUTE FLAG VISUAL</A>
+<A HREF="#attribute flag wizard">ATTRIBUTE FLAG WIZARD</A>     <A HREF="#attribute flags">ATTRIBUTE FLAGS</A>           <A HREF="#attribute flags2">ATTRIBUTE FLAGS2</A>
+<A HREF="#attribute formatting">ATTRIBUTE FORMATTING</A>      <A HREF="#attribute ownership">ATTRIBUTE OWNERSHIP</A>       <A HREF="#attribute ownership2">attribute ownership2</A>
 <A HREF="#attribute ownership3">attribute ownership3</A>      <A HREF="#attribute tree limitations">ATTRIBUTE TREE LIMITATIONS</A><A HREF="#attribute tree permission">ATTRIBUTE TREE PERMISSION</A>
 <A HREF="#attribute tree setting">ATTRIBUTE TREE SETTING</A>    <A HREF="#attribute tree viewing">ATTRIBUTE TREE VIEWING</A>    <A HREF="#attribute trees">ATTRIBUTE TREES</A>
-<A HREF="#attribute uselock2">ATTRIBUTE USELOCK2</A>        <A HREF="#attribute uselocks">ATTRIBUTE USELOCKS</A>        <A HREF="#audible">AUDIBLE</A>
-<A HREF="#auditorium">AUDITORIUM</A>                <A HREF="#avg()">AVG()</A>                     <A HREF="#bang notation">BANG NOTATION</A>
-<A HREF="#before()">BEFORE()</A>                  <A HREF="#being killed">BEING KILLED</A>              <A HREF="#between()">BETWEEN()</A>
-<A HREF="#bittype()">BITTYPE()</A>                 <A HREF="#blind">BLIND</A>                     <A HREF="#bogus commands">BOGUS COMMANDS</A>
-<A HREF="#boolean values">BOOLEAN VALUES</A>            <A HREF="#bounce">BOUNCE</A>                    <A HREF="#bounceforward">BOUNCEFORWARD</A>
-<A HREF="#bound()">BOUND()</A>                   <A HREF="#brackets()">BRACKETS()</A>                <A HREF="#brandy_mail toggle">BRANDY_MAIL TOGGLE</A>
+<A HREF="#attribute uselock2">ATTRIBUTE USELOCK2</A>        <A HREF="#attribute uselocks">ATTRIBUTE USELOCKS</A>        <A HREF="#attributeMINUScommands">attribute-commands</A>
+<A HREF="#attributes">attributes</A>                <A HREF="#attrpass()">ATTRPASS()</A>                <A HREF="#audible">AUDIBLE</A>
+<A HREF="#auditorium">AUDITORIUM</A>                <A HREF="#avg()">AVG()</A>                     <A HREF="#band()">BAND()</A>
+<A HREF="#bang notation">BANG NOTATION</A>             <A HREF="#bangs notation">BANGS NOTATION</A>            <A HREF="#before()">BEFORE()</A>
+<A HREF="#being killed">BEING KILLED</A>              <A HREF="#between()">BETWEEN()</A>                 <A HREF="#bittype()">BITTYPE()</A>
+<A HREF="#blind">BLIND</A>                     <A HREF="#bnand()">BNAND()</A>                   <A HREF="#bnot()">BNOT()</A>
+<A HREF="#bogus commands">BOGUS COMMANDS</A>            <A HREF="#boolean values">BOOLEAN VALUES</A>            <A HREF="#bor()">BOR()</A>
+<A HREF="#bounce">BOUNCE</A>                    <A HREF="#bounceforward">BOUNCEFORWARD</A>             <A HREF="#bound()">BOUND()</A>
+<A HREF="#brackets()">BRACKETS()</A>                <A HREF="#brandy_mail toggle">BRANDY_MAIL TOGGLE</A>        <A HREF="#bxor()">BXOR()</A>
 <A HREF="#byeroom">BYEROOM</A>                   <A HREF="#cand()">CAND()</A>                    <A HREF="#caplist()">CAPLIST()</A>
 <A HREF="#capstr()">CAPSTR()</A>                  <A HREF="#case()">case()</A>                    <A HREF="#caseall()">caseall()</A>
-<A HREF="#cat()">cat()</A>                     <A HREF="#cd">cd</A>                        <A HREF="#ceil()">CEIL()</A>
-<A HREF="#center()">CENTER()</A>                  <A HREF="#ch">ch</A>                        <A HREF="#changes">changes</A>
-<A HREF="#channel">channel</A>                   <A HREF="#channel2">channel2</A>                  <A HREF="#charin()">CHARIN()</A>
-<A HREF="#charout()">CHAROUT()</A>                 <A HREF="#children()">CHILDREN()</A>                <A HREF="#chkreality()">CHKREALITY()</A>
+<A HREF="#cat()">cat()</A>                     <A HREF="#cdark">cdark</A>                     <A HREF="#ceil()">CEIL()</A>
+<A HREF="#center()">CENTER()</A>                  <A HREF="#changes">changes</A>                   <A HREF="#channel">channel</A>
+<A HREF="#channel2">channel2</A>                  <A HREF="#charin()">CHARIN()</A>                  <A HREF="#charout()">CHAROUT()</A>
+<A HREF="#chidden">chidden</A>                   <A HREF="#children()">CHILDREN()</A>                <A HREF="#chkreality()">CHKREALITY()</A>
 <A HREF="#chkreality()">CHKREALITY()</A>              <A HREF="#chktrace()">CHKTRACE()</A>                <A HREF="#chomp()">CHOMP()</A>
 <A HREF="#chown_ok">CHOWN_OK</A>                  <A HREF="#chr()">CHR()</A>                     <A HREF="#citer()">CITER()</A>
 <A HREF="#cloak">CLOAK</A>                     <A HREF="#clone()">CLONE()</A>                   <A HREF="#cluster commands">CLUSTER COMMANDS</A>
@@ -177,54 +210,62 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#cluster_ueval()">CLUSTER_UEVAL()</A>           <A HREF="#cluster_uldefault()">CLUSTER_ULDEFAULT()</A>       <A HREF="#cluster_ulocal()">CLUSTER_ULOCAL()</A>
 <A HREF="#cluster_ulocal2">CLUSTER_ULOCAL2</A>           <A HREF="#cluster_vattrcnt()">CLUSTER_VATTRCNT()</A>        <A HREF="#cluster_wipe()">CLUSTER_WIPE()</A>
 <A HREF="#cluster_xget()">CLUSTER_XGET()</A>            <A HREF="#clusters">CLUSTERS</A>                  <A HREF="#cmds()">CMDS()</A>
-<A HREF="#cname()">CNAME()</A>                   <A HREF="#co">co</A>                        <A HREF="#colors">colors</A>
-<A HREF="#colors()">COLORS()</A>                  <A HREF="#columns()">COLUMNS()</A>                 <A HREF="#columns2">COLUMNS2</A>
-<A HREF="#columns3">COLUMNS3</A>                  <A HREF="#combat">COMBAT</A>                    <A HREF="#command evaluation">COMMAND EVALUATION</A>
-<A HREF="#command evaluation2">command evaluation2</A>       <A HREF="#commands">commands</A>                  <A HREF="#commands flag">COMMANDS FLAG</A>
-<A HREF="#commands2">commands2</A>                 <A HREF="#comp()">COMP()</A>                    <A HREF="#con()">CON()</A>
-<A HREF="#config()">CONFIG()</A>                  <A HREF="#conn()">CONN()</A>                    <A HREF="#connected">CONNECTED</A>
-<A HREF="#control">CONTROL</A>                   <A HREF="#control_ok">CONTROL_OK</A>                <A HREF="#controls()">controls()</A>
-<A HREF="#convsecs()">CONVSECS()</A>                <A HREF="#convtime()">CONVTIME()</A>                <A HREF="#copyright">COPYRIGHT</A>
-<A HREF="#cor()">COR()</A>                     <A HREF="#cos()">COS()</A>                     <A HREF="#cosh()">COSH()</A>
-<A HREF="#costs ">COSTS </A>                    <A HREF="#councilor">COUNCILOR</A>                 <A HREF="#cpattr2">CPATTR2</A>
-<A HREF="#cpattr3">CPATTR3</A>                   <A HREF="#cputime toggle">CPUTIME TOGGLE</A>            <A HREF="#cputime2">CPUTIME2</A>
-<A HREF="#crc32()">CRC32()</A>                   <A HREF="#create()">CREATE()</A>                  <A HREF="#createtime()">CREATETIME()</A>
+<A HREF="#cname()">CNAME()</A>                   <A HREF="#coding">CODING</A>                    <A HREF="#coding attrib">CODING ATTRIB</A>
+<A HREF="#coding attrib2">CODING ATTRIB2</A>            <A HREF="#coding command">CODING COMMAND</A>            <A HREF="#coding funct">CODING FUNCT</A>
+<A HREF="#coding nest">CODING NEST</A>               <A HREF="#coding queue">CODING QUEUE</A>              <A HREF="#coding regs">CODING REGS</A>
+<A HREF="#coding subs">CODING SUBS</A>               <A HREF="#coding2">CODING2</A>                   <A HREF="#coding3">CODING3</A>
+<A HREF="#colors">colors</A>                    <A HREF="#colors()">COLORS()</A>                  <A HREF="#columns()">COLUMNS()</A>
+<A HREF="#columns2">COLUMNS2</A>                  <A HREF="#columns3">COLUMNS3</A>                  <A HREF="#combat">COMBAT</A>
+<A HREF="#command evaluation">COMMAND EVALUATION</A>        <A HREF="#command evaluation2">command evaluation2</A>       <A HREF="#commands">commands</A>
+<A HREF="#commands flag">COMMANDS FLAG</A>             <A HREF="#commands2">commands2</A>                 <A HREF="#comp()">COMP()</A>
+<A HREF="#con()">CON()</A>                     <A HREF="#config()">CONFIG()</A>                  <A HREF="#conn()">CONN()</A>
+<A HREF="#connect">connect</A>                   <A HREF="#connected">CONNECTED</A>                 <A HREF="#control">CONTROL</A>
+<A HREF="#control_ok">CONTROL_OK</A>                <A HREF="#controls()">controls()</A>                <A HREF="#convsecs()">CONVSECS()</A>
+<A HREF="#convtime()">CONVTIME()</A>                <A HREF="#copyright">COPYRIGHT</A>                 <A HREF="#cor()">COR()</A>
+<A HREF="#cos()">COS()</A>                     <A HREF="#cosh()">COSH()</A>                    <A HREF="#costs ">COSTS </A>
+<A HREF="#councilor">COUNCILOR</A>                 <A HREF="#cpattr2">CPATTR2</A>                   <A HREF="#cpattr3">CPATTR3</A>
+<A HREF="#cputime toggle">CPUTIME TOGGLE</A>            <A HREF="#cputime2">CPUTIME2</A>                  <A HREF="#crc32()">CRC32()</A>
+<A HREF="#create">create</A>                    <A HREF="#create()">CREATE()</A>                  <A HREF="#createtime()">CREATETIME()</A>
 <A HREF="#credits">CREDITS</A>                   <A HREF="#credits2">credits2</A>                  <A HREF="#credits3">credits3</A>
 <A HREF="#credits4">credits4</A>                  <A HREF="#credits5">credits5</A>                  <A HREF="#creplace()">CREPLACE()</A>
 <A HREF="#ctu()">CTU()</A>                     <A HREF="#dark">DARK</A>                      <A HREF="#database information functions">database information functions</A>
 <A HREF="#debug">DEBUG</A>                     <A HREF="#dec()">DEC()</A>                     <A HREF="#decode64()">DECODE64()</A>
 <A HREF="#decrypt()">DECRYPT()</A>                 <A HREF="#default()">default()</A>                 <A HREF="#delete()">DELETE()</A>
-<A HREF="#delextract()">delextract()</A>              <A HREF="#destroy()">DESTROY()</A>                 <A HREF="#destroy_ok">DESTROY_OK</A>
-<A HREF="#dice()">DICE()</A>                    <A HREF="#die()">DIE()</A>                     <A HREF="#differences">DIFFERENCES</A>
-<A HREF="#differences2">DIFFERENCES2</A>              <A HREF="#dig()">DIG()</A>                     <A HREF="#digest()">DIGEST()</A>
-<A HREF="#dist2d()">DIST2D()</A>                  <A HREF="#dist3d()">DIST3D()</A>                  <A HREF="#div()">DIV()</A>
-<A HREF="#doing">doing</A>                     <A HREF="#door syntax">DOOR SYNTAX</A>               <A HREF="#door_close">DOOR_CLOSE</A>
-<A HREF="#door_kick">DOOR_KICK</A>                 <A HREF="#door_list">DOOR_LIST</A>                 <A HREF="#door_list2">DOOR_LIST2</A>
-<A HREF="#door_open">DOOR_OPEN</A>                 <A HREF="#door_push">DOOR_PUSH</A>                 <A HREF="#door_status">DOOR_STATUS</A>
-<A HREF="#door_writing">DOOR_WRITING</A>              <A HREF="#door_writing2">DOOR_WRITING2</A>             <A HREF="#door_writing3">DOOR_WRITING3</A>
-<A HREF="#doored">DOORED</A>                    <A HREF="#drop">drop</A>                      <A HREF="#dropMINUStos">DROP-TOS</A>
-<A HREF="#e()">E()</A>                       <A HREF="#edefault()">edefault()</A>                <A HREF="#edit()">EDIT()</A>
-<A HREF="#editansi()">EDITANSI()</A>                <A HREF="#ee()">EE()</A>                      <A HREF="#elementpos()">ELEMENTPOS()</A>
-<A HREF="#elements()">elements()</A>                <A HREF="#elementsmux()">elementsmux()</A>             <A HREF="#elist()">elist()</A>
-<A HREF="#elock()">elock()</A>                   <A HREF="#emit()">EMIT()</A>                    <A HREF="#enactor">ENACTOR</A>
-<A HREF="#encode64()">ENCODE64()</A>                <A HREF="#encrypt()">ENCRYPT()</A>                 <A HREF="#enter">enter</A>
-<A HREF="#enter_ok">ENTER_OK</A>                  <A HREF="#entrances()">ENTRANCES()</A>               <A HREF="#eq()">eq()</A>
-<A HREF="#error()">ERROR()</A>                   <A HREF="#escape()">ESCAPE()</A>                  <A HREF="#escapex()">ESCAPEX()</A>
-<A HREF="#esclist()">ESCLIST()</A>                 <A HREF="#eval()">EVAL()</A>                    <A HREF="#examine">examine</A>
-<A HREF="#examine2">examine2</A>                  <A HREF="#examine3">examine3</A>                  <A HREF="#examine4">examine4</A>
-<A HREF="#exit()">EXIT()</A>                    <A HREF="#exits">EXITS</A>                     <A HREF="#exp()">EXP()</A>
-<A HREF="#extansi toggle">EXTANSI TOGGLE</A>            <A HREF="#extract()">EXTRACT()</A>                 <A HREF="#extractword()">EXTRACTWORD()</A>
-<A HREF="#failure">FAILURE</A>                   <A HREF="#fbetween()">FBETWEEN()</A>                <A HREF="#fbound()">FBOUND()</A>
-<A HREF="#fdiv()">FDIV()</A>                    <A HREF="#filter()">filter()</A>                  <A HREF="#findable()">findable()</A>
-<A HREF="#first()">FIRST()</A>                   <A HREF="#firstof()">FIRSTOF()</A>                 <A HREF="#flag aliases">FLAG ALIASES</A>
-<A HREF="#flag list">FLAG LIST</A>                 <A HREF="#flag list2">FLAG LIST2</A>                <A HREF="#flags">FLAGS</A>
-<A HREF="#flags()">FLAGS()</A>                   <A HREF="#flip()">FLIP()</A>                    <A HREF="#floating">FLOATING</A>
-<A HREF="#floor()">FLOOR()</A>                   <A HREF="#floordiv()">FLOORDIV()</A>                <A HREF="#fmod()">FMOD()</A>
-<A HREF="#fold()">fold()</A>                    <A HREF="#folder">folder</A>                    <A HREF="#folder change">folder change</A>
-<A HREF="#folder cmdlist">folder cmdlist</A>            <A HREF="#folder create">folder create</A>             <A HREF="#folder cshare">folder cshare</A>
-<A HREF="#folder current">folder current</A>            <A HREF="#folder delete">folder delete</A>             <A HREF="#folder list">folder list</A>
-<A HREF="#folder move">folder move</A>               <A HREF="#folder rename">folder rename</A>             <A HREF="#folder share">folder share</A>
-<A HREF="#foldercurrent()">FOLDERCURRENT()</A>           <A HREF="#folderlist()">FOLDERLIST()</A>              <A HREF="#foreach()">FOREACH()</A>
+<A HREF="#delextract()">delextract()</A>              <A HREF="#descformat">descformat</A>                <A HREF="#destroy()">DESTROY()</A>
+<A HREF="#destroy_ok">DESTROY_OK</A>                <A HREF="#dice()">DICE()</A>                    <A HREF="#die()">DIE()</A>
+<A HREF="#differences">DIFFERENCES</A>               <A HREF="#differences2">DIFFERENCES2</A>              <A HREF="#dig()">DIG()</A>
+<A HREF="#digest()">DIGEST()</A>                  <A HREF="#dist2d()">DIST2D()</A>                  <A HREF="#dist3d()">DIST3D()</A>
+<A HREF="#div()">DIV()</A>                     <A HREF="#doing">doing</A>                     <A HREF="#door syntax">DOOR SYNTAX</A>
+<A HREF="#door_close">DOOR_CLOSE</A>                <A HREF="#door_kick">DOOR_KICK</A>                 <A HREF="#door_list">DOOR_LIST</A>
+<A HREF="#door_list2">DOOR_LIST2</A>                <A HREF="#door_open">DOOR_OPEN</A>                 <A HREF="#door_push">DOOR_PUSH</A>
+<A HREF="#door_status">DOOR_STATUS</A>               <A HREF="#door_writing">DOOR_WRITING</A>              <A HREF="#door_writing2">DOOR_WRITING2</A>
+<A HREF="#door_writing3">DOOR_WRITING3</A>             <A HREF="#doored">DOORED</A>                    <A HREF="#drop">drop</A>
+<A HREF="#dropMINUStos">DROP-TOS</A>                  <A HREF="#e()">E()</A>                       <A HREF="#edefault()">edefault()</A>
+<A HREF="#edit()">EDIT()</A>                    <A HREF="#editansi()">EDITANSI()</A>                <A HREF="#ee()">EE()</A>
+<A HREF="#elementpos()">ELEMENTPOS()</A>              <A HREF="#elements()">elements()</A>                <A HREF="#elementsmux()">elementsmux()</A>
+<A HREF="#elist()">elist()</A>                   <A HREF="#elock()">elock()</A>                   <A HREF="#emit()">EMIT()</A>
+<A HREF="#enactor">ENACTOR</A>                   <A HREF="#encode64()">ENCODE64()</A>                <A HREF="#encrypt()">ENCRYPT()</A>
+<A HREF="#enter">enter</A>                     <A HREF="#enter_ok">ENTER_OK</A>                  <A HREF="#entrances()">ENTRANCES()</A>
+<A HREF="#eq()">eq()</A>                      <A HREF="#error()">ERROR()</A>                   <A HREF="#escape()">ESCAPE()</A>
+<A HREF="#escapex()">ESCAPEX()</A>                 <A HREF="#esclist()">ESCLIST()</A>                 <A HREF="#eval()">EVAL()</A>
+<A HREF="#examine">examine</A>                   <A HREF="#examine2">examine2</A>                  <A HREF="#examine3">examine3</A>
+<A HREF="#examine4">examine4</A>                  <A HREF="#exit()">EXIT()</A>                    <A HREF="#exits">EXITS</A>
+<A HREF="#exp()">EXP()</A>                     <A HREF="#extansi toggle">EXTANSI TOGGLE</A>            <A HREF="#extract()">EXTRACT()</A>
+<A HREF="#extractword()">EXTRACTWORD()</A>             <A HREF="#failure">FAILURE</A>                   <A HREF="#fbetween()">FBETWEEN()</A>
+<A HREF="#fbound()">FBOUND()</A>                  <A HREF="#fdiv()">FDIV()</A>                    <A HREF="#filter()">filter()</A>
+<A HREF="#findable()">findable()</A>                <A HREF="#first()">FIRST()</A>                   <A HREF="#firstof()">FIRSTOF()</A>
+<A HREF="#flag aliases">FLAG ALIASES</A>              <A HREF="#flag list">FLAG LIST</A>                 <A HREF="#flag list2">FLAG LIST2</A>
+<A HREF="#flags">FLAGS</A>                     <A HREF="#flags()">FLAGS()</A>                   <A HREF="#flip()">FLIP()</A>
+<A HREF="#floating">FLOATING</A>                  <A HREF="#floor()">FLOOR()</A>                   <A HREF="#floordiv()">FLOORDIV()</A>
+<A HREF="#fmod()">FMOD()</A>                    <A HREF="#fold()">fold()</A>                    <A HREF="#folder">folder</A>
+<A HREF="#folder change">folder change</A>             <A HREF="#folder cmdlist">folder cmdlist</A>            <A HREF="#folder create">folder create</A>
+<A HREF="#folder cshare">folder cshare</A>             <A HREF="#folder current">folder current</A>            <A HREF="#folder delete">folder delete</A>
+<A HREF="#folder list">folder list</A>               <A HREF="#folder move">folder move</A>               <A HREF="#folder quicklist">folder quicklist</A>
+<A HREF="#folder rename">folder rename</A>             <A HREF="#folder share">folder share</A>              <A HREF="#folder/change">folder/change</A>
+<A HREF="#folder/create">folder/create</A>             <A HREF="#folder/cshare">folder/cshare</A>             <A HREF="#folder/current">folder/current</A>
+<A HREF="#folder/delete">folder/delete</A>             <A HREF="#folder/list">folder/list</A>               <A HREF="#folder/move">folder/move</A>
+<A HREF="#folder/rename">folder/rename</A>             <A HREF="#folder/share">folder/share</A>              <A HREF="#foldercurrent()">FOLDERCURRENT()</A>
+<A HREF="#folderlist()">FOLDERLIST()</A>              <A HREF="#foreach()">FOREACH()</A>                 <A HREF="#formatdesc">formatdesc</A>
 <A HREF="#free">FREE</A>                      <A HREF="#fubar">FUBAR</A>                     <A HREF="#fullname()">FULLNAME()</A>
 <A HREF="#function aliases">FUNCTION ALIASES</A>          <A HREF="#function classes">FUNCTION CLASSES</A>          <A HREF="#function classes2">FUNCTION CLASSES2</A>
 <A HREF="#function classes3">FUNCTION CLASSES3</A>         <A HREF="#function classes4">FUNCTION CLASSES4</A>         <A HREF="#function classes5">FUNCTION CLASSES5</A>
@@ -234,25 +275,28 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#game information functions">game information functions</A><A HREF="#garble()">GARBLE()</A>                  <A HREF="#gender">GENDER</A>
 <A HREF="#get">get</A>                       <A HREF="#get()">GET()</A>                     <A HREF="#get2">get2</A>
 <A HREF="#get_eval()">GET_EVAL()</A>                <A HREF="#give">give</A>                      <A HREF="#globalroom()">GLOBALROOM()</A>
-<A HREF="#goals">GOALS</A>                     <A HREF="#going">GOING</A>                     <A HREF="#goto">goto</A>
-<A HREF="#grab">grab</A>                      <A HREF="#grab()">GRAB()</A>                    <A HREF="#graball()">GRABALL()</A>
-<A HREF="#grep()">GREP()</A>                    <A HREF="#gt()">gt()</A>                      <A HREF="#gte()">gte()</A>
-<A HREF="#guests">GUESTS</A>                    <A HREF="#guild()">GUILD()</A>                   <A HREF="#guildmaster">GUILDMASTER</A>
-<A HREF="#halted">HALTED</A>                    <A HREF="#hasattr()">hasattr()</A>                 <A HREF="#hasattrp()">hasattrp()</A>
-<A HREF="#hasflag()">hasflag()</A>                 <A HREF="#hasquota()">hasquota()</A>                <A HREF="#hasrxlevel()">HASRXLEVEL()</A>
-<A HREF="#hastoggle()">HASTOGGLE()</A>               <A HREF="#hastxlevel()">HASTXLEVEL()</A>              <A HREF="#hastype()">hastype()</A>
-<A HREF="#haven">HAVEN</A>                     <A HREF="#help">help</A>                      <A HREF="#here">HERE</A>
+<A HREF="#globbing">GLOBBING</A>                  <A HREF="#goals">GOALS</A>                     <A HREF="#going">GOING</A>
+<A HREF="#goto">goto</A>                      <A HREF="#grab">grab</A>                      <A HREF="#grab()">GRAB()</A>
+<A HREF="#graball()">GRABALL()</A>                 <A HREF="#grep()">GREP()</A>                    <A HREF="#gt()">gt()</A>
+<A HREF="#gte()">gte()</A>                     <A HREF="#guests">GUESTS</A>                    <A HREF="#guild()">GUILD()</A>
+<A HREF="#guildmaster">GUILDMASTER</A>               <A HREF="#halted">HALTED</A>                    <A HREF="#hasattr()">hasattr()</A>
+<A HREF="#hasattrp()">hasattrp()</A>                <A HREF="#hasflag()">hasflag()</A>                 <A HREF="#hasquota()">hasquota()</A>
+<A HREF="#hasrxlevel()">HASRXLEVEL()</A>              <A HREF="#hastoggle()">HASTOGGLE()</A>               <A HREF="#hastotem()">HASTOTEM()</A>
+<A HREF="#hastxlevel()">HASTXLEVEL()</A>              <A HREF="#hastype()">hastype()</A>                 <A HREF="#haven">HAVEN</A>
+<A HREF="#help">help</A>                      <A HREF="#here">HERE</A>                      <A HREF="#historical">historical</A>
 <A HREF="#home()">HOME()</A>                    <A HREF="#homes">HOMES</A>                     <A HREF="#ibreak()">IBREAK()</A>
 <A HREF="#ic">IC</A>                        <A HREF="#idiv()">IDIV()</A>                    <A HREF="#idle">IDLE</A>
-<A HREF="#idle()">IDLE()</A>                    <A HREF="#ifelse()">ifelse()</A>                  <A HREF="#iindex()">IINDEX()</A>
-<A HREF="#ilev()">ILEV()</A>                    <A HREF="#immortal">IMMORTAL</A>                  <A HREF="#inc()">INC()</A>
-<A HREF="#indestructible">INDESTRUCTIBLE</A>            <A HREF="#index()">INDEX()</A>                   <A HREF="#info">INFO</A>
-<A HREF="#inherit">INHERIT</A>                   <A HREF="#inprogram()">INPROGRAM()</A>               <A HREF="#insert()">INSERT()</A>
+<A HREF="#idle()">IDLE()</A>                    <A HREF="#if()">if()</A>                      <A HREF="#ifelse()">ifelse()</A>
+<A HREF="#iindex()">IINDEX()</A>                  <A HREF="#ilev()">ILEV()</A>                    <A HREF="#immortal">IMMORTAL</A>
+<A HREF="#inc()">INC()</A>                     <A HREF="#indestructible">INDESTRUCTIBLE</A>            <A HREF="#index()">INDEX()</A>
+<A HREF="#inf()">INF()</A>                     <A HREF="#info">INFO</A>                      <A HREF="#inherit">INHERIT</A>
+<A HREF="#inprogram()">INPROGRAM()</A>               <A HREF="#insert()">INSERT()</A>                  <A HREF="#insert2 ">INSERT2 </A>
 <A HREF="#internal_doors">INTERNAL_DOORS</A>            <A HREF="#inum()">INUM()</A>                    <A HREF="#inventory">inventory</A>
-<A HREF="#inzone()">INZONE()</A>                  <A HREF="#isalnum()">ISALNUM()</A>                 <A HREF="#isalpha()">ISALPHA()</A>
-<A HREF="#iscluster()">ISCLUSTER()</A>               <A HREF="#isdbref()">ISDBREF()</A>                 <A HREF="#isdigit()">ISDIGIT()</A>
-<A HREF="#ishidden()">ISHIDDEN()</A>                <A HREF="#isint()">ISINT()</A>                   <A HREF="#islower()">ISLOWER()</A>
-<A HREF="#isnum()">ISNUM()</A>                   <A HREF="#ispunct()">ISPUNCT()</A>                 <A HREF="#isspace()">ISSPACE()</A>
+<A HREF="#invformat">invformat</A>                 <A HREF="#inzone()">INZONE()</A>                  <A HREF="#isalnum()">ISALNUM()</A>
+<A HREF="#isalpha()">ISALPHA()</A>                 <A HREF="#iscluster()">ISCLUSTER()</A>               <A HREF="#isdbref()">ISDBREF()</A>
+<A HREF="#isdigit()">ISDIGIT()</A>                 <A HREF="#ishidden()">ISHIDDEN()</A>                <A HREF="#isint()">ISINT()</A>
+<A HREF="#islower()">ISLOWER()</A>                 <A HREF="#isnum()">ISNUM()</A>                   <A HREF="#isobjid()">ISOBJID()</A>
+<A HREF="#ispunct()">ISPUNCT()</A>                 <A HREF="#isspace()">ISSPACE()</A>                 <A HREF="#istag()">ISTAG()</A>
 <A HREF="#isupper()">ISUPPER()</A>                 <A HREF="#isword()">ISWORD()</A>                  <A HREF="#isxdigit()">ISXDIGIT()</A>
 <A HREF="#iter()">ITER()</A>                    <A HREF="#itext()">ITEXT()</A>                   <A HREF="#join">join</A>
 <A HREF="#jump_ok">JUMP_OK</A>                   <A HREF="#keepalive toggle">KEEPALIVE TOGGLE</A>          <A HREF="#keepflags()">KEEPFLAGS()</A>
@@ -270,22 +314,24 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#listening">LISTENING</A>                 <A HREF="#listflags()">LISTFLAGS()</A>               <A HREF="#listfunctions()">LISTFUNCTIONS()</A>
 <A HREF="#listinter()">LISTINTER()</A>               <A HREF="#listmatch()">LISTMATCH()</A>               <A HREF="#listnewsgroups()">LISTNEWSGROUPS()</A>
 <A HREF="#listprotection()">LISTPROTECTION()</A>          <A HREF="#listrlevels()">LISTRLEVELS()</A>             <A HREF="#lists">LISTS</A>
-<A HREF="#listtoggles()">LISTTOGGLES()</A>             <A HREF="#listunion()">LISTUNION()</A>               <A HREF="#lit()">LIT()</A>
-<A HREF="#lj()">LJ()</A>                      <A HREF="#ljc()">LJC()</A>                     <A HREF="#ljust()">LJUST()</A>
-<A HREF="#lloc()">LLOC()</A>                    <A HREF="#lmath()">LMATH()</A>                   <A HREF="#lmax()">LMAX()</A>
-<A HREF="#lmin()">LMIN()</A>                    <A HREF="#lmul()">LMUL()</A>                    <A HREF="#ln()">LN()</A>
-<A HREF="#lnor()">LNOR()</A>                    <A HREF="#lnum()">LNUM()</A>                    <A HREF="#lnum2()">LNUM2()</A>
-<A HREF="#loc()">LOC()</A>                     <A HREF="#localfunc()">LOCALFUNC()</A>               <A HREF="#localize()">LOCALIZE()</A>
-<A HREF="#locate()">LOCATE()</A>                  <A HREF="#locate2">locate2</A>                   <A HREF="#locate3">locate3</A>
-<A HREF="#lock()">lock()</A>                    <A HREF="#lockcheck()">lockcheck()</A>               <A HREF="#lockdecode()">lockdecode()</A>
-<A HREF="#lockencode()">lockencode()</A>              <A HREF="#log()">LOG()</A>                     <A HREF="#logarithmic functions">logarithmic functions</A>
-<A HREF="#logical functions">logical functions</A>         <A HREF="#logout">LOGOUT</A>                    <A HREF="#look">look</A>
-<A HREF="#looping">LOOPING</A>                   <A HREF="#lor()">LOR()</A>                     <A HREF="#lpage">lpage</A>
-<A HREF="#lparent()">LPARENT()</A>                 <A HREF="#lrand()">lrand()</A>                   <A HREF="#lreplace()">LREPLACE()</A>
-<A HREF="#lrooms()">lrooms()</A>                  <A HREF="#lsub()">LSUB()</A>                    <A HREF="#lt()">lt()</A>
-<A HREF="#lte()">lte()</A>                     <A HREF="#ltoggles()">LTOGGLES()</A>                <A HREF="#lwho()">LWHO()</A>
-<A HREF="#lxnor()">LXNOR()</A>                   <A HREF="#lxor()">LXOR()</A>                    <A HREF="#lzone()">LZONE()</A>
-<A HREF="#mail">mail</A>                      <A HREF="#mail alias">mail alias</A>                <A HREF="#mail anonymous">mail anonymous</A>
+<A HREF="#listtoggles()">LISTTOGGLES()</A>             <A HREF="#listtotems()">LISTTOTEMS()</A>              <A HREF="#listunion()">LISTUNION()</A>
+<A HREF="#lit()">LIT()</A>                     <A HREF="#lj()">LJ()</A>                      <A HREF="#ljc()">LJC()</A>
+<A HREF="#ljust()">LJUST()</A>                   <A HREF="#lloc()">LLOC()</A>                    <A HREF="#lmath()">LMATH()</A>
+<A HREF="#lmax()">LMAX()</A>                    <A HREF="#lmin()">LMIN()</A>                    <A HREF="#lmul()">LMUL()</A>
+<A HREF="#ln()">LN()</A>                      <A HREF="#lnor()">LNOR()</A>                    <A HREF="#lnum()">LNUM()</A>
+<A HREF="#lnum2()">LNUM2()</A>                   <A HREF="#loc()">LOC()</A>                     <A HREF="#localfunc()">LOCALFUNC()</A>
+<A HREF="#localize()">LOCALIZE()</A>                <A HREF="#locate()">LOCATE()</A>                  <A HREF="#locate2">locate2</A>
+<A HREF="#locate3">locate3</A>                   <A HREF="#lock()">lock()</A>                    <A HREF="#lockcheck()">lockcheck()</A>
+<A HREF="#lockdecode()">lockdecode()</A>              <A HREF="#lockencode()">lockencode()</A>              <A HREF="#locks">locks</A>
+<A HREF="#log()">LOG()</A>                     <A HREF="#logarithmic functions">logarithmic functions</A>     <A HREF="#logical functions">logical functions</A>
+<A HREF="#logout">LOGOUT</A>                    <A HREF="#look">look</A>                      <A HREF="#looping">LOOPING</A>
+<A HREF="#lor()">LOR()</A>                     <A HREF="#lpage">lpage</A>                     <A HREF="#lparent()">LPARENT()</A>
+<A HREF="#lrand()">lrand()</A>                   <A HREF="#lreplace()">LREPLACE()</A>                <A HREF="#lrooms()">lrooms()</A>
+<A HREF="#lset()">LSET()</A>                    <A HREF="#lsub()">LSUB()</A>                    <A HREF="#lt()">lt()</A>
+<A HREF="#lte()">lte()</A>                     <A HREF="#ltoggles()">LTOGGLES()</A>                <A HREF="#ltotems()">LTOTEMS()</A>
+<A HREF="#lwho()">LWHO()</A>                    <A HREF="#lxnor()">LXNOR()</A>                   <A HREF="#lxor()">LXOR()</A>
+<A HREF="#lzone()">LZONE()</A>                   <A HREF="#mail">mail</A>                      <A HREF="#mail PLUSall">mail +all</A>
+<A HREF="#mail alias">mail alias</A>                <A HREF="#mail anonymous">mail anonymous</A>            <A HREF="#mail attributes">mail attributes</A>
 <A HREF="#mail autofor">mail autofor</A>              <A HREF="#mail autopurges">mail autopurges</A>           <A HREF="#mail ball">mail ball</A>
 <A HREF="#mail basics">mail basics</A>               <A HREF="#mail basics2">mail basics2</A>              <A HREF="#mail both">mail both</A>
 <A HREF="#mail btutor">mail btutor</A>               <A HREF="#mail changes">mail changes</A>              <A HREF="#mail changes2">mail changes2</A>
@@ -300,77 +346,98 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#mail mark">mail mark</A>                 <A HREF="#mail massmail">mail massmail</A>             <A HREF="#mail nall">mail nall</A>
 <A HREF="#mail new">mail new</A>                  <A HREF="#mail next">mail next</A>                 <A HREF="#mail number">mail number</A>
 <A HREF="#mail page">mail page</A>                 <A HREF="#mail password">mail password</A>             <A HREF="#mail previous">mail previous</A>
-<A HREF="#mail quick">mail quick</A>                <A HREF="#mail quicklist">mail quicklist</A>            <A HREF="#mail quota">mail quota</A>
-<A HREF="#mail read">mail read</A>                 <A HREF="#mail recall">mail recall</A>               <A HREF="#mail recall2">mail recall2</A>
-<A HREF="#mail recall3">mail recall3</A>              <A HREF="#mail reject">mail reject</A>               <A HREF="#mail reply">mail reply</A>
-<A HREF="#mail save">mail save</A>                 <A HREF="#mail send">mail send</A>                 <A HREF="#mail send brandy">mail send brandy</A>
+<A HREF="#mail ptutor">mail ptutor</A>               <A HREF="#mail quick">mail quick</A>                <A HREF="#mail quicklist">mail quicklist</A>
+<A HREF="#mail quota">mail quota</A>                <A HREF="#mail read">mail read</A>                 <A HREF="#mail recall">mail recall</A>
+<A HREF="#mail recall2">mail recall2</A>              <A HREF="#mail recall3">mail recall3</A>              <A HREF="#mail reject">mail reject</A>
+<A HREF="#mail reply">mail reply</A>                <A HREF="#mail save">mail save</A>                 <A HREF="#mail send brandy">mail send brandy</A>
 <A HREF="#mail send examples">mail send examples</A>        <A HREF="#mail send quick">mail send quick</A>           <A HREF="#mail send2">mail send2</A>
-<A HREF="#mail setup_aliases">mail setup_aliases</A>        <A HREF="#mail share">mail share</A>                <A HREF="#mail signature">mail signature</A>
-<A HREF="#mail status">mail status</A>               <A HREF="#mail status2">mail status2</A>              <A HREF="#mail technical">mail technical</A>
-<A HREF="#mail topics">mail topics</A>               <A HREF="#mail tutorial">mail tutorial</A>             <A HREF="#mail uall">mail uall</A>
-<A HREF="#mail unmark">mail unmark</A>               <A HREF="#mail unread">mail unread</A>               <A HREF="#mail version">mail version</A>
-<A HREF="#mail write">mail write</A>                <A HREF="#mail write PLUSacc">mail write +acc</A>           <A HREF="#mail write PLUSbcc">mail write +bcc</A>
-<A HREF="#mail write PLUScc">mail write +cc</A>            <A HREF="#mail write PLUSdel">mail write +del</A>           <A HREF="#mail write PLUSedit">mail write +edit</A>
-<A HREF="#mail write PLUSeditall">mail write +editall</A>       <A HREF="#mail write PLUSfedit">mail write +fedit</A>         <A HREF="#mail write PLUSfeditall">mail write +feditall</A>
-<A HREF="#mail write PLUSforget">mail write +forget</A>        <A HREF="#mail write PLUSforward">mail write +forward</A>       <A HREF="#mail write PLUSinsert">mail write +insert</A>
-<A HREF="#mail write PLUSjoin">mail write +join</A>          <A HREF="#mail write PLUSjustify">mail write +justify</A>       <A HREF="#mail write PLUSlist">mail write +list</A>
-<A HREF="#mail write PLUSproof">mail write +proof</A>         <A HREF="#mail write PLUSreply">mail write +reply</A>         <A HREF="#mail write PLUSsend">mail write +send</A>
-<A HREF="#mail write PLUSsplit">mail write +split</A>         <A HREF="#mail write PLUSsubject">mail write +subject</A>       <A HREF="#mail write MINUS">mail write -</A>
-<A HREF="#mail write adding">mail write adding</A>         <A HREF="#mail write autonotify">mail write autonotify</A>     <A HREF="#mail write cmdlist">mail write cmdlist</A>
-<A HREF="#mail write cmdlist2">mail write cmdlist2</A>       <A HREF="#mail write examples">mail write examples</A>       <A HREF="#mail write forwarding">mail write forwarding</A>
-<A HREF="#mail write quicksending">mail write quicksending</A>   <A HREF="#mail writing">mail writing</A>              <A HREF="#mail zap">mail zap</A>
-<A HREF="#mailMINUSadmin">mail-admin</A>                <A HREF="#mailMINUSaliases">mail-aliases</A>              <A HREF="#mailMINUSaliases2">mail-aliases2</A>
-<A HREF="#mailMINUSdeleting">mail-deleting</A>             <A HREF="#mailMINUSexamples">mail-examples</A>             <A HREF="#mailMINUSfiltering">mail-filtering</A>
-<A HREF="#mailMINUSfolders">mail-folders</A>              <A HREF="#mailMINUSother">mail-other</A>                <A HREF="#mailMINUSreading">mail-reading</A>
-<A HREF="#mailMINUSreviewing">mail-reviewing</A>            <A HREF="#mailMINUSsharing">mail-sharing</A>              <A HREF="#mailMINUSwriting">mail-writing</A>
+<A HREF="#mail sending">mail sending</A>              <A HREF="#mail setup_aliases">mail setup_aliases</A>        <A HREF="#mail share">mail share</A>
+<A HREF="#mail signature">mail signature</A>            <A HREF="#mail status">mail status</A>               <A HREF="#mail status2">mail status2</A>
+<A HREF="#mail technical">mail technical</A>            <A HREF="#mail topics">mail topics</A>               <A HREF="#mail tutorial">mail tutorial</A>
+<A HREF="#mail uall">mail uall</A>                 <A HREF="#mail unmark">mail unmark</A>               <A HREF="#mail unread">mail unread</A>
+<A HREF="#mail version">mail version</A>              <A HREF="#mail write">mail write</A>                <A HREF="#mail write PLUSacc">mail write +acc</A>
+<A HREF="#mail write PLUSbcc">mail write +bcc</A>           <A HREF="#mail write PLUScc">mail write +cc</A>            <A HREF="#mail write PLUSdel">mail write +del</A>
+<A HREF="#mail write PLUSedit">mail write +edit</A>          <A HREF="#mail write PLUSeditall">mail write +editall</A>       <A HREF="#mail write PLUSfedit">mail write +fedit</A>
+<A HREF="#mail write PLUSfeditall">mail write +feditall</A>      <A HREF="#mail write PLUSforget">mail write +forget</A>        <A HREF="#mail write PLUSforward">mail write +forward</A>
+<A HREF="#mail write PLUSinsert">mail write +insert</A>        <A HREF="#mail write PLUSjoin">mail write +join</A>          <A HREF="#mail write PLUSjustify">mail write +justify</A>
+<A HREF="#mail write PLUSlist">mail write +list</A>          <A HREF="#mail write PLUSproof">mail write +proof</A>         <A HREF="#mail write PLUSreply">mail write +reply</A>
+<A HREF="#mail write PLUSsend">mail write +send</A>          <A HREF="#mail write PLUSsplit">mail write +split</A>         <A HREF="#mail write PLUSsubject">mail write +subject</A>
+<A HREF="#mail write MINUS">mail write -</A>              <A HREF="#mail write adding">mail write adding</A>         <A HREF="#mail write autonotify">mail write autonotify</A>
+<A HREF="#mail write cmdlist">mail write cmdlist</A>        <A HREF="#mail write cmdlist2">mail write cmdlist2</A>       <A HREF="#mail write examples">mail write examples</A>
+<A HREF="#mail write forwarding">mail write forwarding</A>     <A HREF="#mail write quicksending">mail write quicksending</A>   <A HREF="#mail writing">mail writing</A>
+<A HREF="#mail zap">mail zap</A>                  <A HREF="#mailMINUSadmin">mail-admin</A>                <A HREF="#mailMINUSaliases">mail-aliases</A>
+<A HREF="#mailMINUSaliases2">mail-aliases2</A>             <A HREF="#mailMINUSattributes">mail-attributes</A>           <A HREF="#mailMINUSdeleting">mail-deleting</A>
+<A HREF="#mailMINUSexamples">mail-examples</A>             <A HREF="#mailMINUSfiltering">mail-filtering</A>            <A HREF="#mailMINUSfolders">mail-folders</A>
+<A HREF="#mailMINUSother">mail-other</A>                <A HREF="#mailMINUSreading">mail-reading</A>              <A HREF="#mailMINUSreviewing">mail-reviewing</A>
+<A HREF="#mailMINUSsharing">mail-sharing</A>              <A HREF="#mailMINUSwriting">mail-writing</A>              <A HREF="#mail/alias">mail/alias</A>
+<A HREF="#mail/anonymous">mail/anonymous</A>            <A HREF="#mail/autofor">mail/autofor</A>              <A HREF="#mail/check">mail/check</A>
+<A HREF="#mail/delete">mail/delete</A>               <A HREF="#mail/forward">mail/forward</A>              <A HREF="#mail/lock">mail/lock</A>
+<A HREF="#mail/mark">mail/mark</A>                 <A HREF="#mail/mark/save">mail/mark/save</A>            <A HREF="#mail/next">mail/next</A>
+<A HREF="#mail/number">mail/number</A>               <A HREF="#mail/page">mail/page</A>                 <A HREF="#mail/password">mail/password</A>
+<A HREF="#mail/previous">mail/previous</A>             <A HREF="#mail/quick">mail/quick</A>                <A HREF="#mail/quota">mail/quota</A>
+<A HREF="#mail/read">mail/read</A>                 <A HREF="#mail/read/save">mail/read/save</A>            <A HREF="#mail/recall">mail/recall</A>
+<A HREF="#mail/reject">mail/reject</A>               <A HREF="#mail/reply">mail/reply</A>                <A HREF="#mail/save">mail/save</A>
+<A HREF="#mail/save/read">mail/save/read</A>            <A HREF="#mail/send">mail/send</A>                 <A HREF="#mail/share">mail/share</A>
+<A HREF="#mail/status">mail/status</A>               <A HREF="#mail/unmark">mail/unmark</A>               <A HREF="#mail/version">mail/version</A>
+<A HREF="#mail/write">mail/write</A>                <A HREF="#mail/write PLUSacc">mail/write +acc</A>           <A HREF="#mail/write PLUSbcc">mail/write +bcc</A>
+<A HREF="#mail/write PLUScc">mail/write +cc</A>            <A HREF="#mail/write PLUSdel">mail/write +del</A>           <A HREF="#mail/write PLUSedit">mail/write +edit</A>
+<A HREF="#mail/write PLUSeditall">mail/write +editall</A>       <A HREF="#mail/write PLUSfedit">mail/write +fedit</A>         <A HREF="#mail/write PLUSfeditall">mail/write +feditall</A>
+<A HREF="#mail/write PLUSforget">mail/write +forget</A>        <A HREF="#mail/write PLUSforward">mail/write +forward</A>       <A HREF="#mail/write PLUSinsert">mail/write +insert</A>
+<A HREF="#mail/write PLUSjoin">mail/write +join</A>          <A HREF="#mail/write PLUSjustify">mail/write +justify</A>       <A HREF="#mail/write PLUSlist">mail/write +list</A>
+<A HREF="#mail/write PLUSproof">mail/write +proof</A>         <A HREF="#mail/write PLUSreply">mail/write +reply</A>         <A HREF="#mail/write PLUSsend">mail/write +send</A>
+<A HREF="#mail/write PLUSsplit">mail/write +split</A>         <A HREF="#mail/write PLUSsubject">mail/write +subject</A>       <A HREF="#mail/zap">mail/zap</A>
 <A HREF="#mail_noparse toggle">MAIL_NOPARSE TOGGLE</A>       <A HREF="#mail_stripreturn toggle">MAIL_STRIPRETURN TOGGLE</A>   <A HREF="#mailfilter">MAILFILTER</A>
-<A HREF="#mailquick()">MAILQUICK()</A>               <A HREF="#mailvalidate toggle">MAILVALIDATE TOGGLE</A>       <A HREF="#map()">map()</A>
-<A HREF="#marker0">MARKER0</A>                   <A HREF="#marker1">MARKER1</A>                   <A HREF="#marker2">MARKER2</A>
-<A HREF="#marker3">MARKER3</A>                   <A HREF="#marker4">MARKER4</A>                   <A HREF="#marker5">MARKER5</A>
-<A HREF="#marker6">MARKER6</A>                   <A HREF="#marker7">MARKER7</A>                   <A HREF="#marker8">MARKER8</A>
-<A HREF="#marker9">MARKER9</A>                   <A HREF="#mask()">MASK()</A>                    <A HREF="#match()">MATCH()</A>
-<A HREF="#max()">MAX()</A>                     <A HREF="#me">ME</A>                        <A HREF="#member()">member()</A>
+<A HREF="#mailnotify">MAILNOTIFY</A>                <A HREF="#mailquick()">MAILQUICK()</A>               <A HREF="#mailvalidate toggle">MAILVALIDATE TOGGLE</A>
+<A HREF="#map()">map()</A>                     <A HREF="#marker0">MARKER0</A>                   <A HREF="#marker1">MARKER1</A>
+<A HREF="#marker2">MARKER2</A>                   <A HREF="#marker3">MARKER3</A>                   <A HREF="#marker4">MARKER4</A>
+<A HREF="#marker5">MARKER5</A>                   <A HREF="#marker6">MARKER6</A>                   <A HREF="#marker7">MARKER7</A>
+<A HREF="#marker8">MARKER8</A>                   <A HREF="#marker9">MARKER9</A>                   <A HREF="#mask()">MASK()</A>
+<A HREF="#match()">MATCH()</A>                   <A HREF="#max args">MAX ARGS</A>                  <A HREF="#max()">MAX()</A>
+<A HREF="#max_name_protect">max_name_protect</A>          <A HREF="#me">ME</A>                        <A HREF="#member()">member()</A>
 <A HREF="#merge()">MERGE()</A>                   <A HREF="#mid()">MID()</A>                     <A HREF="#min()">MIN()</A>
 <A HREF="#miscellaneous functions">miscellaneous functions</A>   <A HREF="#mix()">MIX()</A>                     <A HREF="#mod()">MOD()</A>
 <A HREF="#modifytime()">MODIFYTIME()</A>              <A HREF="#modulo()">MODULO()</A>                  <A HREF="#money">MONEY</A>
 <A HREF="#money()">MONEY()</A>                   <A HREF="#moneyname()">MONEYNAME()</A>               <A HREF="#monitor">MONITOR</A>
 <A HREF="#monitor toggle">MONITOR TOGGLE</A>            <A HREF="#moon()">MOON()</A>                    <A HREF="#move">move</A>
 <A HREF="#move()">MOVE()</A>                    <A HREF="#moving">MOVING</A>                    <A HREF="#moving2">moving2</A>
-<A HREF="#moving3">moving3</A>                   <A HREF="#mrpage">mrpage</A>                    <A HREF="#mudname()">MUDNAME()</A>
-<A HREF="#mul()">MUL()</A>                     <A HREF="#munge()">MUNGE()</A>                   <A HREF="#munge2">MUNGE2</A>
-<A HREF="#muxpage toggle">MUXPAGE TOGGLE</A>            <A HREF="#mwords()">MWORDS()</A>                  <A HREF="#myopic">MYOPIC</A>
-<A HREF="#name()">NAME()</A>                    <A HREF="#nameq()">NAMEQ()</A>                   <A HREF="#nand()">NAND()</A>
-<A HREF="#ncomp()">NCOMP()</A>                   <A HREF="#nearby()">NEARBY()</A>                  <A HREF="#neq()">neq()</A>
-<A HREF="#new users">NEW USERS</A>                 <A HREF="#news">news</A>                      <A HREF="#news changes">news changes</A>
-<A HREF="#news check">news check</A>                <A HREF="#news cmdlist">news cmdlist</A>              <A HREF="#news default group">news default group</A>
-<A HREF="#news description">news description</A>          <A HREF="#news description2">news description2</A>         <A HREF="#news extend">news extend</A>
-<A HREF="#news general">news general</A>              <A HREF="#news groupinfo">news groupinfo</A>            <A HREF="#news grouplist">news grouplist</A>
-<A HREF="#news groupmem">news groupmem</A>             <A HREF="#news info">news info</A>                 <A HREF="#news jump">news jump</A>
-<A HREF="#news login">news login</A>                <A HREF="#news mailto">news mailto</A>               <A HREF="#news new user">news new user</A>
-<A HREF="#news old news">news old news</A>             <A HREF="#news post">news post</A>                 <A HREF="#news postlist">news postlist</A>
-<A HREF="#news postlock">news postlock</A>             <A HREF="#news read">news read</A>                 <A HREF="#news readall">news readall</A>
-<A HREF="#news readlock">news readlock</A>             <A HREF="#news repost">news repost</A>               <A HREF="#news status">news status</A>
-<A HREF="#news subscribe">news subscribe</A>            <A HREF="#news technical">news technical</A>            <A HREF="#news unsubscribe">news unsubscribe</A>
-<A HREF="#news userinfo">news userinfo</A>             <A HREF="#news verbose">news verbose</A>              <A HREF="#news yank">news yank</A>
-<A HREF="#next()">NEXT()</A>                    <A HREF="#no_ansi_ex toggle">NO_ANSI_EX TOGGLE</A>         <A HREF="#no_ansi_exit toggle">NO_ANSI_EXIT TOGGLE</A>
-<A HREF="#no_ansi_player toggle">NO_ANSI_PLAYER TOGGLE</A>     <A HREF="#no_ansi_room toggle">NO_ANSI_ROOM TOGGLE</A>       <A HREF="#no_ansi_thing toggle">NO_ANSI_THING TOGGLE</A>
-<A HREF="#no_command">NO_COMMAND</A>                <A HREF="#no_flash">NO_FLASH</A>                  <A HREF="#no_spoof">NO_SPOOF</A>
-<A HREF="#no_tel">NO_TEL</A>                    <A HREF="#no_underline">NO_UNDERLINE</A>              <A HREF="#no_walls">NO_WALLS</A>
-<A HREF="#no_yell">NO_YELL</A>                   <A HREF="#nocommand">NOCOMMAND</A>                 <A HREF="#noflash">NOFLASH</A>
-<A HREF="#noglobparent toggle">NOGLOBPARENT TOGGLE</A>       <A HREF="#noisy">NOISY</A>                     <A HREF="#nor()">NOR()</A>
-<A HREF="#nospoof">NOSPOOF</A>                   <A HREF="#nostr()">NOSTR()</A>                   <A HREF="#not()">NOT()</A>
-<A HREF="#notchr()">NOTCHR()</A>                  <A HREF="#notel">NOTEL</A>                     <A HREF="#notify_link toggle">NOTIFY_LINK TOGGLE</A>
-<A HREF="#nounderline">NOUNDERLINE</A>               <A HREF="#nowalls">NOWALLS</A>                   <A HREF="#noyell">NOYELL</A>
-<A HREF="#nozoneparent toggle">NOZONEPARENT TOGGLE</A>       <A HREF="#npemit()">NPEMIT()</A>                  <A HREF="#nsiter()">NSITER()</A>
-<A HREF="#null()">NULL()</A>                    <A HREF="#num()">NUM()</A>                     <A HREF="#numerical conversion functions">numerical conversion functions</A>
-<A HREF="#nummatch()">NUMMATCH()</A>                <A HREF="#nummember()">NUMMEMBER()</A>               <A HREF="#numpos()">NUMPOS()</A>
-<A HREF="#numwildmatch()">numwildmatch()</A>            <A HREF="#obj()">OBJ()</A>                     <A HREF="#object information functions">object information functions</A>
-<A HREF="#object information functions2">object information functions2</A><A HREF="#object types">OBJECT TYPES</A>              <A HREF="#objeval()">OBJEVAL()</A>
+<A HREF="#moving3">moving3</A>                   <A HREF="#mrpage">mrpage</A>                    <A HREF="#msecs()">MSECS()</A>
+<A HREF="#muddiff">MUDDIFF</A>                   <A HREF="#mudname()">MUDNAME()</A>                 <A HREF="#mul()">MUL()</A>
+<A HREF="#munge()">MUNGE()</A>                   <A HREF="#munge2">MUNGE2</A>                    <A HREF="#muxpage toggle">MUXPAGE TOGGLE</A>
+<A HREF="#mwords()">MWORDS()</A>                  <A HREF="#myopic">MYOPIC</A>                    <A HREF="#name()">NAME()</A>
+<A HREF="#nameq()">NAMEQ()</A>                   <A HREF="#nand()">NAND()</A>                    <A HREF="#ncomp()">NCOMP()</A>
+<A HREF="#nearby()">NEARBY()</A>                  <A HREF="#neq()">neq()</A>                     <A HREF="#new users">NEW USERS</A>
+<A HREF="#news">news</A>                      <A HREF="#news changes">news changes</A>              <A HREF="#news check">news check</A>
+<A HREF="#news cmdlist">news cmdlist</A>              <A HREF="#news default group">news default group</A>        <A HREF="#news description">news description</A>
+<A HREF="#news description2">news description2</A>         <A HREF="#news extend">news extend</A>               <A HREF="#news general">news general</A>
+<A HREF="#news groupinfo">news groupinfo</A>            <A HREF="#news grouplist">news grouplist</A>            <A HREF="#news groupmem">news groupmem</A>
+<A HREF="#news info">news info</A>                 <A HREF="#news jump">news jump</A>                 <A HREF="#news login">news login</A>
+<A HREF="#news mailto">news mailto</A>               <A HREF="#news new user">news new user</A>             <A HREF="#news old news">news old news</A>
+<A HREF="#news post">news post</A>                 <A HREF="#news postlist">news postlist</A>             <A HREF="#news postlock">news postlock</A>
+<A HREF="#news read">news read</A>                 <A HREF="#news readall">news readall</A>              <A HREF="#news readlock">news readlock</A>
+<A HREF="#news repost">news repost</A>               <A HREF="#news status">news status</A>               <A HREF="#news subscribe">news subscribe</A>
+<A HREF="#news technical">news technical</A>            <A HREF="#news unsubscribe">news unsubscribe</A>          <A HREF="#news userinfo">news userinfo</A>
+<A HREF="#news verbose">news verbose</A>              <A HREF="#news yank">news yank</A>                 <A HREF="#next()">NEXT()</A>
+<A HREF="#no_ansi_ex toggle">NO_ANSI_EX TOGGLE</A>         <A HREF="#no_ansi_exit toggle">NO_ANSI_EXIT TOGGLE</A>       <A HREF="#no_ansi_player toggle">NO_ANSI_PLAYER TOGGLE</A>
+<A HREF="#no_ansi_room toggle">NO_ANSI_ROOM TOGGLE</A>       <A HREF="#no_ansi_thing toggle">NO_ANSI_THING TOGGLE</A>      <A HREF="#no_command">NO_COMMAND</A>
+<A HREF="#no_flash">NO_FLASH</A>                  <A HREF="#no_spoof">NO_SPOOF</A>                  <A HREF="#no_tel">NO_TEL</A>
+<A HREF="#no_underline">NO_UNDERLINE</A>              <A HREF="#no_walls">NO_WALLS</A>                  <A HREF="#no_yell">NO_YELL</A>
+<A HREF="#nocommand">NOCOMMAND</A>                 <A HREF="#noflash">NOFLASH</A>                   <A HREF="#noglobparent toggle">NOGLOBPARENT TOGGLE</A>
+<A HREF="#noisy">NOISY</A>                     <A HREF="#nor()">NOR()</A>                     <A HREF="#nospoof">NOSPOOF</A>
+<A HREF="#nostr()">NOSTR()</A>                   <A HREF="#not()">NOT()</A>                     <A HREF="#notchr()">NOTCHR()</A>
+<A HREF="#notel">NOTEL</A>                     <A HREF="#notify_link toggle">NOTIFY_LINK TOGGLE</A>        <A HREF="#nounderline">NOUNDERLINE</A>
+<A HREF="#nowalls">NOWALLS</A>                   <A HREF="#noyell">NOYELL</A>                    <A HREF="#nozoneparent toggle">NOZONEPARENT TOGGLE</A>
+<A HREF="#npemit()">NPEMIT()</A>                  <A HREF="#nsiter()">NSITER()</A>                  <A HREF="#null()">NULL()</A>
+<A HREF="#num()">NUM()</A>                     <A HREF="#numerical conversion functions">numerical conversion functions</A><A HREF="#nummatch()">NUMMATCH()</A>
+<A HREF="#nummember()">NUMMEMBER()</A>               <A HREF="#numpos()">NUMPOS()</A>                  <A HREF="#numwildmatch()">numwildmatch()</A>
+<A HREF="#obj()">OBJ()</A>                     <A HREF="#object information functions">object information functions</A><A HREF="#object information functions2">object information functions2</A>
+<A HREF="#object types">OBJECT TYPES</A>              <A HREF="#objeval()">OBJEVAL()</A>                 <A HREF="#objid()">OBJID()</A>
 <A HREF="#oemit()">OEMIT()</A>                   <A HREF="#ofparse()">OFPARSE()</A>                 <A HREF="#ofparse2">OFPARSE2</A>
 <A HREF="#opaque">OPAQUE</A>                    <A HREF="#open()">OPEN()</A>                    <A HREF="#or()">OR()</A>
 <A HREF="#orchr()">ORCHR()</A>                   <A HREF="#orflag()">ORFLAG()</A>                  <A HREF="#orflags()">ORFLAGS()</A>
+<A HREF="#ortotem()">ORTOTEM()</A>                 <A HREF="#ortotems()">ORTOTEMS()</A>                <A HREF="#outpageformat">OUTPAGEFORMAT</A>
 <A HREF="#outputprefix">OUTPUTPREFIX</A>              <A HREF="#outputsuffix">OUTPUTSUFFIX</A>              <A HREF="#owner()">OWNER()</A>
-<A HREF="#pack()">PACK()</A>                    <A HREF="#page">page</A>                      <A HREF="#page2 ">page2 </A>
+<A HREF="#pack()">PACK()</A>                    <A HREF="#packmath()">PACKMATH()</A>                <A HREF="#page">page</A>
+<A HREF="#page2 ">page2 </A>                    <A HREF="#pageformat">PAGEFORMAT</A>                <A HREF="#pageformat2">pageformat2</A>
 <A HREF="#parenmatch()">PARENMATCH()</A>              <A HREF="#parenstr()">PARENSTR()</A>                <A HREF="#parent objects">PARENT OBJECTS</A>
 <A HREF="#parent()">PARENT()</A>                  <A HREF="#parent2 ">PARENT2 </A>                  <A HREF="#parent_ok">PARENT_OK</A>
 <A HREF="#parents()">PARENTS()</A>                 <A HREF="#parse()">PARSE()</A>                   <A HREF="#parsestr()">PARSESTR()</A>
@@ -378,36 +445,39 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#pedit()">PEDIT()</A>                   <A HREF="#pemit()">PEMIT()</A>                   <A HREF="#penn_mail toggle">PENN_MAIL TOGGLE</A>
 <A HREF="#pfind()">PFIND()</A>                   <A HREF="#pgrep()">PGREP()</A>                   <A HREF="#pi()">PI()</A>
 <A HREF="#pickrand()">pickrand()</A>                <A HREF="#pid()">PID()</A>                     <A HREF="#pid2">PID2</A>
-<A HREF="#player">PLAYER</A>                    <A HREF="#player information functions">player information functions</A><A HREF="#pmatch()">PMATCH()</A>
-<A HREF="#port()">PORT()</A>                    <A HREF="#pos()">POS()</A>                     <A HREF="#pose">pose</A>
-<A HREF="#poss()">POSS()</A>                    <A HREF="#power()">POWER()</A>                   <A HREF="#power10()">POWER10()</A>
+<A HREF="#player">PLAYER</A>                    <A HREF="#player information functions">player information functions</A><A HREF="#plushelp">plushelp</A>
+<A HREF="#pmatch()">PMATCH()</A>                  <A HREF="#port()">PORT()</A>                    <A HREF="#pos()">POS()</A>
+<A HREF="#pose">pose</A>                      <A HREF="#poss()">POSS()</A>                    <A HREF="#power()">POWER()</A>
+<A HREF="#power10()">POWER10()</A>                 <A HREF="#printf borders">PRINTF BORDERS</A>            <A HREF="#printf borders2">PRINTF BORDERS2</A>
 <A HREF="#printf codelist">PRINTF CODELIST</A>           <A HREF="#printf examples">PRINTF EXAMPLES</A>           <A HREF="#printf examples2">PRINTF EXAMPLES2</A>
 <A HREF="#printf examples3">PRINTF EXAMPLES3</A>          <A HREF="#printf examples4">PRINTF EXAMPLES4</A>          <A HREF="#printf examples5">PRINTF EXAMPLES5</A>
 <A HREF="#printf examples6">PRINTF EXAMPLES6</A>          <A HREF="#printf penn">PRINTF PENN</A>               <A HREF="#printf penn2">PRINTF PENN2</A>
 <A HREF="#printf syntax ">PRINTF SYNTAX </A>            <A HREF="#printf()">PRINTF()</A>                  <A HREF="#private">PRIVATE</A>
-<A HREF="#privatize()">PRIVATIZE()</A>               <A HREF="#programmer()">PROGRAMMER()</A>              <A HREF="#ptimefmt()">PTIMEFMT()</A>
-<A HREF="#ptimefmt2">PTIMEFMT2</A>                 <A HREF="#puppet">PUPPET</A>                    <A HREF="#puppets">PUPPETS</A>
-<A HREF="#pushregs()">PUSHREGS()</A>                <A HREF="#quickreference">QUICKREFERENCE</A>            <A HREF="#quiet">QUIET</A>
-<A HREF="#quit ">quit </A>                     <A HREF="#quota alternate2">quota alternate2</A>          <A HREF="#quota alternate3">quota alternate3</A>
-<A HREF="#quota()">quota()</A>                   <A HREF="#r()">R()</A>                       <A HREF="#race()">RACE()</A>
-<A HREF="#rand()">RAND()</A>                    <A HREF="#randextract()">randextract()</A>             <A HREF="#randmatch()">randmatch()</A>
-<A HREF="#randpos()">randpos()</A>                 <A HREF="#read">read</A>                      <A HREF="#reality level functions">reality level functions</A>
-<A HREF="#reality levels">REALITY LEVELS</A>            <A HREF="#rebootsecs()">REBOOTSECS()</A>              <A HREF="#reboottime()">REBOOTTIME()</A>
-<A HREF="#regedit()">REGEDIT()</A>                 <A HREF="#regeditall()">REGEDITALL()</A>              <A HREF="#regeditalli()">REGEDITALLI()</A>
-<A HREF="#regeditallilit()">REGEDITALLILIT()</A>          <A HREF="#regeditalllit()">REGEDITALLLIT()</A>           <A HREF="#regediti()">REGEDITI()</A>
-<A HREF="#regeditilit()">REGEDITILIT()</A>             <A HREF="#regeditlit()">REGEDITLIT()</A>              <A HREF="#regexp classes">REGEXP CLASSES</A>
-<A HREF="#regexp classes2">REGEXP CLASSES2</A>           <A HREF="#regexp examples">REGEXP EXAMPLES</A>           <A HREF="#regexp syntax">REGEXP SYNTAX</A>
-<A HREF="#regexp syntax2">REGEXP SYNTAX2</A>            <A HREF="#regexp syntax3">REGEXP SYNTAX3</A>            <A HREF="#regexp syntax4">REGEXP SYNTAX4</A>
-<A HREF="#regexp syntax5">REGEXP SYNTAX5</A>            <A HREF="#regexp syntax6">REGEXP SYNTAX6</A>            <A HREF="#regexp syntax7">REGEXP SYNTAX7</A>
-<A HREF="#regexp syntax8">REGEXP SYNTAX8</A>            <A HREF="#regexps">REGEXPS</A>                   <A HREF="#regexps2">REGEXPS2</A>
-<A HREF="#reglmatch()">REGLMATCH()</A>               <A HREF="#reglmatchall()">REGLMATCHALL()</A>            <A HREF="#reglmatchalli()">REGLMATCHALLI()</A>
-<A HREF="#reglmatchi()">REGLMATCHI()</A>              <A HREF="#regmatch()">REGMATCH()</A>                <A HREF="#regmatchi()">REGMATCHI()</A>
-<A HREF="#regnummatch()">REGNUMMATCH()</A>             <A HREF="#regnummatchi()">REGNUMMATCHI()</A>            <A HREF="#regrab()">REGRAB()</A>
-<A HREF="#regraball()">REGRABALL()</A>               <A HREF="#regraballi()">REGRABALLI()</A>              <A HREF="#regrabi()">REGRABI()</A>
-<A HREF="#regrep()">REGREP()</A>                  <A HREF="#regrepi()">REGREPI()</A>                 <A HREF="#regular expression functions">regular expression functions</A>
-<A HREF="#relational functions">relational functions</A>      <A HREF="#remainder()">REMAINDER()</A>               <A HREF="#remflags()">REMFLAGS()</A>
-<A HREF="#remit()">REMIT()</A>                   <A HREF="#remove()">remove()</A>                  <A HREF="#remtype()">REMTYPE()</A>
-<A HREF="#repeat()">REPEAT()</A>                  <A HREF="#replace()">REPLACE()</A>                 <A HREF="#rest()">REST()</A>
+<A HREF="#privatize()">PRIVATIZE()</A>               <A HREF="#privatize2">PRIVATIZE2</A>                <A HREF="#programmer()">PROGRAMMER()</A>
+<A HREF="#protect_addenh">protect_addenh</A>            <A HREF="#ptimefmt()">PTIMEFMT()</A>                <A HREF="#ptimefmt2">PTIMEFMT2</A>
+<A HREF="#puppet">PUPPET</A>                    <A HREF="#puppets">PUPPETS</A>                   <A HREF="#pushregs()">PUSHREGS()</A>
+<A HREF="#quickreference">QUICKREFERENCE</A>            <A HREF="#quiet">QUIET</A>                     <A HREF="#quit ">quit </A>
+<A HREF="#quota alternate2">quota alternate2</A>          <A HREF="#quota alternate3">quota alternate3</A>          <A HREF="#quota()">quota()</A>
+<A HREF="#r()">R()</A>                       <A HREF="#race()">RACE()</A>                    <A HREF="#rand()">RAND()</A>
+<A HREF="#randextract()">randextract()</A>             <A HREF="#randmatch()">randmatch()</A>               <A HREF="#randpos()">randpos()</A>
+<A HREF="#read">read</A>                      <A HREF="#reality level functions">reality level functions</A>   <A HREF="#reality levels">REALITY LEVELS</A>
+<A HREF="#rebootsecs()">REBOOTSECS()</A>              <A HREF="#reboottime()">REBOOTTIME()</A>              <A HREF="#regedit()">REGEDIT()</A>
+<A HREF="#regeditall()">REGEDITALL()</A>              <A HREF="#regeditalli()">REGEDITALLI()</A>             <A HREF="#regeditallilit()">REGEDITALLILIT()</A>
+<A HREF="#regeditalllit()">REGEDITALLLIT()</A>           <A HREF="#regediti()">REGEDITI()</A>                <A HREF="#regeditilit()">REGEDITILIT()</A>
+<A HREF="#regeditlit()">REGEDITLIT()</A>              <A HREF="#regexp casesensitive">REGEXP CASESENSITIVE</A>      <A HREF="#regexp casesensitivity">REGEXP CASESENSITIVITY</A>
+<A HREF="#regexp classes">REGEXP CLASSES</A>            <A HREF="#regexp classes2">REGEXP CLASSES2</A>           <A HREF="#regexp examples">REGEXP EXAMPLES</A>
+<A HREF="#regexp syntax">REGEXP SYNTAX</A>             <A HREF="#regexp syntax2">REGEXP SYNTAX2</A>            <A HREF="#regexp syntax3">REGEXP SYNTAX3</A>
+<A HREF="#regexp syntax4">REGEXP SYNTAX4</A>            <A HREF="#regexp syntax5">REGEXP SYNTAX5</A>            <A HREF="#regexp syntax6">REGEXP SYNTAX6</A>
+<A HREF="#regexp syntax7">REGEXP SYNTAX7</A>            <A HREF="#regexp syntax8">REGEXP SYNTAX8</A>            <A HREF="#regexps">REGEXPS</A>
+<A HREF="#regexps2">REGEXPS2</A>                  <A HREF="#register">register</A>                  <A HREF="#reglmatch()">REGLMATCH()</A>
+<A HREF="#reglmatchall()">REGLMATCHALL()</A>            <A HREF="#reglmatchalli()">REGLMATCHALLI()</A>           <A HREF="#reglmatchi()">REGLMATCHI()</A>
+<A HREF="#regmatch()">REGMATCH()</A>                <A HREF="#regmatchi()">REGMATCHI()</A>               <A HREF="#regnummatch()">REGNUMMATCH()</A>
+<A HREF="#regnummatchi()">REGNUMMATCHI()</A>            <A HREF="#regrab()">REGRAB()</A>                  <A HREF="#regraball()">REGRABALL()</A>
+<A HREF="#regraballi()">REGRABALLI()</A>              <A HREF="#regrabi()">REGRABI()</A>                 <A HREF="#regrep()">REGREP()</A>
+<A HREF="#regrepi()">REGREPI()</A>                 <A HREF="#regular expression functions">regular expression functions</A><A HREF="#relational functions">relational functions</A>
+<A HREF="#remainder()">REMAINDER()</A>               <A HREF="#remflags()">REMFLAGS()</A>                <A HREF="#remit()">REMIT()</A>
+<A HREF="#remove()">remove()</A>                  <A HREF="#remtype()">REMTYPE()</A>                 <A HREF="#repeat()">REPEAT()</A>
+<A HREF="#replace()">REPLACE()</A>                 <A HREF="#require_trees">REQUIRE_TREES</A>             <A HREF="#rest()">REST()</A>
 <A HREF="#reswitch()">RESWITCH()</A>                <A HREF="#reswitchall()">RESWITCHALL()</A>             <A HREF="#reswitchalli()">RESWITCHALLI()</A>
 <A HREF="#reswitchi()">RESWITCHI()</A>               <A HREF="#reverse()">REVERSE()</A>                 <A HREF="#revisions">revisions</A>
 <A HREF="#revwords()">REVWORDS()</A>                <A HREF="#right()">RIGHT()</A>                   <A HREF="#rindex()">RINDEX()</A>
@@ -416,11 +486,13 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#robot">ROBOT</A>                     <A HREF="#roman()">ROMAN()</A>                   <A HREF="#room">ROOM</A>
 <A HREF="#room()">ROOM()</A>                    <A HREF="#rotl()">rotl()</A>                    <A HREF="#rotr()">rotr()</A>
 <A HREF="#round()">ROUND()</A>                   <A HREF="#royalty">ROYALTY</A>                   <A HREF="#rpage">rpage</A>
-<A HREF="#rset()">RSET()</A>                    <A HREF="#rxlevel()">RXLEVEL()</A>                 <A HREF="#s()">S()</A>
-<A HREF="#safe">SAFE</A>                      <A HREF="#safebuff()">SAFEBUFF()</A>                <A HREF="#safelog toggle">SAFELOG TOGGLE</A>
-<A HREF="#save">save</A>                      <A HREF="#say">say</A>                       <A HREF="#score">score</A>
-<A HREF="#scramble()">scramble()</A>                <A HREF="#search classes">search classes</A>            <A HREF="#search()">SEARCH()</A>
-<A HREF="#searchng()">SEARCHNG()</A>                <A HREF="#secs()">SECS()</A>                    <A HREF="#secure()">SECURE()</A>
+<A HREF="#rset()">RSET()</A>                    <A HREF="#ruler()">RULER()</A>                   <A HREF="#rxdesc()">RXDESC()</A>
+<A HREF="#rxlevel()">RXLEVEL()</A>                 <A HREF="#s()">S()</A>                       <A HREF="#safe">SAFE</A>
+<A HREF="#safebuff()">SAFEBUFF()</A>                <A HREF="#safelog toggle">SAFELOG TOGGLE</A>            <A HREF="#sandbox()">SANDBOX()</A>
+<A HREF="#sandbox2">SANDBOX2</A>                  <A HREF="#save">save</A>                      <A HREF="#say">say</A>
+<A HREF="#score">score</A>                     <A HREF="#scramble()">scramble()</A>                <A HREF="#search classes">search classes</A>
+<A HREF="#search()">SEARCH()</A>                  <A HREF="#searchng()">SEARCHNG()</A>                <A HREF="#searchngobjid()">SEARCHNGOBJID()</A>
+<A HREF="#searchobjid()">SEARCHOBJID()</A>             <A HREF="#secs()">SECS()</A>                    <A HREF="#secure()">SECURE()</A>
 <A HREF="#securex()">SECUREX()</A>                 <A HREF="#sees()">sees()</A>                    <A HREF="#semaphores">SEMAPHORES</A>
 <A HREF="#semaphores2">semaphores2</A>               <A HREF="#senses">SENSES</A>                    <A HREF="#session">SESSION</A>
 <A HREF="#set()">SET()</A>                     <A HREF="#setdiff()">SETDIFF()</A>                 <A HREF="#setinter()">SETINTER()</A>
@@ -432,54 +504,60 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#sign()">SIGN()</A>                    <A HREF="#sin()">SIN()</A>                     <A HREF="#singlethreading">SINGLETHREADING</A>
 <A HREF="#singletime()">SINGLETIME()</A>              <A HREF="#sinh()">SINH()</A>                    <A HREF="#slave">SLAVE</A>
 <A HREF="#smell">smell</A>                     <A HREF="#sort()">SORT()</A>                    <A HREF="#sortby()">SORTBY()</A>
-<A HREF="#sortlist()">SORTLIST()</A>                <A HREF="#soundex()">SOUNDEX()</A>                 <A HREF="#soundex2">SOUNDEX2</A>
-<A HREF="#soundlike()">SOUNDLIKE()</A>               <A HREF="#soundslike()">SOUNDSLIKE()</A>              <A HREF="#space()">SPACE()</A>
-<A HREF="#speak()">SPEAK()</A>                   <A HREF="#spellnum()">SPELLNUM()</A>                <A HREF="#splice()">SPLICE()</A>
-<A HREF="#spoofing">SPOOFING</A>                  <A HREF="#sql">SQL</A>                       <A HREF="#sql()">SQL()</A>
-<A HREF="#sqlescape()">SQLESCAPE()</A>               <A HREF="#sqlite_query()">SQLITE_QUERY()</A>            <A HREF="#sqlite_query2">SQLITE_QUERY2</A>
-<A HREF="#sqloff()">SQLOFF()</A>                  <A HREF="#sqlon()">SQLON()</A>                   <A HREF="#sqlping()">SQLPING()</A>
-<A HREF="#sqrt()">SQRT()</A>                    <A HREF="#squish()">SQUISH()</A>                  <A HREF="#squish()">SQUISH()</A>
-<A HREF="#stack">STACK</A>                     <A HREF="#startsecs()">STARTSECS()</A>               <A HREF="#starttime()">STARTTIME()</A>
-<A HREF="#stats()">STATS()</A>                   <A HREF="#step()">STEP()</A>                    <A HREF="#sticky">STICKY</A>
-<A HREF="#str()">STR()</A>                     <A HREF="#strallof()">STRALLOF()</A>                <A HREF="#strcat()">STRCAT()</A>
-<A HREF="#strdistance()">STRDISTANCE()</A>             <A HREF="#streq()">STREQ()</A>                   <A HREF="#streval()">STREVAL()</A>
-<A HREF="#strfirstof()">STRFIRSTOF()</A>              <A HREF="#strfunc()">STRFUNC()</A>                 <A HREF="#string functions">string functions</A>
-<A HREF="#string functions2">string functions2</A>         <A HREF="#string functions3">string functions3</A>         <A HREF="#strip()">STRIP()</A>
-<A HREF="#stripaccents()">STRIPACCENTS()</A>            <A HREF="#stripansi()">STRIPANSI()</A>               <A HREF="#strlen()">STRLEN()</A>
-<A HREF="#strlenraw()">STRLENRAW()</A>               <A HREF="#strlenvis()">STRLENVIS()</A>               <A HREF="#strmatch()">STRMATCH()</A>
-<A HREF="#strmath()">strmath()</A>                 <A HREF="#strtrunc()">STRTRUNC()</A>                <A HREF="#sub()">SUB()</A>
-<A HREF="#subj()">SUBJ()</A>                    <A HREF="#subnetmatch()">SUBNETMATCH()</A>             <A HREF="#substitutions">SUBSTITUTIONS</A>
-<A HREF="#substitutions2">substitutions2</A>            <A HREF="#success">SUCCESS</A>                   <A HREF="#superMINUSroyalty">SUPER-ROYALTY</A>
-<A HREF="#switch()">SWITCH()</A>                  <A HREF="#switchall()">SWITCHALL()</A>               <A HREF="#switches">SWITCHES</A>
-<A HREF="#t()">T()</A>                       <A HREF="#take">take</A>                      <A HREF="#take2">take2</A>
-<A HREF="#tan()">TAN()</A>                     <A HREF="#tanh()">TANH()</A>                    <A HREF="#taste">taste</A>
-<A HREF="#tel()">TEL()</A>                     <A HREF="#telok">TELOK</A>                     <A HREF="#temple">TEMPLE</A>
-<A HREF="#terse">TERSE</A>                     <A HREF="#thing">THING</A>                     <A HREF="#think">think</A>
-<A HREF="#throw">throw</A>                     <A HREF="#time functions">time functions</A>            <A HREF="#time()">TIME()</A>
-<A HREF="#timefmt advanced">TIMEFMT ADVANCED</A>          <A HREF="#timefmt advanced example">TIMEFMT ADVANCED EXAMPLE</A>  <A HREF="#timefmt advanced2">TIMEFMT ADVANCED2</A>
-<A HREF="#timefmt codelist">TIMEFMT CODELIST</A>          <A HREF="#timefmt codelist2">TIMEFMT CODELIST2</A>         <A HREF="#timefmt date">TIMEFMT DATE</A>
-<A HREF="#timefmt elapsed">TIMEFMT ELAPSED</A>           <A HREF="#timefmt escapes">TIMEFMT ESCAPES</A>           <A HREF="#timefmt examples">TIMEFMT EXAMPLES</A>
-<A HREF="#timefmt syntax">TIMEFMT SYNTAX</A>            <A HREF="#timefmt syntax2">TIMEFMT SYNTAX2</A>           <A HREF="#timefmt time">TIMEFMT TIME</A>
-<A HREF="#timefmt timezone">TIMEFMT TIMEZONE</A>          <A HREF="#timefmt()">TIMEFMT()</A>                 <A HREF="#timezone list">timezone list</A>
-<A HREF="#timezone list10">timezone list10</A>           <A HREF="#timezone list11">timezone list11</A>           <A HREF="#timezone list12">timezone list12</A>
-<A HREF="#timezone list2">timezone list2</A>            <A HREF="#timezone list3">timezone list3</A>            <A HREF="#timezone list4">timezone list4</A>
-<A HREF="#timezone list5">timezone list5</A>            <A HREF="#timezone list6">timezone list6</A>            <A HREF="#timezone list7">timezone list7</A>
-<A HREF="#timezone list8">timezone list8</A>            <A HREF="#timezone list9">timezone list9</A>            <A HREF="#tobin()">TOBIN()</A>
-<A HREF="#todec()">TODEC()</A>                   <A HREF="#toggle list">TOGGLE LIST</A>               <A HREF="#toggle()">toggle()</A>
-<A HREF="#toggles">TOGGLES</A>                   <A HREF="#tohex()">TOHEX()</A>                   <A HREF="#tooct()">TOOCT()</A>
-<A HREF="#topics">topics</A>                    <A HREF="#totcmds()">TOTCMDS()</A>                 <A HREF="#totmatch()">TOTMATCH()</A>
+<A HREF="#sortlist()">SORTLIST()</A>                <A HREF="#sortlist2">SORTLIST2</A>                 <A HREF="#soundex()">SOUNDEX()</A>
+<A HREF="#soundex2">SOUNDEX2</A>                  <A HREF="#soundlike()">SOUNDLIKE()</A>               <A HREF="#soundslike()">SOUNDSLIKE()</A>
+<A HREF="#space()">SPACE()</A>                   <A HREF="#speak()">SPEAK()</A>                   <A HREF="#special characters">SPECIAL CHARACTERS</A>
+<A HREF="#speech_prefix">SPEECH_PREFIX</A>             <A HREF="#speech_suffix">SPEECH_SUFFIX</A>             <A HREF="#spellnum()">SPELLNUM()</A>
+<A HREF="#splice()">SPLICE()</A>                  <A HREF="#spoofing">SPOOFING</A>                  <A HREF="#sql">SQL</A>
+<A HREF="#sql()">SQL()</A>                     <A HREF="#sqlescape()">SQLESCAPE()</A>               <A HREF="#sqlite_query()">SQLITE_QUERY()</A>
+<A HREF="#sqlite_query2">SQLITE_QUERY2</A>             <A HREF="#sqloff()">SQLOFF()</A>                  <A HREF="#sqlon()">SQLON()</A>
+<A HREF="#sqlping()">SQLPING()</A>                 <A HREF="#sqrt()">SQRT()</A>                    <A HREF="#squish()">SQUISH()</A>
+<A HREF="#squish()">SQUISH()</A>                  <A HREF="#stack">STACK</A>                     <A HREF="#startsecs()">STARTSECS()</A>
+<A HREF="#starttime()">STARTTIME()</A>               <A HREF="#stats()">STATS()</A>                   <A HREF="#stderr()">STDERR()</A>
+<A HREF="#step()">STEP()</A>                    <A HREF="#sticky">STICKY</A>                    <A HREF="#str()">STR()</A>
+<A HREF="#strallof()">STRALLOF()</A>                <A HREF="#strcat()">STRCAT()</A>                  <A HREF="#strdistance()">STRDISTANCE()</A>
+<A HREF="#streq()">STREQ()</A>                   <A HREF="#streval()">STREVAL()</A>                 <A HREF="#strfirstof()">STRFIRSTOF()</A>
+<A HREF="#strfunc()">STRFUNC()</A>                 <A HREF="#string functions">string functions</A>          <A HREF="#string functions2">string functions2</A>
+<A HREF="#string functions3">string functions3</A>         <A HREF="#strip()">STRIP()</A>                   <A HREF="#stripaccents()">STRIPACCENTS()</A>
+<A HREF="#stripansi()">STRIPANSI()</A>               <A HREF="#strlen()">STRLEN()</A>                  <A HREF="#strlenraw()">STRLENRAW()</A>
+<A HREF="#strlenvis()">STRLENVIS()</A>               <A HREF="#strmatch()">STRMATCH()</A>                <A HREF="#strmath()">strmath()</A>
+<A HREF="#strmath2">strmath2</A>                  <A HREF="#strtrunc()">STRTRUNC()</A>                <A HREF="#sub()">SUB()</A>
+<A HREF="#subeval()">SUBEVAL()</A>                 <A HREF="#subj()">SUBJ()</A>                    <A HREF="#subnetmatch()">SUBNETMATCH()</A>
+<A HREF="#substitutions">SUBSTITUTIONS</A>             <A HREF="#substitutions2">substitutions2</A>            <A HREF="#success">SUCCESS</A>
+<A HREF="#superMINUSroyalty">SUPER-ROYALTY</A>             <A HREF="#switch()">SWITCH()</A>                  <A HREF="#switchall()">SWITCHALL()</A>
+<A HREF="#switches">SWITCHES</A>                  <A HREF="#t()">T()</A>                       <A HREF="#tag()">TAG()</A>
+<A HREF="#take">take</A>                      <A HREF="#take2">take2</A>                     <A HREF="#tan()">TAN()</A>
+<A HREF="#tanh()">TANH()</A>                    <A HREF="#taste">taste</A>                     <A HREF="#tel()">TEL()</A>
+<A HREF="#telok">TELOK</A>                     <A HREF="#template()">TEMPLATE()</A>                <A HREF="#temple">TEMPLE</A>
+<A HREF="#terse">TERSE</A>                     <A HREF="#testlock()">TESTLOCK()</A>                <A HREF="#thing">THING</A>
+<A HREF="#think">think</A>                     <A HREF="#throw">throw</A>                     <A HREF="#time functions">time functions</A>
+<A HREF="#time()">TIME()</A>                    <A HREF="#timefmt advanced">TIMEFMT ADVANCED</A>          <A HREF="#timefmt advanced example">TIMEFMT ADVANCED EXAMPLE</A>
+<A HREF="#timefmt advanced2">TIMEFMT ADVANCED2</A>         <A HREF="#timefmt codelist">TIMEFMT CODELIST</A>          <A HREF="#timefmt codelist2">TIMEFMT CODELIST2</A>
+<A HREF="#timefmt date">TIMEFMT DATE</A>              <A HREF="#timefmt elapsed">TIMEFMT ELAPSED</A>           <A HREF="#timefmt escapes">TIMEFMT ESCAPES</A>
+<A HREF="#timefmt examples">TIMEFMT EXAMPLES</A>          <A HREF="#timefmt syntax">TIMEFMT SYNTAX</A>            <A HREF="#timefmt syntax2">TIMEFMT SYNTAX2</A>
+<A HREF="#timefmt time">TIMEFMT TIME</A>              <A HREF="#timefmt timezone">TIMEFMT TIMEZONE</A>          <A HREF="#timefmt()">TIMEFMT()</A>
+<A HREF="#timezone list">timezone list</A>             <A HREF="#timezone list10">timezone list10</A>           <A HREF="#timezone list11">timezone list11</A>
+<A HREF="#timezone list12">timezone list12</A>           <A HREF="#timezone list2">timezone list2</A>            <A HREF="#timezone list3">timezone list3</A>
+<A HREF="#timezone list4">timezone list4</A>            <A HREF="#timezone list5">timezone list5</A>            <A HREF="#timezone list6">timezone list6</A>
+<A HREF="#timezone list7">timezone list7</A>            <A HREF="#timezone list8">timezone list8</A>            <A HREF="#timezone list9">timezone list9</A>
+<A HREF="#tobin()">TOBIN()</A>                   <A HREF="#todec()">TODEC()</A>                   <A HREF="#toggle list">TOGGLE LIST</A>
+<A HREF="#toggle()">toggle()</A>                  <A HREF="#toggles">TOGGLES</A>                   <A HREF="#tohex()">TOHEX()</A>
+<A HREF="#tooct()">TOOCT()</A>                   <A HREF="#topics">topics</A>                    <A HREF="#totcmds()">TOTCMDS()</A>
+<A HREF="#totems()">TOTEMS()</A>                  <A HREF="#totemset()">TOTEMSET()</A>                <A HREF="#totmatch()">TOTMATCH()</A>
 <A HREF="#totmember()">TOTMEMBER()</A>               <A HREF="#totpos()">TOTPOS()</A>                  <A HREF="#totwildmatch()">totwildmatch()</A>
 <A HREF="#touch">touch</A>                     <A HREF="#tr()">TR()</A>                      <A HREF="#trace">TRACE</A>
-<A HREF="#trace()">TRACE()</A>                   <A HREF="#trace2">trace2</A>                    <A HREF="#trace_grep">TRACE_GREP</A>
-<A HREF="#train">train</A>                     <A HREF="#translate()">TRANSLATE()</A>               <A HREF="#transparent">TRANSPARENT</A>
-<A HREF="#trigonometry functions">trigonometry functions</A>    <A HREF="#trim()">TRIM()</A>                    <A HREF="#trunc()">TRUNC()</A>
+<A HREF="#trace()">TRACE()</A>                   <A HREF="#trace2">trace2</A>                    <A HREF="#trace_color">TRACE_COLOR</A>
+<A HREF="#trace_grep">TRACE_GREP</A>                <A HREF="#tracetab">TRACETAB</A>                  <A HREF="#train">train</A>
+<A HREF="#translate()">TRANSLATE()</A>               <A HREF="#transparent">TRANSPARENT</A>               <A HREF="#trigonometry functions">trigonometry functions</A>
+<A HREF="#trim()">TRIM()</A>                    <A HREF="#trreverse()">TRREVERSE()</A>               <A HREF="#trunc()">TRUNC()</A>
 <A HREF="#txlevel()">TXLEVEL()</A>                 <A HREF="#type()">type()</A>                    <A HREF="#u()">U()</A>
 <A HREF="#u2()">U2()</A>                      <A HREF="#u2default()">u2default()</A>               <A HREF="#u2ldefault()">u2ldefault()</A>
 <A HREF="#u2local()">U2LOCAL()</A>                 <A HREF="#u2local2">U2LOCAL2</A>                  <A HREF="#ucstr()">UCSTR()</A>
 <A HREF="#udefault()">udefault()</A>                <A HREF="#ueval()">UEVAL()</A>                   <A HREF="#uldefault()">uldefault()</A>
 <A HREF="#ulocal()">ULOCAL()</A>                  <A HREF="#ulocal2">ULOCAL2</A>                   <A HREF="#unesclist()">UNESCLIST()</A>
-<A HREF="#unfindable">UNFINDABLE</A>                <A HREF="#unpack()">UNPACK()</A>                  <A HREF="#use">use</A>
-<A HREF="#useful">USEFUL</A>                    <A HREF="#user attributes">USER ATTRIBUTES</A>           <A HREF="#userlocks">userlocks</A>
+<A HREF="#unfindable">UNFINDABLE</A>                <A HREF="#unicode support">UNICODE SUPPORT</A>           <A HREF="#unpack()">UNPACK()</A>
+<A HREF="#use">use</A>                       <A HREF="#useful">USEFUL</A>                    <A HREF="#user attributes">USER ATTRIBUTES</A>
+<A HREF="#userlocks">userlocks</A>                 <A HREF="#utf8 support">UTF8 SUPPORT</A>              <A HREF="#utf8 toggle">UTF8 TOGGLE</A>
 <A HREF="#v()">V()</A>                       <A HREF="#vadd()">VADD()</A>                    <A HREF="#valid()">VALID()</A>
 <A HREF="#vanilla_errors toggle">VANILLA_ERRORS TOGGLE</A>     <A HREF="#variable exits">VARIABLE EXITS</A>            <A HREF="#variable toggle">VARIABLE TOGGLE</A>
 <A HREF="#vatovz">VATOVZ</A>                    <A HREF="#vattrcnt()">VATTRCNT()</A>                <A HREF="#vcross()">VCROSS()</A>
@@ -490,7 +568,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#vsub()">VSUB()</A>                    <A HREF="#vunit()">VUNIT()</A>                   <A HREF="#wanderer">wanderer</A>
 <A HREF="#where()">WHERE()</A>                   <A HREF="#while()">WHILE()</A>                   <A HREF="#while2">WHILE2</A>
 <A HREF="#whisper">whisper</A>                   <A HREF="#who">who</A>                       <A HREF="#wielded">wielded</A>
-<A HREF="#wildmatch()">wildmatch()</A>               <A HREF="#wipe()">WIPE()</A>                    <A HREF="#wizards">WIZARDS</A>
+<A HREF="#wildcards">WILDCARDS</A>                 <A HREF="#wildcards2">WILDCARDS2</A>                <A HREF="#wildmatch()">wildmatch()</A>
+<A HREF="#wipe()">WIPE()</A>                    <A HREF="#wizard attributes">WIZARD ATTRIBUTES</A>         <A HREF="#wizards">WIZARDS</A>
 <A HREF="#wordpos()">wordpos()</A>                 <A HREF="#words()">WORDS()</A>                   <A HREF="#worn">worn</A>
 <A HREF="#wrap()">WRAP()</A>                    <A HREF="#wrap2">WRAP2</A>                     <A HREF="#wrapcolumns()">WRAPCOLUMNS()</A>
 <A HREF="#wrapcolumns2">WRAPCOLUMNS2</A>              <A HREF="#wrapcolumns3">WRAPCOLUMNS3</A>              <A HREF="#writable()">WRITABLE()</A>
@@ -504,14 +583,32 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#zfun2local2">ZFUN2LOCAL2</A>               <A HREF="#zfundefault()">zfundefault()</A>             <A HREF="#zfuneval()">ZFUNEVAL()</A>
 <A HREF="#zfunldefault()">zfunldefault()</A>            <A HREF="#zfunlocal()">ZFUNLOCAL()</A>               <A HREF="#zfunlocal2">ZFUNLOCAL2</A>
 <A HREF="#zone functions">zone functions</A>            <A HREF="#zone_autoadd toggle">ZONE_AUTOADD TOGGLE</A>       <A HREF="#zone_autoaddall toggle">ZONE_AUTOADDALL TOGGLE</A>
-<A HREF="#zonecmdchk">ZONECMDCHK</A>                <A HREF="#zonecontents">ZONECONTENTS</A>              <A HREF="#zonemaster">ZONEMASTER</A>
-<A HREF="#zoneparent ">ZONEPARENT </A>               <A HREF="#zones">zones</A>                     <A HREF="#zones2">zones2</A>
-<A HREF="#zwho()">ZWHO()</A>                    <HR><A NAME="QUOTE"><H3>&quot;</H3></A><PRE>
+<A HREF="#zonecmd()">ZONECMD()</A>                 <A HREF="#zonecmd2 ">ZONECMD2 </A>                 <A HREF="#zonecmdchk">ZONECMDCHK</A>
+<A HREF="#zonecontents">ZONECONTENTS</A>              <A HREF="#zonemaster">ZONEMASTER</A>                <A HREF="#zoneparent ">ZONEPARENT </A>
+<A HREF="#zones">zones</A>                     <A HREF="#zones2">zones2</A>                    <A HREF="#zwho()">ZWHO()</A>
+<HR><A NAME="QUOTE"><H3>&quot;</H3></A><PRE>
   Command: &quot;&lt;message&gt;
-  Says &lt;message&gt; out loud to everyone in your current room.  Example:
-  the command '&quot;Where is the movie theater?' produces
-  '&lt;yourname&gt; says &quot;Where is the movie theater&gt;&quot;'.  Note that the closing
-  double quote is automatically added.
+  
+  Says &lt;message&gt; out loud to everyone in your current room.  
+  
+  You may use two special attributes for pre and post processing of any
+  says you receive.  These attributes will have substitutions evaluated
+  but will not evaluate functions.  If these attributes are set NO_COMMAND
+  then they will not be processed.
+    SPEECH_PREFIX  -- Contents will be evaluated before the say/pose.
+    SPEECH_SUFFIX  -- Contents will be evaluated after the say/pose.
+  
+  Both of these attributes handle three arguments.  These are:
+    %0 - The original say/pose that triggered the attribute.
+    %1 - The date in the form MM/DD/YYYY
+    %2 - The time in the form HH:MM:SS
+    %3 - The dbref# of the player issuing the say/pose/emit (#-1 if spoofed)
+  
+  Example: (assuming your name is Bob)
+   &gt; &quot;Where is the movie theater?
+   Bob says &quot;Where is the movie theater&gt;&quot;  
+  
+  Note that the closing double quote is automatically added.
   
   See Also: page, pose, say, :, &quot;, @saystring
   
@@ -521,12 +618,16 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="#"><H3>#</H3></A><PRE>
   Command: #&lt;number&gt; &lt;command&gt;
-  Forces the object whose database number is &lt;number&gt; to perform &lt;command&gt;.
-  Example: '#1033 move north' forces object #1033 to go north (assuming that
-  you control it).  The same restrictions that apply to @force also apply to
-  this command.
   
-  See Also: @force
+  Forces the object whose database number is &lt;number&gt; to perform &lt;command&gt;.
+  
+  Example: 
+    &gt; #1033 move north 
+
+  This forces object #1033 to go north (assuming that you control it).  
+  The same restrictions that apply to @force also apply to this command.
+  
+  See Also: @force, @sudo
   
 </PRE>
 <A HREF="#QUOTE">[PREV]</A>
@@ -562,7 +663,13 @@ Generated: Wed Jan 13 04:15:48 2016
   *NOT* working on players.  Talk to your local administration to see if 
   this option has been enabled or disabled.
   
-  See Also: ARBITRARY COMMANDS
+  For normal globbing command syntax, please refer to:
+                    'help ARBITRARY COMMANDS'
+  
+  For regular expression (regex) command syntax, please refer to:
+                    'help REGEXPS'
+  
+  See Also: ^-listens, lcmds(), lattr()
   
 </PRE>
 <A HREF="##lambda">[PREV]</A>
@@ -578,27 +685,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -609,6 +726,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="%BANG"><H3>%!</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -661,6 +780,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="%#"><H3>%#</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -720,27 +841,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -751,6 +882,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="%PLUS"><H3>%+</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -810,27 +943,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -848,27 +991,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -886,27 +1039,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -924,27 +1087,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -962,27 +1135,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1000,27 +1183,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1038,27 +1231,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1076,27 +1279,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1114,27 +1327,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1152,27 +1375,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1190,37 +1423,49 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
 </PRE>
 <A HREF="#%8">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
-<A HREF="#%LT">[NEXT]</A>
+<A HREF="#%:">[NEXT]</A>
 <BR>
-<HR><A NAME="%LT"><H3>%&lt;</H3></A><PRE>
+<HR><A NAME="%:"><H3>%:</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -1269,10 +1514,66 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#%9">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#%LT">[NEXT]</A>
+<BR>
+<HR><A NAME="%LT"><H3>%&lt;</H3></A><PRE>
+    %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
+              displayed or the action list to be run.
+    %l      = Database number of the location of the object that caused the
+              message to be displayed or the action list to be run.
+    %!      = Database number of the object holding the message or running
+              the action list.
+    %@      = Database number of the object immediately calling %! (Caller).
+              This number starts as the same as %#, but can be affected by
+              u()-type functions, zones, and @function.
+    %+      = Show the total arguments a function received.
+    %?      = Show current function invocation as well as current nest levels.
+    %c      = ANSI substitution or Last Command Executed.
+    %x      = ANSI substitution or Last Command Executed.
+    %_      = The TRACE breakpoint marker.  See 'help %_' for more.
+    %m      = ANSI substitution or Last Command Executed.
+
+              The functionality of above subs depends on compile options:
+
+            * ANSI substitution: It takes the next character as the ansi
+              sequence and continues with that sequence till the next one
+              or end of the line.  You may also specify 0x## (ie: 0x20)
+              to use extended 256 colors.
+
+            * Last Command Executed: The substitution contains the whole,
+              unevaluated code of the last command executed.
+
+    %f      = Specify template for accent handler for strings.  To see a list
+              of templates, see help on the accent() function.
+    %&lt;      = Used for UNICODE (ASCII 160 through 255).  Syntax: %&lt;###&gt;
+              This requires the ACCENT toggle to utilize.
+  
+  Note:  The functionality of '%c' and '%x' may be switched.  Check
+         @list options to check.
+  
+  Note:  The functionality of '%f' is only useable if ZENTY_ANSI is enabled.
+         The functionality of '%&lt;' is only useable if ZENTY_ANSI is enabled.
+         The functionality of '%&lt;' requires the ACCENTS toggle.
+   
+  If the letter following the % is capitalized, the first letter of the
+  result of the substitution is also capitalized.
+   
+  Note: %&lt;whatever&gt; is equivalent to [v(&lt;whatever&gt;)], but is more efficient.
+        This _ONLY_ works for @va to @vz attributes currently.  Sorry.
+  
+  See Also: GENDER, V(), SHIFT(), ACCENT()
+  
+</PRE>
+<A HREF="#%:">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#%?">[NEXT]</A>
 <BR>
 <HR><A NAME="%?"><H3>%?</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -1326,6 +1627,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="%@"><H3>%@</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
               displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
+              displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
     %!      = Database number of the object holding the message or running
@@ -1377,36 +1680,74 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="%_"><H3>%_</H3></A><PRE>
   Topic: SUBSTITUTIONS
-  Syntax: %_&lt;label&gt;  -- enables debugging if &lt;label&gt; is in TRACE attribute.
-          %_&lt;-label&gt; -- disables debugging for &lt;label&gt;
-          %_&lt;off&gt;    -- disables all debugging
+  Syntax: %_&lt;label&gt;      -- enables debugging if &lt;label&gt; is in TRACE attribute.
+          %_&lt;-label&gt;     -- disables debugging for last named &lt;label&gt;
+          %_&lt;-&gt;          -- disables debugging for last defined label
+          %_&lt;off&gt;        -- disables all debugging labels
+          %_&lt;!list&gt;      -- List current stack, in-use stack, and all labels.
+          %_&lt;!shortlist&gt; -- List current stack and in-use stack.
+  
+  You can have a total of 1000 label declarations total for processing per
+  command queue.
+  
+  The @label command can be used to integrate labels into attributes.
   
   The %_ substitution is a special substitution as it allows you to enbed
   breakpoints into code to toggle on and off debugging on the fly dynamically.
   This is handled by the enactors 'TRACE' attribute that houses the marker
   that you specify for the substitutions.  The marker can be any string.
   
-  You use - for the label to turn off debugging for that particular debug
-  marker.  For stacked debugging this will decrement the debug stack count.
+  You use - as a prefix for the label to turn off debugging for that 
+  particular debug marker.  For stacked debugging this will remove the
+  last defined label from the stack.  If you use the same label twice,
+  it will remove the newest defined first working backwards.
+  
+  If you specify a label of just '-' it removes the last defined label.
    
   Using the &lt;label&gt; adds to the debug stack and using &lt;-label&gt; reduces one
-  from the debug stack.  This allows you to essentially nest debugging
-  breakpoints within code and only enable/disable them when you set
-  the specified label in your TRACE value.  For instance, &amp;TRACE me=123
+  from the debug stack by removing the latest named label.  This allows you 
+  to essentially nest debugging breakpoints within code and only 
+  enable/disable them when you set the specified label in your TRACE value.  
+  For instance, &amp;TRACE object=123
+  
+  The &lt;label&gt; needs to be always in lower case.
   
   Note: This has absolutely no impact on the TRACE flag and uses another
   method to keep track of how it's tracing information.  You can use
   this in addition to the TRACE flag if you so wish.
   
-  You may use the attribute TRACE_COLOR to set a standard color for your
-  labels.   For instance, &amp;TRACE_COLOR me=+purple.  You may specify colors
-  by label as &amp;TRACE_COLOR_&lt;label&gt; me=+orange.  Like &amp;TRACE_COLOR_123.
-  This will fall back on 'TRACE_COLOR' if the by label isn't found.
+  { see 'help %_2' to continue }
+
+</PRE>
+<A HREF="#%@">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#%_2">[NEXT]</A>
+<BR>
+<HR><A NAME="%_2"><H3>%_2</H3></A><PRE>
+  Topic: SUBSTITUTIONS (CONTINUED)
+  Syntax: %_&lt;label&gt;      -- enables debugging if &lt;label&gt; is in TRACE attribute.
+          %_&lt;-label&gt;     -- disables debugging for last named &lt;label&gt;
+          %_&lt;-&gt;          -- disables debugging for last defined label
+          %_&lt;off&gt;        -- disables all debugging
+          %_&lt;!list&gt;      -- List current stack, in-use stack, and all labels.
+          %_&lt;!shortlist&gt; -- List current stack and in-use stack.
   
-  You may specify a TRACE_GREP attibute on yourself (&amp;TRACE_GREP me=&lt;string&gt;)
-  if you wish to have a specific piece of code in trace output which matches
-  the trace output return in red the match.  If the TRACE_GREP attribute
-  is attribute-set REGEXP, it will take the string as a regexp match.
+  You may use the attribute TRACE_COLOR to set a standard color for your
+  labels.   For instance, &amp;TRACE_COLOR object=+purple.  You may specify 
+  colors by label as &amp;TRACE_COLOR_&lt;label&gt; object=+orange.  Like 
+  &amp;TRACE_COLOR_123.  This will fall back on 'TRACE_COLOR' if the by 
+  label isn't found.
+  
+  You may specify a TRACE_GREP attibute on the enactor 
+  (&amp;TRACE_GREP object=&lt;string&gt;) if you wish to have a specific piece 
+  of code in trace output which matches the trace output return in red 
+  the match.  If the TRACE_GREP attribute is attribute-set REGEXP, 
+  it will take the string as a regexp match.
+  
+  Keep in mind, the various &amp;TRACE attributes need to be on the executor,
+  not the object enacting the command.  It will behave like the TRACE flag.
+  So all attributes (like &amp;TRACE) need to be on the target that you 
+  have the labels on.
    
   Examples:
     &gt; &amp;TRACE me=123
@@ -1420,13 +1761,64 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say Debugging: [add(1,1)]%_&lt;123&gt;[add(2,2)]%_&lt;off&gt;[add(3,3)]
     YourPlayerName(#12345) [123]} 'add(2,2)' -&gt; '4'
     You say &quot;Debugging: 246&quot;
+    &gt; say Debugging: [add(1,1)]%_&lt;123&gt;[add(2,2)]%_&lt;-&gt;[add(3,3)]
+    YourPlayerName(#12345) [123]} 'add(2,2)' -&gt; '4'
+    You say &quot;Debugging: 246&quot;
   
-  In the last exampole, the 123 inside the []'s would have been orange.
+  In the last two examples, the 123 inside the []'s would have been orange.
   
-  See Also: SUBSTITUTIONS, TRACE, trace()
+  See 'help %_vars' for variables used with trace label debugging.
+  
+  See Also: SUBSTITUTIONS, TRACE, trace(), @label, ruler()
   
 </PRE>
-<A HREF="#%@">[PREV]</A>
+<A HREF="#%_">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#%_vars">[NEXT]</A>
+<BR>
+<HR><A NAME="%_vars"><H3>%_vars</H3></A><PRE>
+  Topic: SUBSTITUTIONS (CONTINUED)
+  Syntax: %_&lt;label&gt;      -- enables debugging if &lt;label&gt; is in TRACE attribute.
+          %_&lt;-label&gt;     -- disables debugging for last named &lt;label&gt;
+          %_&lt;-&gt;          -- disables debugging for last defined label
+          %_&lt;off&gt;        -- disables all debugging
+          %_&lt;!list&gt;      -- List current stack, in-use stack, and all labels.
+          %_&lt;!shortlist&gt; -- List current stack and in-use stack.
+  
+  The following special variables are used for %_ label debugging.
+  
+  TRACE            -- This is the main controller for labels.  When the
+                      object running code has a label matching one
+                      in this attribute, it will run debugging code
+                      for that label until turned off.   This should always
+                      have labels in lower case.
+  
+  TRACE_GREP       -- * Without the REGEXP attribute flag, it will use
+                        standard direct string matching and hilight red
+                        any match in your trace output.  Again, this must
+                        be set on the object running code.
+                      * With the REGEXP attribute flag, it uses enhanced
+                        regular expression matching to hilite red any
+                        matching pattern.
+  
+  TRACE_COLOR      -- This is the global generic color code that you wish
+                      any label to have.  If there's not a label specific
+                      color, this is what it will choose.  If no color
+                      is selected, it just hilights it.  Again, this must
+                      be set on the object running code.
+  
+  TRACE_COLOR_&lt;L&gt;  -- Where '&lt;L&gt;' is the name of the label.  For example
+                      if your label was 'bob' the attribute name would be
+                      'TRACE_COLOR_BOB'.  This will set a specific color
+                      for the given label to use.  This will have priority
+                      over the global TRACE_COLOR definition.
+  
+  TRACETAB         -- Specify how many spaces to indent on each parse
+  
+  See Also: SUBSTITUTIONS, TRACE, trace(), @label, ruler()
+  
+</PRE>
+<A HREF="#%_2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#%a">[NEXT]</A>
 <BR>
@@ -1439,32 +1831,42 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
 </PRE>
-<A HREF="#%_">[PREV]</A>
+<A HREF="#%_vars">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#%b">[NEXT]</A>
 <BR>
@@ -1477,27 +1879,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1508,6 +1920,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="%c"><H3>%c</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -1567,27 +1981,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1598,6 +2022,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="%f"><H3>%f</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -1657,27 +2083,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1695,27 +2131,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1726,6 +2172,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="%l"><H3>%l</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -1778,6 +2226,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="%m"><H3>%m</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -1837,27 +2287,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1875,27 +2335,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1913,27 +2383,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -1951,32 +2431,90 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
 </PRE>
 <A HREF="#%p">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#%qLT">[NEXT]</A>
+<BR>
+<HR><A NAME="%qLT"><H3>%q&lt;</H3></A><PRE>
+  Topic: SUBSTITUTIONS
+ 
+  All messages may contain %-substitutions, which evaluate to gender-specific
+  pronouns if the player's gender is set or to other useful information.
+  Information returned is based on the player that caused the message to be
+  displayed, not the object that stored the message or which is running the
+  action list.  The substitutions available are:
+ 
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
+  
+{ 'help substitutions2' for more }
+
+</PRE>
+<A HREF="#%q">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#%r">[NEXT]</A>
 <BR>
@@ -1989,32 +2527,42 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
 </PRE>
-<A HREF="#%q">[PREV]</A>
+<A HREF="#%qLT">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#%s">[NEXT]</A>
 <BR>
@@ -2027,27 +2575,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -2065,27 +2623,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -2103,27 +2671,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -2141,27 +2719,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -2172,6 +2760,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="%x"><H3>%x</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -2253,6 +2843,154 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#%x">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#AMPERmailfilter">[NEXT]</A>
+<BR>
+<HR><A NAME="AMPERmailfilter"><H3>&amp;MAILFILTER</H3></A><PRE>
+  Attribute: &amp;MAILFILTER
+  
+  This attribute, when set on a player, will allow that player individual
+  control of where the mail will go.  This allows the player to redirect
+  incoming mail into pre-existing folders.  The following are passed:
+              %0  - the dbref# of the player (or #-1 if anonymous)
+              %1  - the subject of the message
+              %2  - the body of the message
+              %3  - the date/time of the message
+  Examples:
+    &gt; folder/list
+      Mail: You have the following folders -&gt;
+      Incoming Testing Junk
+    &gt; &amp;MAILFILTER me=[switch(%0,#123,Testing,#234,Junk)]
+      Set.
+    &gt; think [num(me)] [name(me)]
+      #123 Yourself
+    &gt; mail me=A Test//A Test
+      Mail: You have new mail from -&gt; Yourself [Subj: A Test]
+      Mail: Auto-Moved to folder -&gt; Testing
+      Mail: Message sent to -&gt; Yourself
+    &gt; (recieving mail from Bob, dbref #999)
+      Mail: You have new mail from -&gt; Bob [Subj: Hey!]
+    &gt; (recieving mail from Tony, dbref #234)
+      Mail: You have new mail from -&gt; Tony [Subj: You smell]
+      Mail: Auto-Moved to folder -&gt; Junk
+  
+  See Also: @mailsig, &amp;mailnotify
+ 
+</PRE>
+<A HREF="#AMPER">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#AMPERmailnotify">[NEXT]</A>
+<BR>
+<HR><A NAME="AMPERmailnotify"><H3>&amp;MAILNOTIFY</H3></A><PRE>
+  Attribute: &amp;MAILNOTIFY
+  
+  This attribute, when set on a player, will send a message to the person
+  mailing them depending on the evaluated text in the attribute.
+  
+  If the message evaluates to an empty string, no message is sent.
+  
+  The following arguments are passed for evaluation:
+              %0  - the dbref# of the player (or #-1 if anonymous)
+              %1  - the subject of the message
+              %2  - the body of the message
+              %3  - the date/time of the message
+  
+  Examples:
+    &gt; &amp;mailnotify me=Hi, [name(%0)]!  You sent me mail!
+    Set.
+    &gt; think [name(me)]
+    Bob
+    &gt; mail me=Test!
+    Hi, Bob!  You sent me mail!
+    Mail: You have new mail from -&gt; Bob
+    Mail: Message sent to -&gt; Bob
+    Mail: Done
+    &gt; think [name(me)]
+    Betty
+    &gt; mail bob=Test!
+    Hi, Betty! You sent me mail!
+    Mail: Message sent to -&gt; Bob
+    Mail: Done
+  
+  See Also: @mailsig, &amp;mailfilter
+
+</PRE>
+<A HREF="#AMPERmailfilter">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#AMPERoutpageformat">[NEXT]</A>
+<BR>
+<HR><A NAME="AMPERoutpageformat"><H3>&amp;OUTPAGEFORMAT</H3></A><PRE>
+  Attribute: &amp;outpageformat &lt;object&gt;[=&lt;message&gt;]
+             &amp;pageformat &lt;object&gt;[=&lt;message&gt;]
+  
+  &amp;PAGEFORMAT changes the message seen by &lt;object&gt; when it receives a page.
+  &amp;OUTPAGEFORMAT sets the message seen by &lt;object&gt; when it sends a page.
+  
+  %0 - will be set to the page message (not including :, ; or &quot;).
+  %1 - will be set to ':' ';' or '&quot;' for pose, semipose and normal page, 
+       reespectively.
+  %2 - will be set to the alias of the pager, if any.
+  %3 - will be a space-separated list of recipient dbrefs.
+  %4 - will be set to the default message (based on pageformat/outpageformat).
+  
+  { See 'help &amp;pageformat2' for examples. }
+
+</PRE>
+<A HREF="#AMPERmailnotify">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#AMPERpageformat">[NEXT]</A>
+<BR>
+<HR><A NAME="AMPERpageformat"><H3>&amp;PAGEFORMAT</H3></A><PRE>
+  Attribute: &amp;outpageformat &lt;object&gt;[=&lt;message&gt;]
+             &amp;pageformat &lt;object&gt;[=&lt;message&gt;]
+  
+  &amp;PAGEFORMAT changes the message seen by &lt;object&gt; when it receives a page.
+  &amp;OUTPAGEFORMAT sets the message seen by &lt;object&gt; when it sends a page.
+  
+  %0 - will be set to the page message (not including :, ; or &quot;).
+  %1 - will be set to ':' ';' or '&quot;' for pose, semipose and normal page, 
+       reespectively.
+  %2 - will be set to the alias of the pager, if any.
+  %3 - will be a space-separated list of recipient dbrefs.
+  %4 - will be set to the default message (based on pageformat/outpageformat).
+  
+  { See 'help &amp;pageformat2' for examples. }
+
+</PRE>
+<A HREF="#AMPERoutpageformat">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#AMPERpageformat2">[NEXT]</A>
+<BR>
+<HR><A NAME="AMPERpageformat2"><H3>&amp;pageformat2</H3></A><PRE>
+  Attribute: &amp;outpageformat &lt;object&gt;[=&lt;message&gt;]    (CONTINUED)
+             &amp;pageformat &lt;object&gt;[=&lt;message&gt;]
+  
+  Examples:
+    &gt; &amp;pageformat me=\[[time()]\] %4
+    Set.
+    &gt; @outpageformat me=\[[time()]\] %4
+    Set.
+
+    (To obtain @toggle vpage behavior:)
+    &gt; &amp;pageformat me=[setq(0,%n[if(%2,%b(%2))],1,switch(%3,%!,,elist(iter(%3,
+                     name(##),%b,|),,|)))][switch(%1,&quot;,%q0 pages[if(%q1,%b%q1)]:
+                     %0,:,From afar[if(%q1,%b(to %q1))]\, %q0 %0,
+                     From afar[if(%q1, %b(to %q1))]\, %q0%0)]
+    Set.
+
+    (To obtain no @toggle vpage behavior:)
+    &gt; &amp;pageformat me=[setq(1,switch(%3,%!,,elist(iter(%3,name(##),%b,|),,|)))]
+                     [switch(%1,&quot;,%n pages[if(%q1,%b%q1)]: %0,:,From 
+                     afar[if(%q1,%b(to %q1))]\, %n %0,From 
+                     afar[if(%q1,%b(to %q1))]\, %n%0)]
+    Set.
+  
+    Both examples above will return how 'page' would normally show.
+  
+  See Also: page, lpage, rpage, mrpage
+
+</PRE>
+<A HREF="#AMPERpageformat">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#PLUSchannel">[NEXT]</A>
 <BR>
 <HR><A NAME="PLUSchannel"><H3>+channel</H3></A><PRE>
@@ -2273,7 +3011,7 @@ Generated: Wed Jan 13 04:15:48 2016
   (help channel2 to continue)
 
 </PRE>
-<A HREF="#AMPER">[PREV]</A>
+<A HREF="#AMPERpageformat2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#PLUSchannel2">[NEXT]</A>
 <BR>
@@ -2307,8 +3045,12 @@ Generated: Wed Jan 13 04:15:48 2016
   'help' does, but for +help.  This is intended for TINY/MUX compatibility
   and is disabled by default.
   
-  The /search switch works for +help as well.
+  The following switches work for +help:
+    /search -- allow wildcard patterning for searches (Eg: help/search *@mail*)
+    /query  -- allow detailed searching and return (Eg: help/query *@mail*)
   
+  See Also: help 
+
 </PRE>
 <A HREF="#PLUSchannel2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -2324,6 +3066,33 @@ Generated: Wed Jan 13 04:15:48 2016
   
 </PRE>
 <A HREF="#PLUShelp">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#MINUS">[NEXT]</A>
+<BR>
+<HR><A NAME="MINUS"><H3>-</H3></A><PRE>
+  Command: mail/write &lt;text&gt;
+           -&lt;text&gt;
+  
+  The '-' subcommand is used to continue lines of text after the initial
+  'mail/write' was used to start the mail message.  This is used in
+  juncture with sending, forwarding, or replying to mail using the
+  line editor.  This command will NOT be recognized as a valid command
+  if you did not use mail/write previous to it!
+  
+  Example:
+    &gt; -this is a line of text
+    Huh?  (Type 'help' for help.)
+    &gt; mail/write I forgot to start the message first!
+    Mail: Write message started (37/32758).
+    &gt; -this is a line of text
+    Mail: Write line 2 added (60/32758)
+    &gt; mail/write another line of text
+    Mail: Write line 3 added (81/32758)
+  
+  See Also: mail write cmdlist, mail write adding
+  
+</PRE>
+<A HREF="#PLUSuptime">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#1.0.0p0">[NEXT]</A>
 <BR>
@@ -2352,7 +3121,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * Memory leak in db engine [NYS]
   
 </PRE>
-<A HREF="#PLUSuptime">[PREV]</A>
+<A HREF="#MINUS">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#1.5.0p0">[NEXT]</A>
 <BR>
@@ -2754,7 +3523,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * uselock attrib flag checks matching ~&lt;attribute&gt; for uselock [ASH]
   * SPAMMONITOR flag check target for spam (60 cmds/sec) [ASH]
   * ZONEINHERIT allows zonemasters to have attribs inherited to children [ASH]
-  * muddb_name admin param for db names to seperate from 'mud_name' [ASH]
+  * muddb_name admin param for db names to separate from 'mud_name' [ASH]
   * global_error_obj evaluate the VA attribute on the object for huh? [ASH]
   * mail_autodeltime specifies when mail is globally purged (def 21 days) [ASH]
   * global_parent_room globally inherit attribs to room w/o @parent [ASH]
@@ -2779,7 +3548,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * @list user_attributes handle wildcard matching [ASH]
   * @list alloc shows better buffer stats [ASH]
   * better replace_token call for all ##/#@ subs [ASH]
-  * citer() has optional seperator [ASH]
+  * citer() has optional separator [ASH]
   * lwho() has argument to list just ports [ASH]
   * modified MONITOR site monitoring to show remote port [ASH]
   * sin(), tan(), etc modified for MUX compatibility [ASH]
@@ -2970,7 +3739,7 @@ Generated: Wed Jan 13 04:15:48 2016
   New Features
   ------------
   * fmod() for Penn compatibility [ASH]
-  * seperate .conf file for most commonly used params [AMB]
+  * separate .conf file for most commonly used params [AMB]
   * @admin roomlog_path to specify different path for LOGROOM [ASH]
   * new minimal_db imported [ASH]
   
@@ -3092,10 +3861,10 @@ Generated: Wed Jan 13 04:15:48 2016
   * localize() to localize registers from eval [ASH]
   * null() to snuff output of string [SEA]
   * ladd(), lsub(), lmul(), ldiv(), land(), lavg(), lmax(),
-  lmin(), lor(), lxor(), lnor(), lxnor(), ncomp(), streq(),
-  xcon(), inzone(), zemit(), zwho(), zfun(), zfun2(),
-  zfunlocal(), zfun2local(), zfundefault(), zfun2default(),
-  zfuneval(), zfunldefault(), zfunl2default() [SEA]
+    lmin(), lor(), lxor(), lnor(), lxnor(), ncomp(), streq(),
+    xcon(), inzone(), zemit(), zwho(), zfun(), zfun2(),
+    zfunlocal(), zfun2local(), zfundefault(), zfun2default(),
+    zfuneval(), zfunldefault(), zfunl2default() [SEA]
   * lastcreate(), while(), modifystamp(), createdstamp() [ASH]
   * @hide[/on/off] - For PENN compatibility [ASH]
   * @saystring define what is substituted instead of 'says' [ASH]
@@ -3178,7 +3947,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Changes
   -------
   * @prog aliased to @program [ASH]
-  * filter() now supports an output seperator [ASH]
+  * filter() now supports an output separator [ASH]
   * lnum() and lnum2() optionally return NULL if given a '0' [ASH]
   * mask() now takes '~' for adding 1's comp, '1' for 1's and '2' for 2's [ASH]
   * mailquick() takes 3rd argument for MUX mail() compatibility [ASH]
@@ -3190,7 +3959,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * @ansiname now allows raw ansi [ASH]
   * dig(), create(), open(), clone() all optionally return dbref#'s [ASH]
   * @list options now shows more (and valuable) information [ASH]
-  * @function/list now shows flags for privalaged/preserved functions [ASH]
+  * @function/list now shows flags for privileged/preserved functions [ASH]
   * mail/status and mail/read now show connected players [ASH]
   * mail/write and - now show how many characters you have written [ASH]
   * mail/forward and mail/reply now recognize the BRANDY_MAIL @toggle [ASH]
@@ -3325,7 +4094,7 @@ Generated: Wed Jan 13 04:15:48 2016
   -------
   * lnum()/lnum2() handles negative numbers [ASH]
   * NOMODIFY optionally set to immortal only [ASH]
-  * all vector functions recognize output seperator [ASH]
+  * all vector functions recognize output separator [ASH]
   * mail +justify, +insert, +edit, +editall handles line numbers [ASH]
   * dice has more arguments for offset values [ASH]
   * modified/created is examinable now [ASH]
@@ -3363,7 +4132,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * NO_PARSE attribute flag that stops /evaluation of %0-%9 in $commands [ASH]
   * SAFE attribute flag that stops modification of attribute [ASH]
   * SHOWFAILCMD show any matching failed $cmd uses the @ufail suite [ASH]
-  * MAIL_STRIPRETURN when combining lines uses spaces not carrage returns [ASH]
+  * MAIL_STRIPRETURN when combining lines uses spaces not carriage returns [ASH]
   * PENN_MAIL when sending mail, use PENN like style [ASH]
   * guest_namelist specifies a dynamic namelist for guests [ASH]
   * hackattr_nowiz defines if '_attr' is wiz only or follows normal rules [ASH]
@@ -3985,7 +4754,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * $Z in timefmt() would show negative values in &gt; 32 bit math [ASH]
   * case sensitivity was reversed for reswitch/reswitchi cases [ASH]
   * backward compatibility with v(#) was broke. [ASH]
-  * IDLE mis-aligned carrage return and line feeds [ASH]
+  * IDLE mis-aligned carriage return and line feeds [ASH]
   
 </PRE>
 <A HREF="#3.9.3p2">[PREV]</A>
@@ -4280,7 +5049,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * float_precision for floating point decimal precision (default 6) [ASH]
   * file_object parameter to specify dynamic override for connect.txt and 
     friends [ASH]
-  * extractword() is a multi-char delimeter/seperator/ansi-aware 
+  * extractword() is a multi-char delimeter/separator/ansi-aware 
     extract/delextract [ASH]
   * mwords() is a multi-char delimiter/ansi-ignore words [ASH]
   * @dbclean to purge unused attributes from the db [ASH]
@@ -4521,7 +5290,7 @@ Generated: Wed Jan 13 04:15:48 2016
     sub() now handle multiple arguments for Penn compatibility. [ASH]
   * For those who are used to Penn, 'DEBUG' is aliased to 'TRACE' [ASH]
   * textfile() takes optional arguments to sanitize output for use
-    in various coding including an output seperator [ASH]
+    in various coding including an output separator [ASH]
   * hilite topic headers for help (as requested by many) [ASH]
   * mysql more vigerously tries to keep stale connections active [ASH]
   * the build script more cleanly does dynamic building of Makefile [ASH]
@@ -4560,7 +5329,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * enhanced content searches for help [ASH]
   * @grep now handles /parent switch [ASH]
   * ! shown on @function and @lfunction if a flag permission exists [ASH]
-  * array() has optional output seperator [ASH]
+  * array() has optional output separator [ASH]
   * %q&lt;LABEL&gt; now also handles 0-9a-z registers [ASH]
   * first() and last() are now optionally ANSI-aware with 3rd arg [ASH]
   * @chownall now optionally allows a mix of specifying room, exit,
@@ -4623,6 +5392,42 @@ Generated: Wed Jan 13 04:15:48 2016
   * execscript() with matching sideeffect value and @power execscript to
     allow executing external script as a function with appropiate 
     safeguards for script name and arguments [ASH]
+  * penn_setq -- Penn compatibility option for labels with setq/setr. [ASH]
+  * customized connect screens so you may add custom commands that a player
+    can type at the connect screen. [ASH]
+  * object id's and objid()/%: for all features that'd handle %#. [ASH]
+  * isobjid() added. [ASH]
+  * zonecmd() added (side-effect of @zone) [ASH]
+  * VISIBLE options to lcon() and xcon() to check only visible items [ASH]
+  * searchobjid(), and searchngobjid() for objid results on searches [ASH]
+  * examine has /cluster switch for examining clusters [ASH]
+  * @zone has /replace and /list switches.  zonecmd() has similar [ASH]
+  * Startmush is much more optimized for flatfile loading if required [ASH]
+  * @newpassword optionally allows /des switch to enforce DES passwords [ASH]
+  * @admin delim_null param allows '@@' to be seen as an empty separator
+    for all arguments with an output separator [ASH]
+  * REQUIRE_TREES flag when set requires the flag method to set attribs
+    on the target that contain a tree character [ASH]
+  * function_max to cap a ceiling on @functions allowed (1000 default) [ASH]
+  * parent_follow @admin param (default to 1/yes) to allow control of target
+    to see entire parent chain [ASH]
+  * @list advbuffers to show filename/linenumber of the allocation [ASH]
+  * Added FORMATTING @power that when set on target allows %0-%3 to be
+    passed to @conformat, @exitformat, and @Nameformat [ASH]
+  * Added new 'minimal-DBs' directory in order to ship multiple different
+    minimal DBs. [AMB]
+  * Added new Amb-MinimalRhost DB to the 'minimal-DBs' directory. [AMB]
+  * Added /overwrite switch to @snapshot to overwrite existing files [ASH]
+  * Added /unall to @snapshot to unload a list of targets [ASH]
+  * invformat for inventory formatting [ASH]
+  * @lset to set permissions for locks [ASH]
+  * lset() added to mirror @lset but as a sideeffect [ASH]
+  * @label added to help integrate %_ labels into code [ASH]
+  * ruler() added to give a positional ruler for attribute content [ASH]
+  * &amp;pageformat and &amp;outpage format added [ASH]
+  * @admin param vattr_command allows you to make @commands for 
+    user-defined attributes (VATTRS) [ASH]
+  * @list vattrcmds to show attribute relationships to commands [ASH]
   
   Changes
   ------------
@@ -4636,6 +5441,74 @@ Generated: Wed Jan 13 04:15:48 2016
   * optional 3rd argument to parenmatch() does pretty-print of mush code [ASH]
   * securex() and escapex() now optionally accept 'a' as argument to ignore
     ansi [ASH]
+  * @dynhelp has a /nolabel switch to snarf the hilighted index values [ASH]
+  * Improved compatibility with execscript [ASH]
+  * NPEMIT(), like PEMIT(), now handles 3 arguments. [ASH]
+  * enhanced argument range check on all regedit*() functions [ASH]
+  * added '*' option to printf that allows cutting values from the right [ASH]
+  * @list functions accepts sub-options 'user', 'local', and 'built-in' [ASH]
+  * improved help for attrib formatting and added a plug in normal help [ASH]
+  * @wipe, @cluster/wipe, wipe(), and cluster_wipe() now take optional 
+    owner argument to wipe only attributes owned by owner [ASH]
+  * modified elock() to specify default values for locks [ASH]
+  * the listen argument to lcon()/xcon() included $commands since that
+    was seen as listening in @sweeps, but we have broken this out now so
+    that 'LISTEN' is truly listening and 'CMDLISTEN' is the old behavior [ASH]
+  * lwho() is now objid aware optionally [ASH]
+  * lexits(), lcon(), xcon(), lrooms(), lparents(), lzone(), zwho(), and 
+    children() are now objid aware [ASH]
+  * sortlist() now handles 'm' for merging. [ASH]
+  * @quitprogram has /quiet switch [ASH]
+  * programmer() optionally returns target/attrib pair of program call [ASH]
+  * @name added to @lock/twink as what you can do [ASH]
+  * @progreset allows you to optionally modify in-action someone's active
+    @program prompt [ASH]
+  * Permissions on @function laxed to allow full access to wizards [ASH]
+  * added new time formats for convtime() and enhanced_convtime [ASH]
+  * @progprompt hard-limited to 80 characters and now allows ANSI [ASH]
+  * ltoggles()/hastoggle() laxed to mimic lflags/hasflag perms [ASH]
+  * logout_cmd_access if option set 'DARK' will be ignored and bypassed [ASH]
+  * newpass_god modified to reset #1's password in-game if set [ASH]
+  * 'w' option for / / in printf() allows cutting on line when |&quot; used [ASH]
+  * '&lt;' and '&gt;' values to null current value if prevous/next value null [ASH]
+  * repeat() has optional third argument for better ansi handling [ASH]
+  * printf() would print a blank line if the last argument for each field
+    was a carriage return.  New option '.' for each field will now
+    supress the last line if all arguments are empty for that line [ASH]
+  * writable() is more useful with how it works for non-existant attribs [ASH]
+  * logtofile() optionally can write to the mush system log [ASH]
+  * LOGGED attribute flag now logs the last command issued to change it [ASH]
+  * modified chkgarbage() to handle a (b)oth option [ASH]
+  * left() and right() are now optionally ansi-aware [ASH]
+  * @register has /message switch to immediately message player the pass [ASH]
+  * Exits that are @powered FULLTEL will allow variable exits to assume
+    'linkable' to any valid destination [ASH]
+  * make config/confsource now saves your last state you compiled with [ASH]
+  * output_limit defaults now based on LBUF size [ASH]
+  * Moved minimal_db into new 'minimal-DBs' folder [AMB]
+  * added advanced buffer labeling to exec calls [ASH]
+  * @snapshot/del now takes multiple arguments [ASH]
+  * Added /quiet switch to @pipe [ASH]
+  * Added low/high ranges to strmath() [ASH]
+  * cleanup of the sideeffect handler to be more verbose [ASH]
+  * PARIS mode WHO/DOING (alternate who) is notified on @list options [ASH]
+  * increase %_ labels to 1000 total instead of 100 [ASH]
+  * 5th arg to keeptype() and remtype() to return dbref#'s [ASH]
+  * improved featureset to sortlist() for merging [ASH]
+  * modified @edit so that /check or sets are higlighted if a change 
+    actually occured with the first word 'Set' or 'Check' [ASH]
+  * change over from strtok to strtok_r throughout source code [ASH]
+  * keeptype(), remtype(), keepflags(), remflags() handle OBJID [ASH]
+  * foreach() is now optionally ansi-aware [ASH]
+  * added /ruler to @label to mimic ruler() functionality [ASH]
+  * asc() now handles optional second argument for 3 char padding [ASH]
+  * added 'fake' config params lbuf_size, mbuf_size, and sbuf_size to
+    the config() function for mortals to pull values [ASH]
+  * *_site and *_host will no longer allow duplicated entries [ASH]
+  * parenmatch() optionally allows stateful flags to specify additional
+    spaces for padding to make output easier to read [ASH]
+  * ldelete(), replace(), and insert() now take optional output delims [ASH]
+  * extractword() handles args from 1 now and negative operators [ASH]
     
   Bug Fixes
   ------------
@@ -4643,38 +5516,733 @@ Generated: Wed Jan 13 04:15:48 2016
     4 or more arguments [ASH]
   * foreach() had a possibility of overwriting a static buffer in-use
     which could return erraneous results (non-crash-bug) [ASH]
+  * Ancient systems (CentOS 4/5) didn't successfully handle MTU values [ASH]
+  * enhanced_convtime didn't handle all conditions properly [ASH]
+  * bug with streval which didn't process right on non-player evaluation [ASH]
+  * minor glitch if an object set STOP and SHOWFAILCMD [ASH]
+  * minor glitch with @snapshot/loading over a player already connected [ASH]
+  * flag_access_set, flag_access_unset, flag_access_see were case sensitive
+    and they shouldn't be [ASH]
+  * possible crash bug in @dbclean if there's a cached attribute that
+    was not in-use properly [ASH]
+  * small dangling check fix for %&lt;###&gt; ascii encoding [ASH]
+  * mailsend() was too restrictive for non-player types [ASH]
+  * cleanup of the idle_checker to always make current hash last in list [ASH]
+  * crash bug if error.txt file was empty [ASH]
+  * possible memory leak in extractword() in certain conditions [ASH]
+  * @tel/list didn't handle a comma separator properly for source [ASH]
+  * permission issue with guildmaster and setting attributes [ASH]
+  * memory leak on rare occurances of lookup_site [ASH]
+  * internal function for player lookup was not objid aware [ASH]
+  * parents() was too restrictive for thing getting own parent tree [ASH]
+  * Long standing issue with left()/right() with arg of '0' cut string [ASH]
+  * missing free when name_with_desc enabled [ASH]
+  * @sudo didn't handle @power/@depower like @fo [ASH]
+  * Inventory was not fully Reality Level aware nor color aware [ASH]
+  * invalid null termination in mix(), ltoggles(), and squish() [ASH]
+  * rand() didn't handle floating point quite right and cleaned up code [ASH]
+  * FreeBSD compatibility change for make/gmake in master Makefile [ASH]
+  * issue with left() and buffering [ASH]
+  * convert strtok to strtok_r in conf.c to avoid static buffer clobbers [ASH]
+  * dark exits didn't work properly with sees() [ASH]
+  * fixed ruler() and introduced internal function for notify quiet to
+    handle ansi [ASH]
+  * enforce @label to use lowercase for all labels [ASH]
+  * objid took localtime instead of GMtime [ASH]
+    - NOTE:  For compatibility to existing behavior, set: objid_localtime 1
+  * safer_ufun didn't take some conditions into consideration [ASH]
+  * erraneous ansi-normal on cname() if the name was not ansified [ASH]
+  * small bug in time conversion in timefmt() with daylight savings [ASH]
+  * mail did not handle commas for player separation properly [ASH]
+
 </PRE>
 <A HREF="#3.9.5p2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#3.9.5p4">[NEXT]</A>
+<BR>
+<HR><A NAME="3.9.5p4"><H3>3.9.5p4</H3></A><PRE>
+  Release Date: 11/23/16
+  Status: Alpha
+  
+  New Features
+  ------------
+  * testlock() for PennMUSH compatibility on testing locks [ASH]
+  * hook_offline if enabled will trigger the @hook/after on
+    @pcreate/@register on AO_&lt;command&gt; attribute.  Player created 
+    will be %# [ASH]
+  * @hook/include converts A_* (after) and B_* (before) hooks into
+    command processors instead of function processors.  Work was done
+    to avoid recursive calling.
+  * sandbox() to deny access to functions (built in or user) [ASH]
+  * BYPASS @admin function permission to tag a function (built in or user)
+    to not be affected by the sandbox() function [ASH]
+  * packmath() to allow math on varying radix compressions [ASH]
+  * subeval() evaluates string without executiong functions [ASH]
+  * %_&lt;-&gt; pops last stack for debug labels [ASH]
+  * alternative messages for those who hit 'MAX' on optional max values
+    for site restrictions for noguest, register, and forbid. [ASH]
+  * alternative messages for those set NOCONNECT or NOPOSSESS [KAG, ASH]
+  
+  Changes
+  ------------
+  * lt(), lte(), gt(), gte(), eq(), neq() handle multiple args [ASH]
+  * @hook will show if hook_offline is enabled [ASH]
+  * offline 'create' optionally triggers @hook [ASH]
+  * [co]nnect, [cr]eate, etc on connect screen are no longer case
+    sensitive [ASH]
+  * strmath() now handles &lt;, &gt;, &lt;=, &gt;=, =, != [ASH]
+  * elements()/elementsmux() now handles negative values to pull
+    from the end [ASH]
+  * improve folder/list to be more descriptive [ASH]
+  * xinc() and xdec() modified to handle advanced inc/dec [ASH]
+  * mail/status @folder works for displaying mail of folder [ASH]
+  * backend exec() parser passes EV_NOFCHECK to avoid parsing funcs [ASH]
+  * modified the backend to allow easy setting permissions on user attrib [ASH]
+  * When /save is used with /read it will output the format of your mail
+    in an MBOX standard format [ASH]
+  * UEVAL() and ZFUNEVAL() now accept /SUBEVAL as a switch [ASH]
+  * %-&lt;number&gt; now optionally handles %-subs 0-999 [ASH]
+  * %-m handles last command for @hooks only [ASH]
+  * improved %_&lt;subs&gt; to be more vigerous with removal and pops
+    last match first.
+  * colors have a (n)ame option to display name of the ansi arg [ASH]
+  * alternate date formats for convtime() [ASH]
+  * optional double eval for subeval (safe as it doesn't do functs) [ASH]
+  
+  Bug Fixes
+  ------------
+  * GCC 6.2 had different sizes for pointer and structure data [ASH]
+  * cleanup of warnings for GCC 6.2. [ASH]
+  * cleanup of warnings for CLANG on MacOSX Sierra [ASH]
+  * fix crash bug in ljc() [ASH]
+  * potential buffer corruption with very large function, flag,
+    toggle, and command lists [ASH]
+  * listfunctions() didn't work properly with local @lfunctions [ASH]
+  * mail/status [&lt;folder&gt;] wouldn't show mail of the given folder [ASH]
+  * bug with matching when NO_NAME was in effect on a target [ASH]
+  * folders mistakenly seen as corrupt when you had no mail at all [ASH]
+  * potential crash with NONAME when examining [ASH]
+  * @hook/include would break IGNORE feature sets and single chr commands [ASH]
+  * missing free buffer for sqlite [ASH]
+  * @hook didn't case desensitize commands passed to it [ASH]
+  * MAX on noguest didn't actually check guests connected when it should [ASH]
+  * nested /NOTRACE on @function/@lfunction didn't work [ASH]
+
+</PRE>
+<A HREF="#3.9.5p3">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#4.0.0p0">[NEXT]</A>
+<BR>
+<HR><A NAME="4.0.0p0"><H3>4.0.0p0</H3></A><PRE>
+  Release Date: 01/15/17
+  Status: Alpha
+    
+  New Features
+  ------------
+  * # option to printf for converting tabs to specified number of spaces [ASH]
+  * BANG support is now supported in %-&lt;num&gt; regs and %q&lt;&gt; regs [ASH]
+  * BANG support is now supported in %i&lt;num&gt; and %d&lt;num&gt; substitutions [ASH]
+  * SPEECH_PREFIX and SPEECH_SUFFIX attributes for prefix and suffix
+    processing of say (&quot;), pose (: &amp; ;), and @emit (//)  messages.  
+    Note: if set NO_COMMAND these will not process [ASH]
+  * Added argument %3 to SPEECH_PREFIX/SUFFIX for dbref# of enactor.  This
+    follows rules of 'spoofing' and spoofers show up as #-1.  [ASH]
+  * @admin param posesay_funct will optionally allow SPEECH_PREFIX and
+    SPEECH_SUFFIX to evaluate functions as long as not set NO_COMMAND.  [ASH]
+  * privatize() handles localize level of evaluation [ASH]
+  * @jump added to jump 'ahead' a set number of commands in sequence [ASH]
+  * @rollback to allow rolling back in the command queue based on varying
+    abilities [ASH]
+  * @goto command, a command similiar to @jump, using numerical labels. [AMB]
+  * @list alloc now lists network statistics for current running mush [ASH]
+  * @rollback handles /label to be compatible with @goto [ASH]
+  * msecs() like secs() but shows milisecond counts [ASH]
+  * exec_secure for execscript(_) config param (default 1) which does as it 
+    does now.  setting it to '0' escapes all characters but alphanumeric [ASH]
+  * A form of REST API has been added.  Please refer to documentation in-game
+    in help and wizhelp for how to use the API handler. [ASH]
+  * @api command to empower/enable API handling of a target [ASH]
+  * forbidapi_host/forbidapi_site for API handling [ASH]
+  * api_port for the unique port for the API handler [ASH]
+  * api_nodns to disable DNS lookups for all API handling [ASH]
+  * max_lastsite_api to set maximum API connections a minute [ASH]
+  * @power API (used with @api) for empowering objects [ASH]
+  * @power MONITORAPI (used with MONITOR_SITE) for filtering API [ASH]
+  * @admin param guest_randomize if enabled will randomly select a guest
+    each time one connects [ASH]
+  * passproxy_site/passproxy_host for bypassing the automatic proxy
+    detection subsystem.
+  
+  Changes
+  ------------
+  * increased the size of altname to 100 characters due to unicode [ASH]
+  * laxed some restrictions (like line length) for execscript [ASH]
+  * TESTLOCK() now handles more arguments for multi-targets [ASH]
+  * attribute uselocks now pass args %0-%9 that $commands have [ASH]
+  * listmatch() takes optional 4th arg to specify args to display [ASH]
+  * increased spellnum() to decillion [ASH]
+  * Added additional time formats to convtime() [ASH]
+  * moved up initializers for cpu alerts to be more aggressive [ASH]
+  * @decompile/tf will now, if passed /noextra in addition, surpress the
+    additional information on decompile (like attribute flags) [ASH]
+  * added negative time values for some sequences for convtime() [ASH]
+  * Split up and improved the CPU alarm subsystem [ASH]
+  * decode64 handles carrage returns where before it did not [ASH]
+  
+  Bug Fixes
+  ------------
+  * permission combination sets on connect screen could cause a crash [ASH]
+  * small bug in backend ansi handler that wouldn't allow background 16color
+    with foreground 256color [ASH]
+  * lnum2() didn't work properly with lnum_compat enabled [ASH]
+  * a one off unitialized variable for loading in command tables [ASH]
+  * small cleanup with compiling without ZENTY_ANSI [ASH]
+  * handler cleaned up for no-op handling [ASH,AMB]
+  * small parsing issue with bang notation with functions caused cutoff [ASH]
+  * rare issue of not null terminating string for a parser condition [ASH]
+  * the mail fix routine didn't range-check player lookups properly [ASH]
+  * possible out of bounds with UTF8 on notify to port [ASH]
+  * trim didn't default to 'space' if third argument existed and null [ASH]
+  * fix for *BSD missing 'daylight' timezone variable definition [ASH]
+  * /0 CIDR notation would not set properly [ASH]
+  * all localization doesn't keep setq names properly + clear [ASH] 
+  * fix that @jump could potentially blow the stack of the mush
+    to fix a stack leak, you must @shutdown then start mush [ASH]
+  * @rollback had a missing buffer free [ASH]
+  * ] for @hook/ignore and @hook/permit was broken [ASH]
+  * @goto could potentially overflow a buffer [ASH]
+  * off by one argument handler for @rollback [ASH]
+  * segments not initialized properly for CPU alarms [ASH]
+  * error in CPUTIME not always being initialized properly [ASH]
+  * Some CPU handlers were broke and far too aggressive [ASH]
+  * bug in @dolist/inline that wouldn't fully honor CPU protection [ASH]
+  * MUX password check algo didn't fully work because memcmp() is stupid [ASH]
+  * Bug with @nuke on wiping mail if issued from a non-player [ASH]
+  * Fixed an ancient crashbug in right() when second arg was missing [AMB]
+  * potatoe sent invalid data-stream of NULL followed by CRLF.  We ignore
+    this now and no longer update idle time [ASH]
+  * bug in @protect that didn't set/unset the proper flags [ASH]
+  * The base UTF8 conversion had a math error in stringutil.c [eery]
+  * UTF8 ran into codepoint corruption due to missing terminator [eery]
+
+</PRE>
+<A HREF="#3.9.5p4">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#4.0.0p1">[NEXT]</A>
+<BR>
+<HR><A NAME="4.0.0p1"><H3>4.0.0p1</H3></A><PRE>
+  Release Date: 09/08/17
+  Status: Alpha
+    
+  New Features
+  ------------
+  * @name/ansi combines @name and @extansi.  If you do not have @extansi
+    access, @name/ansi will fail as well [ASH]
+  * @pcreate, @create, @open, @dig, @clone, and @register now handle
+    /ansi as well [ASH]
+  * ansipos() to return the markup of the ansi and accents of the given
+    position in the string. [ASH]
+  * added @admin param 'null_is_idle' to treat @@ like IDLE to stop @@
+    from updating idle times. [ASH]
+  * @power wiz_idle to allow target players the enhanced idle features [ASH]
+  * attribute 'mailnotify' (set via &amp;mailnotify) will evaluate the attribute
+    and send to the target person who is issuing mail [ASH]
+  * WIZ_SPOOF @power to grant spoofing ability to target [ASH]
+  * Attribute TRACETAB to control how many spaces(0-10) to indent on trace
+    output for those who prefer PENN's debug format [ASH]
+  * passapi_host and passapi_site to bypass max api connections [ASH]
+  * trreverse().  Works like reverse() but transposes characters like &lt;&gt; [ASH]
+  * insert() now has additional arguments to append, prepend, and box
+    (including transposing box) arguments [ASH]  
+  * noparse @admin function_access parameter [ASH]
+  * @admin param iter_loop_max to control maximum cycles of iter special
+    processing [ASH]
+  * inf() (an iter() clone) allows special string substitutions for input 
+    of :&lt;value&gt;:&gt;: or :&lt;value&gt;:&lt;: for 'infinite loop' checks.  Normal 
+    function invocation and cpu alarms as well as the @admin param 
+    iter_loop_max dictates maximums for the looping [ASH]
+  * extractword() takes an optional MOD argument that allows applying a modulo
+    to the 'first' value for automatic wrap-around.
+  * @recover has a /detail switch that now will show attribute details of the
+    target object.
+  
+  Changes
+  ------------
+  * objid's are now statically stored on things to finally get around
+    weird timezone issues [ASH]
+  * More aggressively handle API processing [ASH]
+  * colors() works with +&lt;color&gt; as well as &lt;color&gt; now [ASH]
+  * Initial fix for stored procedures in MySQL [ASH]
+  * optional argument to set() and @set to allow setting attributes with
+    a content that starts with '_'  [ASH]
+  * COMP() now handles case insensitive, numbers, floats, and dbref#s [ASH]
+  * squish() now offers a second argument to specify count for filler [ASH]
+  * laxed permissions for exits so that they can fetch lcon/lexits on
+    both source and destination points it is linked to [ASH]
+  
+  Bug Fixes
+  ------------
+  * ANSI16 conversion had bad entries for highlighted yellow [Polk]
+  * EVAL locks had a race condition on redefining calling attrib [ASH]
+  * ANSI didn't fully honor ZENTY_ANSI when ZENTY_ANSI was enabled [ASH]
+  * compiler warnings when ZENTY_ANSI not specified [ASH]
+  * crash bug in printf [ASH]
+  * printf tab replacement did not reset value for next arg [ASH]
+  * mail functions could potentially crash the game if mail is off [ASH]
+  * API would wrongly do AUTH checks even if the code ignored lookups [ASH]
+  * cleanup @reboot data to strip API lookups and other things [ASH]
+  * Nospoof didn't work if you were @toggled UTF8
+  * bug in objid where the validation check wouldn't always work [ASH]
+  * insert(), ldelete(), and replace() didn't fully work with output
+    seperators [ASH]
+  * mail attributes allowed evaluation of mail functions and it likely
+    shouldn't for security reasons [ASH]
+  * timeslice config param could crash the game if used [ASH]
+  * corrupted LBUF in functions.c [ASH]
+  * flatfiles loaded with dbref#'s having more than 750 attributes 
+    could be cut off.  [ASH]
+
+</PRE>
+<A HREF="#4.0.0p0">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#4.0.0p2">[NEXT]</A>
+<BR>
+<HR><A NAME="4.0.0p2"><H3>4.0.0p2</H3></A><PRE>
+  Release Date: 05/26/18
+  Status: Alpha
+    
+  New Features
+  ------------
+  * exit_separator @admin param to specify separator between exits [ASH]
+  * help_separator @admin param to specify separator between help [ASH]
+  * @dynhelp/suggest for suggestions if not finding help entry [ASH] 
+  * dynhelp() and textfile() optionally allow suggestions [ASH]
+  * randextract() optionally has weighted values [ASH]
+  * execscript() modified to pass back and forth registers and vars [ASH]
+  * execscript() passes register names as well [ASH]
+  * Added /query to help, +help, @dynhelp (but not functions) [ASH]
+  * Added /reset switch to @txlevel and @rxlevel to force a clearing
+    of the reality prior to any new sets [ASH]
+  * atrperms_checkall to go through all prefix matching for the lowest
+    permission match [ASH]
+  * added NETMASK support to @blacklist [ASH]
+  * stderr() will convert output starting with #-1 to notify() and remove
+    from the stack. [ASH]
+  
+  Changes
+  ------------
+  * help allows suggestions when it can not find help entry [ASH]
+  * listprotection() has additional arguments to handle @alias [ASH]
+  * Added comments and continous lines to content for execscript [ASH]
+  * Added MUTT compatibility to autoreg mail handling [ASH]
+  * Reality levels with @txlevel/@rxlevel allow setting by bitmask [ASH]
+  * @rxlevel/@txlevel follow NOISY @toggle parameters [ASH]
+  * Options to pemit(), remit(), and zemit() to disable multi-parsing and ## 
+    evaluation [ASH]
+  * sending kill -HUP (SIGHUP) to the main mush process will now
+    not only sync the database but issue a flatfile dump in the
+    form netrhost.SIGHUP.flat [ASH]
+  * All l*() math functions will return '0' now if fed empty lists [ASH]
+  * added parameters to caplist()
+  * singletime() now handles eons
+  
+  Bug Fixes
+  ------------
+  * door.c could crash if non-player executed @door/push [ASH]
+  * help separator bug with /search
+  * @tel target= will now give an error message [ASH]
+  * cleanup script for execscript a bit too aggressive [ASH]
+  * @fpose/nospace didn't work properly [ASH]
+  * initializing of unitialized variables for trace [ASH]
+  * trace buffers were insufficiently sized on 32 byte SBUFS [ASH]
+  * cleanup of possible buffer null terminate on SBUF [ASH]
+  * 3rd arg to strmath() wasn't evaluating [ASH]
+  * door only did LF and not CRLF [ASH]
+  * cleanup of an unused variable in functions.c [ASH]
+  * site paranoia was a bit too, well, paranoid [ASH]
+  * some cleanup to @snapshot on making restrictions on filenames [ASH]
+  * mktime64 was defined in IBM so had to be renamed [ASH]
+  * cleanup of DOORS and potential API connections on @reboot [ASH]
+  * @invformat didn't handle parents [ASH]
+  * lattr() with command checking didn't cleanly check commands [ASH]
+
+</PRE>
+<A HREF="#4.0.0p1">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#4.0.0p3">[NEXT]</A>
+<BR>
+<HR><A NAME="4.0.0p3"><H3>4.0.0p3</H3></A><PRE>
+  Release Date: 12/06/18
+  Status: Alpha
+    
+  New Features
+  ------------
+  * queue timer allows specifying offset from 1 second to 1 milisecond [ASH]
+  * Sites that do not properly send AUTH data or RDNS data get auto-added
+    to the NoAUTH and NoDNS entires to avoid future lag [ASH]
+  * template() function to do auto-replace in a defined template string [ASH]
+  * examine/display allows ansifying parenthesis, braces, and brackets
+    like parenmatch() [ASH]
+  * @conncheck has a /quota switch to show connected command quotas [ASH]
+  * wizard command @cmdquota to alter on-line command quotas of players [ASH]
+  * wizcommand_quota_max to set wizard command quotas [ASH]
+  * @blacklist has the /nodns switch for DNS lookup bypassing [ASH]
+  * Added sub-option 'display' to @list options to work like config() [ASH]
+  * sconnect_reip, sconnect_cmd, sconnect_host for SCONNECT/PROXY support [ASH]
+  * added sconnect handlers and configuration as scripts [Oleo/Adrick/Ash]
+  * @cpattr has /verify switch that validates attributes being copied [ASH]
+  * @blacklist supports /add, /del, and /search by IP [ASH]
+  * @admin param global_error_cmd allows global error obj to process cmds [ASH]
+  * morgrification for say, pose, and @emit.  (See wizhelp morgrify) [ASH]
+  
+  Changes
+  ------------
+  * @blacklist modified to be more user friendly for display values.
+    Must now specify '0' or 'all' to get a full listing (spammy) [ASH]
+  * printf() will now show you the location in the format string erroring [ASH]
+  * the config file handler will now skip lines with nothing but whitespace
+    or entirely blank lines w/o errors [ASH]
+  * caplist() handles more cases of how to capitalize after special chars [ASH]
+  * @saystring is now inherited thorugh parent chains
+  * safebuff() allows an optional cut-off value [ASH]
+  * @list options display and config() now sort the lists properly [ASH]
+  * execscript() allows you to pass vars from other objects you control [ASH]
+  * Global parents (ancestors) now will inherit from their own parents [ASH]
+  * Protection on SSL handler against brute force attacks [ASH]
+  * SPEECH_PREFIX/SPEECH_SUFFIX inherit from parents [ASH]
+  * Modified source so using STUNNEL no longer requires SSL libs [ASH]
+  * Array handled to split on char and not 'word' [ASH]
+  * parsestr has new argument to special prefix @emit handling [ASH]
+  
+  Bug Fixes
+  ------------
+  * some cleanup on milisecond timers
+  * setunion/setinter/setdiff didn't properly sort final lists [ASH]
+  * logic for setunion() didn't always work on conditional type setting [ASH]
+  * logic for setdiff/setinter didn't always work on conditional types [ASH]
+  * duplciate entries could be seen with suggestions for help entries [ASH]
+  * Long standing issue with @extansi that put a raw ansi normal [ASH]
+  * marginal cleanup of parenmatch()/parenstr() to handle raw ansi [ASH]
+  * warning in bsd.c with an unsigned int to int typecast under clang [ASH]
+  * initialized OpenSSL variable for mux password compat [ASH]
+  * SSL connectivity didn't honor nodns/noguest/register/forbid [ASH]
+  * SSL connectivity didn't honor suspect [ASH]
+  * doors could potentially hang for short durations on bad sites [ASH]
+  * UTF8 didn't null terminate properly in some cases [ASH]
+  * A bunch of small one off bugs in the UTF8 handler that borked BSD [ASH]
+  * buffering didn't account for non-ASCII7 entirely cleanly (noncrash) [ASH]
+
+</PRE>
+<A HREF="#4.0.0p2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#4.0.0p4">[NEXT]</A>
+<BR>
+<HR><A NAME="4.0.0p4"><H3>4.0.0p4</H3></A><PRE>
+  Release Date: 10/17/19
+  Status: Alpha
+    
+  New Features
+  ------------
+  * sha2rounds @admin param to increase round recursion for SHA2.  The
+    default value to this is 5000.  [ASH] 
+  * vercustomstr @admin param to allow a 20 character customised version
+    suffix [ASH]
+  * @admin param execscriptpath to specify alphanumerical subdirectories
+    that may be searched for execscript as overrides [ASH]
+  
+  Changes
+  ------------
+  * config files now allow dbref# syntax for numberical values. [ASH]
+    i.e.  'master_room #2' as well as the previous allowable 'master_room 2'
+  * major cleanup of internal parsing of help files [ASH]
+  * Snuff erraneous warnings on empty lines in conf files [ASH]
+  * Added update to help showing the requirement of the config power_objects
+    to be enabled for the API subsystem.
+  * API subsystem is now CORS aware
+  
+  Bug Fixes
+  ------------
+  * version/short_ver didn't have bounds checking for custom versions
+    if someone decided to change the strings to ridiculously large 
+    values [ASH]
+  * @dynhelp didn't honor help_separator [ASH]
+  * temporary static buffer for SSl could be overwritten in display [ASH]
+  * Fix long-existing typecast bugs for compiler [ASH]
+  * BSD select() does not like milisecond timers over 10ms [ASH]
+  * snuff erranous warning when no vattr_cmds are defined [ASH]
+  * vattr_command had the alias and attribute switched on .conf [ASH]
+
+</PRE>
+<A HREF="#4.0.0p3">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#4.1.0p0">[NEXT]</A>
+<BR>
+<HR><A NAME="4.1.0p0"><H3>4.1.0p0</H3></A><PRE>
+  Release Date: 12/15/19
+  Status: Alpha
+    
+  New Features
+  ------------
+  * Initial prep-work to allow future of websockets [ASH]
+  * Grapenut's WebSockets are now enabled for API handling [ASH]
+  * @password/attribute for setting passwords to attributes [ASH]
+  * attrpass() for setting/checking attribute passwords [ASH]
+  * account_login() customized login functionality [ASH]
+  * account_owner() for 'ownership' of a central account [ASH]
+  * account_su() to allow suing between accounts [ASH]
+  * account_who() to allow showing ports using accounts [ASH]
+  * connect_methods @admin param to disable hardcoded connects [ASH]
+  * Tag system for avoiding hardcoded #dbrefs in softcode [AMB]
+  * Added listtags() and tagmatch() function. [AMB]
+  * string_conn, string_conndark, string_connhide, string_create,
+    string_register added for custom connect commands [ASH]
+  * hardconn_site and hardconn_host to specify sites allowed
+    to use connect screen hardcommands if connect_methods enabled [ASH]
+  * istag() to verify if the tag is valid or not [ASH]
+  * Made Rhost hold *.default files of usuall player-changed files.
+    Usually player-edited files will not be affected by repo changes. [AMB]
+  
+  Changes
+  ------------
+  * Modification of DESC internal handler to handle adding on the fly
+    additions to the descriptor table to allow @reboots to handle
+    w/o crashing [ASH] 
+  * minor improvement on return handler of account_login() [ASH]
+  * Added ability to pcreate users from create() [ASH]
+  * mailsend() has new option to specify optional sender [ASH]
+  * @conncheck/account for account membership viewing [ASH]
+  * updated minimal db with latest comsys and account subsys [ASH]
+  * Added an optional wildcard string argument to @tag/list [AMB]
+  * Added matching against #&lt;tagname&gt; as a #dbref replacement. [AMB]
+  * Added tags to @decompile, as well as a /tags switch. [AMB]
+  * Added 'Object Tags' to @list hash. [AMB]
+  * increased Hash width for ANSI and @tag hashtables. [AMB]
+  
+  Bug Fixes
+  ------------
+  * mysql_ping could potentially hang on certaion versions of Mysql [ASH]
+  * Potential buffer overwrite in built in news system [ASH]
+  * potential off by one for API text handler on input -- reverted [ASH]
+  * fix some potential buffer overflow risks [ASH]
+  * fix bug in mysql where null sub-entries would abort rest [ASH]
+  * execscript(), comp(), variable exits, and lookup_player (internal) 
+    are tag aware [ASH]
+  * Made the Tag system buffers more safe. strcat replaced with safe_* [AMB]
+  * Fixed code that was causing warnings in newer GCC and Clang [AMB]
+
+</PRE>
+<A HREF="#4.0.0p4">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#4.1.0p1">[NEXT]</A>
+<BR>
+<HR><A NAME="4.1.0p1"><H3>4.1.0p1</H3></A><PRE>
+  Release Date: 02/23/20
+  Status: Alpha
+  
+  New Features
+  ------------
+  * @ltag - Works like @tag but is localized per user (and belongings) [ASH]
+  * @totem - Dynamic flag subsystem for hardcode, @admin params, inline [ASH]
+  * @totemdef - like @flagdef but for @totems
+  * totem_add          -- config to add new @totems [ASH]
+  * totem_alias        -- config to set aliases to @totems [ASH]
+  * totem_access_set   -- config to set 'set' permissions [ASH]
+  * totem_access_unset -- config to set 'unset' permissions [ASH]
+  * totem_access_see   -- config to set 'see' permissions [ASH]
+  * totem_access_type  -- config to deny sets based on type(s) [ASH]
+  * ltotems()          -- list all totems on target [ASH]
+  * hastotem()         -- check if target has totem [ASH]
+  * totem_letter       -- config to set totem letters [ASH]
+  * totems()           -- list flag letters of totems (skips default '?') [ASH]
+  * andtotem()/ortotem()  letter handling for totems [ASH]
+  * andtotems()/ortotems() totem flag handler for totem names [ASH]
+  * listtotems()       -- like @totem/list (or @list totems) [ASH]
+  * @totem/slot        -- shows the total slots and number of totems defined
+                          to each slot (that you can see). [ASH]
+  * totem_types        -- @admin param to enable flag-like type detection [ASH]
+  * totem_rename       -- optionally rename non-temporary totems [ASH]
+  * @totem/unalias     -- remove aliases of totems [ASH]
+  * totem_name         -- config param to allow renaming totems [ASH]
+  * --version/-version/-v with netrhost returns version and exits [ASH]
+  * totemset() side effect to set/clear @totems on targets [ASH]
+  * blacklist_max param allows a blacklist between 1000 and 5000000 [ASH]
+  * connect_perm config param specifies who can use 'connect' [ASH]
+  * MUSH_OBJID passed as an environment variable to execscript [ASH]
+  * /strict switch for @open, @pcreate, @dig, @create to enforce dbref#
+    you pass is a valid free dbref#. [ASH]
+  * /strict option to matching functions of commands [ASH]
+  * %i_## for inum()/#@ substitutions for iter/list [ASH]
+  * @leveldefault - Wipe Reality Levels off an object to use conf defaults.
+  * pagelock_notify option to snuff the login message about a PAGE LOCK [AMB]
+  * Optional TYPE argument to rloc() to stop if currently downward-traversed
+    location type matches. [AMB]
+  
+  Changes
+  ------------
+  * Added internal boilerplate for future flag conversion to totems [ASH]
+  * /display switch added to @totem [ASH]
+  * /letter switch addedto @totem [ASH]
+  * Added table-loader for Totems for ease of flag/toggle porting [ASH]
+  * Added default markers to Totems as examples [ASH]
+  * wildcard and slot handler for @list totem &amp; @totem/list [ASH]
+  * port() modified so immortal can get port info of #1 [ASH]
+  * added totem, totem2, totem3 to search classes [ASH]
+  * @totem/list optionally allows a slot value [ASH]
+  * improved safer_passwods for better entropy on SHA412 passwords [ASH]
+  * salted SHA512 now randomized between 9 and 19 characters [ASH]
+  * +all option to mail/read[/save] to output ALL mail (spammy) [ASH]
+  * evaluation @locks pass the compared to argument as %1 [ASH]
+  * account_owner() allows the owner to be any data type [ASH]
+  * inzone() optionally checks if a target belongs to a zonemaster [ASH]
+  * @blacklist now has a dynamic value to increase the IP's blocked [ASH]
+  * switch and match logic recognizes =&lt;, &lt;=, =&gt;, &gt;=, = [ASH]
+  * lcon() has optional count value to return total counts [ASH]
+  * %_ is reserved and can no longer be overridden [ASH]
+  * Made quota() work by the same viewing-rules as @quota [AMB]
+  * @levellist now handles /list for multi-targets [ASH]
+  
+  Bug Fixes
+  ------------
+  * @tag wouldn't load tags if threshold reached [ASH]
+  * Crash bug in @totemdef with a missed conversion value [ASH]
+  * Permissions for seeing totems were not working properly [ASH]
+  * Permission bug in @totem set/unset [ASH]
+  * @totem/add wouldn't allow high bit adding (0x80000000) [ASH]
+  * @totem/rename could crash if totem had an alias [ASH]
+  * Small memory leak in @tag/remove [ASH]
+  * Small memory leak in @totem/remove [ASH]
+  * totem_access_set/totem_access_unset/totem_access_see/totem_access_type did
+    not give the correct error responses [ASH]
+  * Error display for @totem/letter was incorrect [ASH]
+  * NO_EVAL and NO_PARSE didn't work properly on @functions/@lfunctions [ASH]
+  * Off by 1 in totem handler for previos db creation [AMB]
+  * SHA512 salt could be larger than some crypt algos allowed [ASH]
+  * SHA512 salt allowable chars restrictive with libxcrypt [ASH]
+  * wrap() and some supporting functions didn't handle XTERM256 [ASH]
+  * wrap() and supporting functions didn't honor markup accents [ASH]
+  * typo in speech.c on a variable call [ASH]
+  * copy_defaultfiles didn't work on older systems [ASH]
+  * main Makefile didn't copy files on default compiles [ASH]
+  * @tel/list could potentially DoS the mush on ridiculous contents [ASH]
+  * Made #Lambda work on objects that are @set NO_EXAMINE [AMB]
+  * Fixed a bug with reality_compare 2-3 + missing desc, but a set format [AMB]
+  * Fixed a bug where objects dest'ing did not increase owner's counter [AMB]
+
+</PRE>
+<A HREF="#4.1.0p0">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#4.1.0p2">[NEXT]</A>
+<BR>
+<HR><A NAME="4.1.0p2"><H3>4.1.0p2</H3></A><PRE>
+  Release Date: 12/10/20
+  Status: Alpha
+    
+  New Features
+  ------------
+  * Support for Websocket protcol connections to the MUSH [KAG]
+  * Added Websocket config option to the Asksource script. [AMB]
+  * spellnum() takes a second argument for ordinals [ASH]
+  * Added %4 to the mogrifier, indicating if the message is player-only in the
+    case of 'say' [AMB]
+  * Added rxdesc() as a complementary to rxlevel(), showing a list of descs
+    visible to an object. [AMB]
+  * float_switches config param to allow @switch/switch() float compares [ASH]
+  * Port binder will now attempt 5 times for port connects to allow slow
+    kernels and/or cached I/O and/or swapped games time to rebind [ASH]
+  * @exec callback for execscript() to push to the queue any command [ASH]
+  
+  Changes
+  ------------
+  * @reclist now handles wildcards to help search for items [ASH]
+  * @list alloc now shows blacklist/nodns statistics [ASH]
+  * @toggle, @set (flag), and @totem added to execscript callback [ASH]
+  * name() has third optional argument for /ansi switch for @name [ASH]
+  * TOTEM_SLOTS will no longer allow starting the mush if &gt; MAX per LBUF [ASH]
+  * @list alloc will show overhead of totems per object [ASH]
+  * Optionally do forced ansi normal only if ansi detected in string [ASH]
+  * Forced carrage returns no longer on connect screen.  
+    Code all softcoded connect screens accordingly!!!! [ASH]
+  * Add MUSH_VERSION environment variable to execscript [ASH]
+  * Totems of player and owner of player passed to execscript [ASH]
+  
+  Bug Fixes
+  ------------
+  * SIDEFX permissions were messed up for normal players [ASH]
+  * Mogrify handler had an off by one for the array [ASH]
+  * websock2 needed further seperation with ENABLE_WEBSOCKS [ASH]
+  * SBUF free on an LBUF free for mogrify (memory leak) [ASH]
+  * #lambda wasn't case insensitive, it now is [ASH]
+  * Due to compile optimizations, timeouts may not work right [ASH]
+  * Improve ansi handler to smart-close ansified strings [ASH]
+  * rloc had SIGSEGV bug with argument checks [ASH]
+  * parse_ansi (internal) didn't initialize values passed to it [ASH]
+  * DOING/WHO didn't initialize values passed to it [ASH]
+</PRE>
+<A HREF="#4.1.0p1">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#:">[NEXT]</A>
 <BR>
 <HR><A NAME=":"><H3>:</H3></A><PRE>
   Command: :&lt;message&gt;
+   
   Displays &lt;message&gt; to everyone in your current room, preceded by your name
-  and a space.  Example: the command ':jumps for joy' produces
-  '&lt;yourname&gt; jumps for joy'.
+  and a space.  
+  
+  You may use two special attributes for pre and post processing of any
+  says you receive.  These attributes will have substitutions evaluated
+  but will not evaluate functions.  If these attributes are set NO_COMMAND
+  then they will not be processed.
+    SPEECH_PREFIX  -- Contents will be evaluated before the say/pose.
+    SPEECH_SUFFIX  -- Contents will be evaluated after the say/pose.
+  
+  Both of these attributes handle three arguments.  These are:
+    %0 - The original say/pose that triggered the attribute.
+    %1 - The date in the form MM/DD/YYYY
+    %2 - The time in the form HH:MM:SS
+    %3 - The dbref# of the player issuing the say/pose/emit (#-1 if spoofed)
+  
+  Example: (assuming your name is Bob)
+    &gt; :jumps for joy
+    Bob jumps for joy
   
   If you have a space after the ':' it will use the ';' format instead.
   
   See Also: page, pose, say, whisper, ;, &quot;
   
 </PRE>
-<A HREF="#3.9.5p3">[PREV]</A>
+<A HREF="#4.1.0p2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#;">[NEXT]</A>
 <BR>
 <HR><A NAME=";"><H3>;</H3></A><PRE>
   Command: ;&lt;message&gt;
+  
   This command is much like the ':' command, except that no space is inserted
-  between your name and the action.  Example: the command ';'s watch beeps.'
-  produces '&lt;yourname&gt;'s watch beeps.'.
- 
+  between your name and the action.  
+  
+  You may use two special attributes for pre and post processing of any
+  says you receive.  These attributes will have substitutions evaluated
+  but will not evaluate functions.  If these attributes are set NO_COMMAND
+  then they will not be processed.
+    SPEECH_PREFIX  -- Contents will be evaluated before the say/pose.
+    SPEECH_SUFFIX  -- Contents will be evaluated after the say/pose.
+  
+  Both of these attributes handle three arguments.  These are:
+    %0 - The original say/pose that triggered the attribute.
+    %1 - The date in the form MM/DD/YYYY
+    %2 - The time in the form HH:MM:SS
+    %3 - The dbref# of the player issuing the say/pose/emit (#-1 if spoofed)
+  
+  Example: (assuming your name is Bob)
+    &gt; ;'s watch beeps.
+    Bob's watch beeps.
+   
   Warning: This command does not work in command lists run from an attribute
   because the ';' is treated as the command separator.  Use pose/nospace
   instead.
   
   If you have a space after the ';' it will use the ':' format instead.
- 
+   
   See Also: page, pose, say, whisper, :, &quot;
   
 </PRE>
@@ -4742,7 +6310,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say [@@(this is a test[setq(0,test)])]- [r(0)]
     You say &quot;- &quot;
   
-  See Also: localize(), eval(), null(), privatize()
+  See Also: localize(), eval(), subeval(), null(), privatize(), sandbox(), 
+            stderr()
   
 </PRE>
 <A HREF="#@@">[PREV]</A>
@@ -5095,6 +6664,9 @@ Generated: Wed Jan 13 04:15:48 2016
   Command: @alias[/&lt;switch&gt;] &lt;player&gt; = &lt;name&gt;
   Attribute: Alias
  
+  Note: You can only have one alias with @alias.  If you wish to use multiple
+        aliases, in addition to this use the @protect system.
+  
   Provides an alternate name by which the player is known.  The alternate
   name is only used for players when referenced as '*&lt;name&gt;' or by commands
   that only take player names (such as page or @stats).  You may not set
@@ -5103,10 +6675,11 @@ Generated: Wed Jan 13 04:15:48 2016
   When setting an alias, the alias is checked to see that it is both a legal
   player name and not already in use.  Only if both checks succeed is the
   alias set.
- 
-  Optional switches are /quiet to suppress output or /noisy to give 
-  verbose output.
   
+  You can not @name yourself to any name you set an @alias to, nor any name
+  anyone else sets an @alias to.  If you wish to be able to switch into
+  and out of protected names, please use the @protect system and not @alias.
+   
   See Also: @name, @protect, listprotection()
   
 </PRE>
@@ -5162,6 +6735,9 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="@ansiname"><H3>@ansiname</H3></A><PRE>
   Command: @ansiname[/&lt;switch&gt;] &lt;object&gt; = &lt;string&gt;
   Attribute: AnsiName
+  
+  The cname() function (or %k substitution) will show the colorized/accented 
+  name.
   
   This sets the ansi codes for the particular object.  As long as that object
   is allowed to have ansi codes (individually or globally) then whatever
@@ -5282,7 +6858,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; test 0
       Before assert
   
-  See Also: $-COMMAND, @@, @break, @skip
+  See Also: $-COMMAND, @@, @break, @skip, @jump, @rollback, @goto
 
 </PRE>
 <A HREF="#@asfail">[PREV]</A>
@@ -5502,7 +7078,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; testme 1
       Before break
   
-  See Also: $-COMMAND, @@, @assert, @skip
+  See Also: $-COMMAND, @@, @assert, @skip, @jump, @rollback, @goto
   
 </PRE>
 <A HREF="#@away">[PREV]</A>
@@ -5515,7 +7091,10 @@ Generated: Wed Jan 13 04:15:48 2016
   
   This attribute sets up a caption that is used when a player is looked at.
   This 'caption' is appended to their name.  You may set a large caption,
-  but only the first 40 characters will be used.  ANSI is also stripped.
+  but only the first 40 characters will be used.  If you do not use the
+  ZENTY_ANSI compile time option then ANSI is also stripped.  Carrage 
+  returns will be stripped.
+  
   This is only used for players and is ignored for every other data type.
   
   Optional switches are /quiet to suppress output or /noisy to give 
@@ -5673,15 +7252,27 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="@clone2"><H3>@clone2</H3></A><PRE>
   The following switches are available:
      /cost       - Treat the argument after the = as the cost of the new
-                   object, not the name.
+                   object, not the name.  Can not be used with /ansi.
      /inherit    - Don't reset the INHERIT bit on the new object.
      /inventory  - Create the new object in your inventory (or your exitlist,
                    in the case of cloning exits).
      /location   - Create the new object in your location (default).
      /parent     - Set the new object's parent to be the template object and
                    don't copy the attributes.
+     /ansi       - Combine @clone and @extansi together.  This follows
+                   @extansi permissions and can not be used with /cost.
+   
+  You may use the lastcreate() function to see the last room that @clone'd.
+  This would be based on the type of thing you @cloned.
   
-  See Also: @create, @decompile, @destroy, VISUAL
+  Examples:
+    &gt; @clone RedWagon
+    RedWagon cloned, new copy is object #17447.
+    &gt; @clone/ansi RedWagon=[ansi(hb,BlueWagon)]
+    Ansi string entered for BlueWagon of 'BlueWagon'. (this would be in blue)
+    RedWagon cloned as BlueWagon, new copy is object #17444.
+  
+  See Also: @create, @decompile, @destroy, VISUAL, lastcreate()
   
 </PRE>
 <A HREF="#@clone">[PREV]</A>
@@ -5711,7 +7302,8 @@ Generated: Wed Jan 13 04:15:48 2016
     /grep   - grep cluster for match     /reaction   - edit action on cluster
     /cut    - 'cut' dbref# from cluster  /trigger    - trigger attr in cluster
     /func   - Specify function action    /regexp     - use regexp pattern match
-    /wipe   - Wipe attrib(s) in cluster
+    /wipe   - Wipe attrib(s) in cluster  /owner      - Owner check for /wipe
+                                         /preserve   - Preserve /wipe pattern
    
   See Also:  clusters, cluster functions, cluster commands, &gt;
 
@@ -6003,6 +7595,32 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#@cluster list">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@cluster owner">[NEXT]</A>
+<BR>
+<HR><A NAME="@cluster owner"><H3>@cluster owner</H3></A><PRE>
+  Command: @cluster/wipe
+  
+  These switches are useful only for @cluster/wipe.  Please see @cluster/wipe
+  for more information.
+  
+  See Also: @cluster wipe
+   
+</PRE>
+<A HREF="#@cluster new">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@cluster preserve">[NEXT]</A>
+<BR>
+<HR><A NAME="@cluster preserve"><H3>@cluster preserve</H3></A><PRE>
+  Command: @cluster/wipe
+  
+  These switches are useful only for @cluster/wipe.  Please see @cluster/wipe
+  for more information.
+  
+  See Also: @cluster wipe
+   
+</PRE>
+<A HREF="#@cluster owner">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@cluster reaction">[NEXT]</A>
 <BR>
 <HR><A NAME="@cluster reaction"><H3>@cluster reaction</H3></A><PRE>
@@ -6019,7 +7637,22 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also:  clusters, cluster functions, cluster commands, &gt;
 
 </PRE>
-<A HREF="#@cluster new">[PREV]</A>
+<A HREF="#@cluster preserve">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@cluster regexp">[NEXT]</A>
+<BR>
+<HR><A NAME="@cluster regexp"><H3>@cluster regexp</H3></A><PRE>
+  Command: @cluster
+  
+  The regexp switch is used to give regular expression matching for the other
+  switches to @cluster.  It is currently useful with the following switches:
+      @cluster/wipe/regexp -- Use regexp matching to wipe attribs.
+      @cluster/grep/regexp -- Use regexp matching to grep attribs.
+  
+  See Also: @cluster wipe, @cluster grep
+   
+</PRE>
+<A HREF="#@cluster reaction">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@cluster repair">[NEXT]</A>
 <BR>
@@ -6041,7 +7674,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also:  clusters, cluster functions, cluster commands, &gt;
 
 </PRE>
-<A HREF="#@cluster reaction">[PREV]</A>
+<A HREF="#@cluster regexp">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@cluster set">[NEXT]</A>
 <BR>
@@ -6112,18 +7745,25 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#@cluster wipe">[NEXT]</A>
 <BR>
 <HR><A NAME="@cluster wipe"><H3>@cluster wipe</H3></A><PRE>
-  Command: @cluster/wipe &lt;object&gt;[/&lt;wildattr&gt;]
-           @cluster/wipe/regexp &lt;object&gt;[/&lt;wildattr&gt;]
+  Command: @cluster/wipe[/regexp] &lt;object&gt;[/&lt;wildattr&gt;]
+           @cluster/wipe/owner[/regexp] &lt;owner&gt;/&lt;object&gt;[/&lt;wildattr&gt;]
   
   The wipe switch, with an optional regexp switch addon, will wipe all matching
   attributes from every item in the cluster.  This works exactly like @wipe
   except is performed on the entirity of the cluster.
+  
+  Following switches are optionally used with @cluster/wipe:
+    /regexp   -- Convert wildcard matching to a regexp pattern.
+    /owner    -- Take optional owner argument to specify attribute ownership.
+    /preserve -- Preserve the wildcard pattern and wipe everything else.
   
   Example:
     &gt; @cluster/wipe #1234/va*
     Cluster wipe: 24 total objects, 0 no-match, 0 safe, 4 attributes wiped.
     &gt; @cluster/wipe/regexp #1234/^..$
     Cluster wipe: 24 total objects, 0 no-match, 0 safe, 22 attributes wiped.
+    &gt; @cluster/wipe/owner Corum/#1234/va*
+    Cluster wipe: 24 total objects, 0 no-match, 0 safe, 4 attributes wiped.
   
   See Also: clusters, cluster functinos, cluster commands, &gt;
 
@@ -6140,6 +7780,10 @@ Generated: Wed Jan 13 04:15:48 2016
   This replaces the normal 'Contents:' and 'Carrying:' lists.  The variable
   is evaluated as it would a description or other similiar message.
   
+  If the target is @powered FORMATTING, then the dbref# list of items that
+  the target sees will be passed as %0 and the | separated list of names
+  will be passed as %1.
+    
   Examples:
     &gt; look
     A big Room
@@ -6155,7 +7799,7 @@ Generated: Wed Jan 13 04:15:48 2016
    
   The mush has to be configured to enable this to work.  '@list options'
   
-  See Also: @exitformat, @nameformat
+  See Also: @exitformat, @nameformat, invformat
   
 </PRE>
 <A HREF="#@cluster wipe">[PREV]</A>
@@ -6194,8 +7838,18 @@ Generated: Wed Jan 13 04:15:48 2016
   You can only copy from objects and attributes you control and only onto
   objects and attributes you control.  You have to specify a valid attribute
   to copy as well.  There are switches available for @cpattr.  These are:
-      /clear  - this erases the attribute on the originating object if
-                a copy was successful.
+  
+      /clear   - this erases the attribute on the originating object if
+                 a copy was successful.
+      /verbose - this will expand wildcard attributes that are copied from
+                 source.
+      /verify  - this will verify the destination attribute and not use
+                 default behavior (see below) if the attribute is not valid.
+  
+  Note: default behavior if the destination attribute is invalid is to use
+        the source attribute for the destination instead.  Using the /verify
+        switch overrides this behavior and will skip any invalid attribute
+        naming conventions. 
   
   You may specify the same object if you wish to move attributes on the same
   object.  You may specify wildcards for attributes.
@@ -6205,19 +7859,97 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#@cost">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@cpattr2">[NEXT]</A>
+<BR>
+<HR><A NAME="@cpattr2"><H3>@CPATTR2</H3></A><PRE>
+  Command: @cpattr (Continued 2 of 3)
+  Syntax:  @cpattr &lt;object&gt;/&lt;attribute&gt;=&lt;object1&gt;/&lt;attr1&gt;/&lt;attr2&gt;
+    
+      - This will copy the given attribute to 'attr1' and 'attr2' of the
+        the destination object.  You may specify from one to any number
+        of destination attributes.  You may use the /verify switch to
+        enforce destination attribute validation.
+  
+  Syntax: @cpattr &lt;object&gt;/&lt;attribute&gt;=&lt;object1&gt;,&lt;object2&gt;/&lt;attr1&gt;
+  
+      - This will copy the given attribute to an attribute of the same name
+        on the first object and copy it with the name 'attr1' on the second
+        object.  Any number of objects may be listed.  You may specify
+        multiple attributes per object as well.  You may use the /verify
+        switch to enforce destination attribute validation.
+   
+  Syntax: @cpattr &lt;object&gt;/&lt;wildcard&gt;=&lt;object1&gt;,...,&lt;objectX&gt;
+ 
+      - This will copy all attributes matching the wildcard to the destination
+        object(s).  You may specify from one to any number of destination
+        objects but must control the objects to copy the attributes.  You may
+        use the /verbose switch to expand wildcards to all the attributes that
+        matched, and you may use the /verify switch to validate attributes.
+        However, in this syntax, using /validate is redundant as source 
+        attributes will all be valid.
+   
+{ 'help cpattr3' for more }
+  
+</PRE>
+<A HREF="#@cpattr">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@cpattr3">[NEXT]</A>
+<BR>
+<HR><A NAME="@cpattr3"><H3>@CPATTR3</H3></A><PRE>
+  Command: @cpattr (Continued 3 of 3)
+  Syntax: @cpattr &lt;attribute&gt;=&lt;object&gt;/&lt;attrib&gt;,...
+  
+      - This copies the attribute on the ENACTOR to the target.  You can
+        specify multiple targets.  You may usethe /verify switch to enforce
+        attribute validation.
+  
+  Syntax: @cpattr/clear &lt;args&gt;
+   
+      - The clear switch is usable with all the previous mentioned @cpattr
+        commands. (help cpattr2 for help on these).  This will work just like
+        the prior, except this will also purge (remove) the attributes that
+        are being copied from the original object.  This acts basically like
+        a move.  You may use the /verify switch to verify on the /clear to
+        enforce clearing will not happen on bad destination naming.
+ 
+  @cpattr returns detailed information of objects copied from and to and
+  any attributes successfully copied.  With the /verify switch it will also
+  list any invalid attributes attempting to be copied.  /verbose will expand
+  all wildcards on source being copied.
+   
+  See Also: @mvattr, @set, &amp;
+  
+</PRE>
+<A HREF="#@cpattr2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@create">[NEXT]</A>
 <BR>
 <HR><A NAME="@create"><H3>@create</H3></A><PRE>
-  Command: @create &lt;name&gt; [=&lt;cost&gt;]
+  Command: @create[/&lt;switch&gt;] &lt;name&gt; [=&lt;cost&gt;]
+  
   Creates a thing with the specified name.  Creation costs either &lt;cost&gt;
   or 10 coins, whichever is greater. The value of a thing is proportional
   to its cost, specifically, value=(cost/5)-1.  The value may not be greater
   than 100, values that would be greater than 100 are rounded down to 100.
   
-  See Also: @destroy, TYPES OF OBJECTS
+  You may use the lastcreate() function to see the last thing @create'd
+  
+  Available switches:
+    /ansi - This combines @create with @extansi to essentially auto-ansify
+            the object that you create with &lt;name&gt;.  This follows 
+            permissions of @extansi.
+  
+  Examples:
+    &gt; @create MyObj
+    MyObj created as object #17508
+    &gt; @create/ansi [ansi(hy,MyObj)]
+    Ansi string entered for MyObj of 'MyObj'. ('MyObj' would be in yellow)
+    MyObj created as object #17508
+  
+  See Also: @destroy, TYPES OF OBJECTS, lastcreate()
   
 </PRE>
-<A HREF="#@cpattr">[PREV]</A>
+<A HREF="#@cpattr3">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@decompile">[NEXT]</A>
 <BR>
@@ -6239,6 +7971,9 @@ Generated: Wed Jan 13 04:15:48 2016
       /regexp  - use regular expression matching
       /tree    - Examine based on Penn trees using '`' as a separator.
       /tf      - allows prefix formatting for clients.
+      /noextra - when used in junction with /tf removes the additional
+                 flags and other information from attribute displaying.
+      /tags    - Show just @tag/adds
   
   Example: @decompile MyObject/attr*
            @decompile MyObject
@@ -6255,10 +7990,55 @@ Generated: Wed Jan 13 04:15:48 2016
             it will use that value (unevaluated) instead of the default.
          4. The default prefix for the /tf switch is: 'FugueEdit &gt; '
   
-  See Also: examine, look
+  See Also: examine, look, lattr(), cluster_lattr()
   
 </PRE>
 <A HREF="#@create">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@descformat">[NEXT]</A>
+<BR>
+<HR><A NAME="@descformat"><H3>@descformat</H3></A><PRE>
+  All NON-ACTION attributes allowed formatting are in: help attributes
+  
+  Attribute formatting can be accomplished multiple ways.  First, there is
+  a generic local 'format' for most @-attributes.  To process this format,
+  you need to set an attribute of the name 'format&lt;attr&gt;' on the target
+  (or parent, global parent, zone of the target. Use &lt;attr&gt;format if the
+  config parameter format_compatibility is enabled). If this attribute is
+  not found, it will then look at the global default parents for matching
+  attribute inheritance.  Any attribute that you wish to inherit default
+  pattern formatting must be set DEFAULT (attribute flag).  The desc is
+  passed into the formatting as '%0'.  Local formatting has priority
+  over global formatting.
+  
+  The DEFAULT attribute flag can be set in two ways.
+    1.  Individually on the attribute: @set #dbref/attribute=default
+    2.  Set it globally through two methods:
+        A.  Internal (built-in): @admin attr_access=attribute default  
+        B.  User defined:        @attribute/access attribute=default
+  
+  Option #1 will be cleared if or when the attribute is cleared.
+  Option #2-A can be done through the netrhost.conf file for permanence.
+  Option #2-B is always permanent and doesn't have to be re-issued.
+  
+  Note: Most RhostMUSHes will be configured to use &amp;FORMAT&lt;attr&gt;.
+        See '@list options system' to discover which method is in use.
+  
+  Examples:
+    &gt; @desc me=This is a test
+    &gt; @admin player_attr_default=123
+    &gt; @desc #123=-&lt; %0 &gt;-
+    &gt; lo me
+      -&lt; This is a test &gt;-
+    &gt; &amp;formatdesc me===&lt;%0&gt;==
+    &gt; lo me
+      ===&lt;This is a test&gt;===
+
+  See Also: ATTRIBUTES, ATTRIBUTE FLAG DEFAULT, @conformat, 
+            @exitformat, @nameformat, invformat
+
+</PRE>
+<A HREF="#@decompile">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@describe">[NEXT]</A>
 <BR>
@@ -6286,7 +8066,7 @@ Generated: Wed Jan 13 04:15:48 2016
             taste, @staste, smell, @ssmell
   
 </PRE>
-<A HREF="#@decompile">[PREV]</A>
+<A HREF="#@descformat">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@destroy">[NEXT]</A>
 <BR>
@@ -6346,6 +8126,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="@dig"><H3>@dig</H3></A><PRE>
   Command: @dig[/&lt;switches&gt;] &lt;name&gt; [= &lt;exitlist&gt; [, &lt;exitlist&gt;] ]
+  
   Creates a new room with the specified name and displays its number. This 
   command costs 10 coins. If the [= &lt;exitlist&gt;] option is used, an exit will
   be opened from the current room to the new room automatically.  If the
@@ -6363,10 +8144,32 @@ Generated: Wed Jan 13 04:15:48 2016
   'Kitchen' back to where you are.  Only the first Exit name is displayed in
   the Obvious exits list.
  
-  If you specify the /teleport switch, then you are @teleported to the
-  room after it is created and any exits are opened.
+  The following switches are available:
+    /teleport - You are @teleported to the room after it is created 
+                and any exits are opened.
+    /ansi     - Combines @dig with @extansi.  @extansi colorization is
+                applied to the room AND THE EXITS that you specify.  This
+                follows permissions of @extansi.
  
-  See Also: @destroy, @link, @open, LINKING, TYPES OF OBJECTS
+  You may use the lastcreate() function to see the last room that @dig'd.
+  
+  Examples:
+    &gt; @dig A Room=Exit In &lt;EI&gt;;exit in;ei,Exit Out &lt;EO&gt;;exit out;eo
+    A Room created with room number 17506.
+    Opened.
+    Linked.
+    Opened.
+    Linked.
+  
+    &gt; @dig/ansi [ansi(hb,Blue Room)]=[ansi(hb,Exit In)] [ansi(hr,&lt;EI&gt;)]
+    Ansi string entered for Blue Room of 'Blue Room'.  (This would be blue)
+    Blue Room created with room number 17503.
+    Ansi string entered for Exit In &lt;EI&gt; of 'Exit In &lt;EI&gt;'. (this would be red)
+    Opened.
+    Linked.
+  
+  See Also: @destroy, @link, @open, LINKING, TYPES OF OBJECTS,
+            lastcreate()
   
 </PRE>
 <A HREF="#@dfail">[PREV]</A>
@@ -6443,7 +8246,7 @@ Generated: Wed Jan 13 04:15:48 2016
     @dolist/delimit , {Frodo, Bilbo Baggins, Gandalf} = page ## = HELP!!!!
     @wait me=@emit Zapping Finished;@dolist/notify bob joe=@emit Zapped ##
   
-  See Also: iter(), parse(), list()
+  See Also: iter(), parse(), list(), inf()
   
 </PRE>
 <A HREF="#@dolist">[PREV]</A>
@@ -6619,6 +8422,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="@emit"><H3>@emit</H3></A><PRE>
   Command: @emit[/&lt;switches&gt;] &lt;message&gt;
+  
   Sends &lt;message&gt; to everyone in your current location without prefixing it by
   your character name.  You can also send the message to everyone in the room
   that contains the object you are inside with the /room switch.
@@ -6637,6 +8441,19 @@ Generated: Wed Jan 13 04:15:48 2016
   
   If both /here and /room switches are specified, the message is sent to both 
   places.  If neither is specified, /here is assumed.
+  
+  You may use two special attributes for pre and post processing of any
+  emits you receive.  These attributes will have substitutions evaluated
+  but will not evaluate functions.  If these attributes are set NO_COMMAND
+  then they will not be processed.
+    SPEECH_PREFIX  -- Contents will be evaluated before the @emit.
+    SPEECH_SUFFIX  -- Contents will be evaluated after the @emit.
+  
+  Both of these attributes handle three arguments.  These are:
+    %0 - The original @emit that triggered the attribute.
+    %1 - The date in the form MM/DD/YYYY
+    %2 - The time in the form HH:MM:SS
+    %3 - The dbref# of the player issuing the say/pose/emit (#-1 if spoofed)
  
   Some MUSHes may restrict the use of this command.
   
@@ -6725,6 +8542,11 @@ Generated: Wed Jan 13 04:15:48 2016
   This replaces the normal 'Obvious exits:'  listing.  The variable is
   evaluated as it would a description or other similiar message.
   
+  If the target is @powered FORMATTING, then the dbref# list of items that
+  the target sees will be passed as %0 and the | separated list of names
+  will be passed as %1.  Any dark exits that the target sees will be passed
+  as dbref#'s into %2, and their respective names | separated as %3.
+    
   Examples:
     &gt; look
     A big Room
@@ -6741,7 +8563,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   The mush has to be configured to enable this to work.  '@list options'
   
-  See Also: @conformat, @nameformat
+  See Also: @conformat, @nameformat, invformat
   
 </PRE>
 <A HREF="#@eval">[PREV]</A>
@@ -6757,6 +8579,10 @@ Generated: Wed Jan 13 04:15:48 2016
   to send the target who enters the exit to.  All exit messages are 
   evaluated and sent as well.
   
+  If the exit is @powered FULLTEL then the exit will be assumed to have 
+  full 'link' permission to any valid destination that exits would normally
+  be able to link to.  @power requires wizard access to set.
+     
   Example:
     &gt; @toggle MyExit=variable
     Set.
@@ -6775,6 +8601,11 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="@extansi"><H3>@extansi</H3></A><PRE>
   Command: @extansi[/&lt;switch&gt;] &lt;object&gt; = &lt;string&gt;
+  
+  Note: @name/ansi combines this feature with @name
+  
+  The cname() function (or %k substitution) will show the colorized/accented 
+  name.
   
   The @extansi command allows you to set multi-color names for an item.  This
   only effects contents, inventories, and the normal 'look'.  It will not
@@ -6829,7 +8660,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; @fail table = It's too heavy to lift!                            &lt;thing&gt;
     &gt; @fail doorway = The doorknob does not turn.                       &lt;exit&gt;
   
-  See Also: get, @afail, @ofail, FAILURE
+  See Also: get, @afail, @ofail, FAILURE, SHOWFAILCMD
   
 </PRE>
 <A HREF="#@extansi">[PREV]</A>
@@ -7008,6 +8839,39 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#@fsay">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@goto">[NEXT]</A>
+<BR>
+<HR><A NAME="@goto"><H3>@goto</H3></A><PRE>
+  Command: @goto[/label] &lt;textlabel&gt;
+ 
+  This command is similiar to @jump, in that it can be used to skip commands
+  following it in the queue, up to a certain point. Unlike @jump, this command
+  does not skip a specified amount of commands, but lets you skip all commands
+  until a specified, text-based label is reached.
+
+  This makes it, yes, quite similiar to classic GOTO commands from other
+  programming languages, with the exception that the @goto command only allows
+  you to skip *forward*, never backward. For backward jumps, see @rollback.
+
+  Example:
+    &gt; @wait 0={th a; th b;@goto foo;th c;th d;@goto/label foo;th e;th f}
+    a
+    b
+    e
+    f
+
+  Notes:
+    1) @goto'ing to a label that does not exist later in the code makes
+       @goto jump the entire remainder of the queue. This can actually be used
+       to skip out of loops and command queues entirely.
+    2) Labels can have a maximum of 16 characters. Any additional characters
+       used in a label's name get ignored.
+
+  See Also: @break, @assert, @skip, @force, @sudo, @switch, @rollback, @jump
+
+</PRE>
+<A HREF="#@gfail">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@grep">[NEXT]</A>
 <BR>
 <HR><A NAME="@grep"><H3>@GREP</H3></A><PRE>
@@ -7031,7 +8895,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @search, examine, get(), match(), grep()
   
 </PRE>
-<A HREF="#@gfail">[PREV]</A>
+<A HREF="#@goto">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@guild">[NEXT]</A>
 <BR>
@@ -7180,7 +9044,9 @@ Generated: Wed Jan 13 04:15:48 2016
     2
     4
   
-  See Also: @include, @force, @trigger, @skip, @break, @assert, @switch
+  See Also: @include, @force, @trigger, @skip, @break, @assert, @switch,
+            @jump, @rollback, @goto
+
 
 </PRE>
 <A HREF="#@idle">[PREV]</A>
@@ -7212,7 +9078,9 @@ Generated: Wed Jan 13 04:15:48 2016
     2
     4
   
-  See Also: @include, @force, @trigger, @skip, @break, @assert, @switch
+  See Also: @include, @force, @trigger, @skip, @break, @assert, @switch,
+            @jump, @rollback, @goto
+
 
 </PRE>
 <A HREF="#@if">[PREV]</A>
@@ -7283,7 +9151,7 @@ Generated: Wed Jan 13 04:15:48 2016
     inny2: bah!
     test2
   
-  See Also: @trigger, @force, @sudo, @skip
+  See Also: @trigger, @force, @sudo, @skip, @jump, @rollback, @goto
 
 </PRE>
 <A HREF="#@include">[PREV]</A>
@@ -7351,6 +9219,69 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#@infilter">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@invformat">[NEXT]</A>
+<BR>
+<HR><A NAME="@invformat"><H3>@invformat</H3></A><PRE>
+  Attribute: INVFORMAT
+  
+  This attribute is set via &amp;INVFORMAT.  There is no '@invformat'.
+  
+  This attribute when set will format the enctor's inventory.  If the enactor
+  is @powered FORMATTING (either directly or through a parent/zone chain),
+  then you may also use %0-%6 for arguments.  They are:
+    %0 - The space separated list of dbref#'s that would normally show 
+         up in inventory.
+    %1 - The '|' delimited list of names that would normally show up in
+         inventory.
+    %2 - The space separated list of exit dbref#'s that would normally 
+         show up in inventory.
+    %3 - The '|' delimited list of exit names that would normally show 
+         up in inventory.
+    %4 - The space separated list of dbref#'s that are toggled WIELDED
+    %5 - The space separated list of dbref#'s that are toggled WORN
+    %6 - The backpack name that is globally set. (@admin inventory_name)
+  
+  If the target is not @powered FORMATTING, then none of the % registers
+  will return a result.
+  
+  See Also: @conformat, @exitformat, @nameformat, attribute formatting
+
+</PRE>
+<A HREF="#@inprefix">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@jump">[NEXT]</A>
+<BR>
+<HR><A NAME="@jump"><H3>@jump</H3></A><PRE>
+  Command: @jump[/&lt;switch&gt;] &lt;amount&gt; [=&lt;evaluation&gt;]
+  
+  This command will skip ahead &lt;amount&gt; number of commands in the current
+  queue.  This effectively 'skips' execution of commands until the number
+  of commands are met.  If &lt;amount&gt; exceeds the number of commands in the
+  current queue, it will gracefully end the command sequence as if the
+  @jump was the last command in the sequence.
+  
+  You can not nest @jumps.  A value for &lt;amount&gt; that is zero or less than
+  zero will assume nothing to be @jump'd and the @jump will be ignored.
+  
+  You may specify an optionale valuation to be evaluated for the @jump
+  processing.  This is intended to execute commands whenever @jump is
+  called.  If a zero or less than zero value is passed, the &lt;evaluation&gt;
+  is not triggered.
+   
+  The following switches exist:
+    /queued  -- The &lt;evaluation&gt; passed to @jump is queued (default)
+    /inline  -- The &lt;evaluation&gt; passed to @jump is in-line.
+  
+  Example:
+    &gt; &amp;FOO me=$foo:say one;@jump 2;say two;say three;say four
+    You say &quot;one&quot;
+    You say &quot;four&quot;
+ 
+  See Also: @break, @assert, @skip, @force, @sudo, @switch, @rollback, @goto
+  
+</PRE>
+<A HREF="#@invformat">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@kill">[NEXT]</A>
 <BR>
 <HR><A NAME="@kill"><H3>@kill</H3></A><PRE>
@@ -7376,7 +9307,287 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: kill, @akill, @okill, BEING KILLED, IMMORTAL, ROYALTY
   
 </PRE>
-<A HREF="#@inprefix">[PREV]</A>
+<A HREF="#@jump">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@label">[NEXT]</A>
+<BR>
+<HR><A NAME="@label"><H3>@label</H3></A><PRE>
+  Command: @label/&lt;switch&gt; &lt;label&gt;=&lt;target&gt;:&lt;start&gt;,&lt;end&gt;
+  
+  The @label command is used to integrate the %_&lt;label&gt; system for debugging
+  and tracing seamlessly into code.  This effectively allows you to add,
+  remove, list and purge labels from attributes, cleanly, to allow a far
+  more enjoyable debugging experience.
+  
+  Quick overview of switches:
+    /add     - Adds the label in attribute
+    /try     - Shows what adding label would look in attribute
+    /delete  - Deletes label in attribute
+    /purge   - Purge all labels in attributes
+    /list    - Lists all specifics of attribute
+    /enable  - Enables label debugging of specific label
+    /disable - Disables label debugging of specific label
+    /color   - Sets (or wipes) specific label
+    /grep    - Sets (or wipes) grep patterning
+    /ruler   - works like ruler()
+  
+  For further explaination of label tracing:  help %_ 
+  For the complete list of variables used:    help %_var
+  
+  { see 'help @label2' to show syntax and detailing labels of switches }
+  { see 'help @label-example' to show step by step in working debug labels }
+
+</PRE>
+<A HREF="#@kill">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@labelMINUSexample">[NEXT]</A>
+<BR>
+<HR><A NAME="@labelMINUSexample"><H3>@label-example</H3></A><PRE>
+  Command: @label/&lt;switch&gt; &lt;label&gt;=&lt;target&gt;:&lt;start&gt;,&lt;end&gt;
+  
+  To use debug labels, you of course need to first set up some code.
+  
+  First, let's create an object:
+    &gt; @create MyObject
+    MyObject created as object #12345
+  
+  Now, let's set an attribute we want to debug on this object.
+    &gt; @set MyObject=inherit
+    Set.
+    &gt; &amp;CMD_TEST MyObject=$foo:@pemit %#=[add(1,1)][sub(2,2)][div(3,3)]
+    Set.
+  
+  We need to see the positioning of the sub() function in our attribute.
+  For this, we can use the nifty @label/ruler command (or ruler() function)
+      (NOTE: think ruler(myobject/cmd_test,60) also works)
+    &gt; @label/ruler myobject/cmd_test=60    
+             | ---------|10-------|20-------|30-------|40-------|50-------|60 |
+             | $foo:@pemit %#=[add(1,1)][sub(2,2)][div(3,3)]                  |
+      0      | 123456789012345678901234567890123456789012345678901234567890   |
+             | ---------|10-------|20-------|30-------|40-------|50-------|60 |
+  
+  Ok, for whatever reason, we want to debug just the sub() function in
+  this.  We will call our label 'watson' for giggles.  We have the start 
+  position of sub as 25, and the end of it as 35.  
+  It will place the labels AFTER the position specified, not before.
+  Let's issue a '/try' on this to make sure we got the positions right.
+    &gt; @label/add/try watson=myobject/cmd_test:25,35
+    @label: /add [/try] would have modified the attribute to look like:
+    $foo:@pemit %#=[add(1,1)]%_&lt;watson&gt;[sub(2,2)]%_&lt;-watson&gt;[div(3,3)]
+  
+  Ok, it looks good, let's add the label.
+    &gt; @label/add watson=myobject/cmd_test:25,35
+    @label: /add successfully added label 'watson' to attribute.
+   
+  { see 'help @label-example2' to continue with the tutorial }
+ 
+</PRE>
+<A HREF="#@label">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@labelMINUSexample2">[NEXT]</A>
+<BR>
+<HR><A NAME="@labelMINUSexample2"><H3>@label-example2</H3></A><PRE>
+  Command: @label/&lt;switch&gt; &lt;label&gt;=&lt;target&gt;:&lt;start&gt;,&lt;end&gt;
+  
+  Now, we have injected the debug label into our code, but we still need to
+  enable the label itself for debugging.  Let's select pink as the optional
+  color.  If you don't specify a color, it'll just highlight it.  You may
+  change or add/remove color from labels after the fact with the /color
+  option.  So don't worry if you don't feel colorful right now.
+    &gt; @label/enable myobject/watson=+pink
+    @label: /enable has enabled label 'watson' with color '+pink'
+  
+  Good show, we now have debugging enabled for the object for the sub()
+  function.  Let's try it out, shall we?
+    &gt; foo
+    MyObject(#12345) [watson]} 'sub(2,2)' -&gt; '0'
+    201
+  
+  Ok, let's see what label based debugging we have on the object itself.
+    &gt; @label/list myobject
+    @label: /list -- Global values set on target
+      Trace: watson
+      Attrib Color: [TRACE_COLOR_WATSON] +pink
+  
+  And now, for the attribute we actually did debugging on.
+    &gt; @label/list myobject/cmd_test
+    @label: /list of all labels for attribute
+      Enable:[   1] watson
+      Disable:[   1] watson
+      Attrib Color: [TRACE_COLOR_WATSON] +pink
+  
+  { see 'help @label-example3' to finish with the tutorial }
+  
+</PRE>
+<A HREF="#@labelMINUSexample">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@labelMINUSexample3">[NEXT]</A>
+<BR>
+<HR><A NAME="@labelMINUSexample3"><H3>@label-example3</H3></A><PRE>
+  Command: @label/&lt;switch&gt; &lt;label&gt;=&lt;target&gt;:&lt;start&gt;,&lt;end&gt;
+  
+  Ok, we've finished debugging.  You can do multiple things here.  Leaving the
+  debugging in is fine, if it's not enabled it won't have much overhead
+  overall.  The other is you can remove the label.
+  --: Disabling the label which removes the label from debugging
+    &gt; @label/disable myobject/watson
+    @label: /disable has disabled label 'watson'
+  --: Removing the label from the attribute entirely
+    &gt; @label/delete watson=myobject/cmd_test
+    @label: /del removed label 'watson'.  1 enable, 1 disable.
+  --: Purging all labels entirely from the attribute
+    &gt; @label/purge myobj/cmd_test
+    @label: /purge removed labels.  1 enable, 1 disable.
+            Removed: watson watson  (twice as it lists enable and disable)
+  
+  Let's test our command to make sure debugging is disabled.
+    &gt; foo
+    201
+  
+  As shown, this allows some great flexibility to debug code on the fly
+  with pinpoint accuracy of where and how you want things to debug.
+  
+  There are more advanced features that are not covered in this basic
+  tutorial as this is meant to just get you started.  For more help
+  please check the following help entries:
+  
+  --: help %_      -- This will give you the total overview of how the label
+                      debugging engine works and what it is doing under
+                      the hood.  You do not need ot use @label at all to
+                      make use of this, but @label is intended as an easy
+                      front end to make it less... challanging.
+  
+  --: help %_var   -- These are the variables that are set when you interface
+                      with the @label comamnd.  You may set these manually
+                      if you so desire.
+  
+  --: help @label  -- The main front-end engine for the entire label debug
+                      system.  While you don't have to use it, it does make
+                      things a bit easier.
+  
+  See Also: @label, %_, %_var, TRACE, ruler()
+
+</PRE>
+<A HREF="#@labelMINUSexample2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@label2">[NEXT]</A>
+<BR>
+<HR><A NAME="@label2"><H3>@label2</H3></A><PRE>
+  Command: @label/&lt;switch&gt; &lt;label&gt;=&lt;target&gt;:&lt;start&gt;,&lt;end&gt;  (CONTINUED)
+    
+  The following switches are available:
+  Syntax:  @label/add &lt;label&gt;=&lt;object&gt;/&lt;attr&gt;:&lt;start&gt;,&lt;end&gt;
+             - Add the label at the specified positions.  It requires two
+               positions since you will want a start and stop point for
+               each label.  You may use the strings START and END 
+               to specify the very beginning and the very end of the
+               attribute when adding labels.
+  
+  Syntax:  @label/add/try &lt;label&gt;=&lt;object&gt;/&lt;attr&gt;:&lt;start&gt;,&lt;end&gt;
+             - When used in junction with /add it will show you what
+               the new attribute would look like if it inserted the
+               labels.  It's useful to make sure you have the position
+               properly set.
+  
+  Syntax:  @label/del &lt;label&gt;=&lt;object&gt;/&lt;attr&gt;
+             - Remove the specified label (both start and stop points) 
+               from the attribute.  This removes all occurances.
+  
+  Syntax:  @label/purge &lt;object&gt;/&lt;attr&gt;
+             - Remove all labels (both start and stop points) from the
+               specified attribute.
+  
+  Syntax:  @label/list &lt;object&gt;[/&lt;attr&gt;]
+             - List all labels (both start and stop points) from the
+               specified attribute.  This will list all other label
+               dependant values of that target.  If you specify the
+               object without an attribute, it just lists all global
+               trace values for that object.
+  
+  { see 'help @label3' to continue syntax and detailing labels of switches  }
+  
+</PRE>
+<A HREF="#@labelMINUSexample3">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@label3">[NEXT]</A>
+<BR>
+<HR><A NAME="@label3"><H3>@label3</H3></A><PRE>
+  Command: @label/&lt;switch&gt; &lt;label&gt;=&lt;target&gt;:&lt;start&gt;,&lt;end&gt;  (CONTINUED)
+    
+  Syntax:  @label/enable &lt;object&gt;/&lt;label&gt; [=&lt;color|wipe&gt;]
+             - Will enable the given label to your trace output.  This
+               essentially adds it to the 'TRACE' attribute.  This can
+               optionally remove label-specified colors that are in
+               the form 'TRACE_COLOR_LABEL' where 'LABEL' is the label.
+  
+  Syntax:  @label/disable &lt;object&gt;/&lt;label&gt; [=&lt;color|wipe&gt;]
+             - Will remove the given label from your trace output.  This
+               removes the label from the 'TRACE' attribute.  This can
+               optionally remove label-specified colors that are in
+               the form 'TRACE_COLOR_LABEL' where 'LABEL' is the label.
+  
+  Syntax:  @label/color &lt;object&gt;/&lt;label|general&gt; = &lt;color|wipe&gt;
+             - This sets either the 'general' color defined by your
+               TRACE_COLOR attribute or the label specific color which
+               is defined by TRACE_COLOR_LABEL.  If you specify 'wipe'
+               it will delete the attribute.
+  
+  Syntax:  @label/grep &lt;object&gt;[/regexp] = &lt;string|wipe&gt;
+             - This will set your TRACE_GREP string or if you specify
+               'wipe' will remove it. If you specify the /regexp
+               option it will also set the attribute REGEXP.
+  
+  Syntax:  @label/ruler &lt;object&gt;/&lt;attribute&gt; [=&lt;ruler value&gt;]
+             - This will work just like ruler() does.  You may specify
+               an optional &lt;ruler value&gt;.  The rule value must be between
+               0 and 100 and must be a multiple of 10.  The default value
+               is '60' which fits inside a 79 column width.
+  
+  { see 'help @label4' for examples }
+
+</PRE>
+<A HREF="#@label2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@label4">[NEXT]</A>
+<BR>
+<HR><A NAME="@label4"><H3>@label4</H3></A><PRE>
+  Command: @label/&lt;switch&gt; &lt;label&gt;=&lt;target&gt;:&lt;start&gt;,&lt;end&gt; (CONTINUED)
+    
+  NOTE:  Any label that starts with a '-' (eg: %_&lt;-foo&gt;) is an end/disable
+         label.  This would stop the tracing.  This is explained more in
+         'help %_'
+   
+  Examples:
+    &gt; @vd me=[add(1,1)][sub(2,2)][div(3,3)]
+    Set.
+    &gt; @label/ruler me/vd=60
+           | ---------|10-------|20-------|30-------|40-------|50-------|60 |
+           | [add(1,1)][sub(2,2)][div(3,3)]                                 |
+    0      | 123456789012345678901234567890123456789012345678901234567890   |
+           | ---------|10-------|20-------|30-------|40-------|50-------|60 |
+    &gt; @label/add/try test=me/vd:10,20
+    @label: /add [/try] would have modified the attribute to look like:
+    [add(1,1)]%_&lt;test&gt;[sub(2,2)]%_&lt;-test&gt;[div(3,3)]
+    &gt; @label/add test=me/vd:10,20
+    @label: /add successfully added label 'test' to attribute.
+    &gt; @label/del test=me/vd
+    @label: /del removed label 'test'.  1 enable, 1 disable.
+    &gt; @label/del test=me/vd
+    @label: /del could not find label 'test' in attribute.
+    &gt; @label/add test=me/vd:10,20
+    @label: /add successfully added label 'test' to attribute.
+    &gt; @label/list me/vd   (label starts are green, ends are red)
+    @label: /list of all labels for attribute
+            Enable:[   1] test
+           Disable:[   1] test
+    &gt; @label/purge me/vd  (label starts are green, ends are red)
+    @label: /purge removed labels.  1 enable, 1 disable.
+            Removed: test test
+  
+  See Also: %_, SUBSTITUTIONS, TRACE, trace(), @label, ruler()
+
+</PRE>
+<A HREF="#@label3">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@lalias">[NEXT]</A>
 <BR>
@@ -7402,7 +9613,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @ealias, enter, leave
   
 </PRE>
-<A HREF="#@kill">[PREV]</A>
+<A HREF="#@label4">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@last">[NEXT]</A>
 <BR>
@@ -7501,6 +9712,11 @@ Generated: Wed Jan 13 04:15:48 2016
   performed on the resulting text.  The result of that substitution is 
   returned as the function result.
   
+  Any function that starts with a _ that matches a hardcode function you can
+  use to override the hardcoded function with sandbox.
+  Example:  @lfunction _ladd=me/my_add_function
+            say sandbox([add(1,1)] is my own add function,add,1)
+  
   You may only have 20 localized functions defined.
   
   The following switches exist:
@@ -7531,7 +9747,7 @@ Generated: Wed Jan 13 04:15:48 2016
   The function definitions created by @lfunction are not stored in the database
   so they need to be re-created each time the RhostMUSH is started.  It is
   recommended that the Startup attribute for the target include code to set up
-  all global functions.  The privalaged and preserved, protect, and notrace 
+  all global functions.  The privileged and preserved, protect, and notrace 
   switches may be combined.
    
   All global functions have precedence over local functions.  All built-in
@@ -7552,7 +9768,7 @@ Generated: Wed Jan 13 04:15:48 2016
              @lfunction/min myfunction=3
   
   Note: With the /list switch, the following letters represent the following:
-             W - privalaged
+             W - privileged
              p - preserved
              + - protected
              t - notrace
@@ -7569,7 +9785,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Example:
      &gt; @function/del #12345_myfunction
   
-  See Also: u(), streval(), eval()
+  See Also: u(), streval(), eval(), sandbox(), subeval()
  
 </PRE>
 <A HREF="#@lfunction">[PREV]</A>
@@ -7626,31 +9842,44 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Lists information from internal databases.  Information is available
   about the following options:
-    attributes      - Valid object attributes.
-    commands        - Commands that you may use (excluding the 
-                      attribute-setting commands as well as any exits, and
-                      $-commands available).
-    costs           - Lists the costs associated with many commands and
-                      actions.
-    default_flags   - Lists the flags that new objects receive by default
-                      when created.
-    flags           - Lists the name and letter of all the flags.
-    functions       - Lists all the available functions.
-    options         - Lists several global options and limits.
-        |             You may specify subtopics: boolean, values, config, 
-        |             mail, and system
-        +-&gt; boolean - Subtopic option for listing boolean values
-        +-&gt; values  - Subtopic option for listing int values
-        +-&gt; config  - Subtopic option for listing config options
-        +-&gt; mail    - Subtopic option for listing mail options
-        +-&gt; system  - Subtopic option for listing system settings
+    attributes       - Valid object attributes.
+    commands         - Commands that you may use (excluding the 
+                       attribute-setting commands as well as any exits, and
+                       $-commands available).
+    costs            - Lists the costs associated with many commands and
+                       actions.
+    default_flags    - Lists the flags that new objects receive by default
+                       when created.
+    default_toggles  - Lists the toggles that new objects receive by default
+                       when created.
+    flags            - Lists the name and letter of all the flags.
+    functions        - Lists all the available functions.
+    options          - Lists several global options and limits.
+        |              You may specify subtopics: boolean, values, config, 
+        |              mail, and system
+        +-&gt; boolean  - Subtopic option for listing boolean values (*)
+        +-&gt; config   - Subtopic option for listing config options 
+        +-&gt; convtime - Shows all formats convtime() handles
+        +-&gt; display  - Gives detailed display for a config option
+        +-&gt; mail     - Subtopic option for listing mail options (*)
+        +-&gt; mysql    - Shows if MySQL is enabled or disabled
+        +-&gt; system   - Subtopic option for listing system settings
+        +-&gt; values   - Subtopic option for listing int values (*)
+        
     switches        - Lists what commands support switches and the switches
                       that they do support.
     toggles         - Lists toggles supported by the mush.
+    mail_globals    - Lists the default mail global parameters
+    guest_names     - List the guest names (if defined)
+    rlevels         - List all the reality levels enabled
+    totems          - Lists the name of all the totems. (wildcard supported)
   
   The information provided by the @list command is definitive, as it reads
   the internal tables to produce the information it displays.  Specifying
   @list with no argument lists the options you may use.
+  
+  Options with '(*)' beside it allow additional arguments for wildcard
+  filtering.
   
 {help @list2 for a listing of subtopics}
   
@@ -7674,8 +9903,9 @@ Generated: Wed Jan 13 04:15:48 2016
                mail      - show all current hardcoded mail configuration.
   
   Examples:
-    &gt; @list options boolean     (For first page - default)
-    &gt; @list options boolean 2   (For second page) 
+    &gt; @list options boolean            (For first page - default)
+    &gt; @list options boolean 2          (For second page) 
+    &gt; @list options boolean *switch*   (For all values that contain 'switch')
   
   See Also: help, news
   
@@ -7687,7 +9917,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="@listen"><H3>@listen</H3></A><PRE>
   Command: @listen[/&lt;switch&gt;] &lt;object&gt; = &lt;string&gt;
   Attribute: Listen
- 
+   
   This attribute contains a wildcard pattern that the object listens for.
   Anything spoken, posed, emitted, or whispered in the room that &lt;object&gt; is
   in, as well as messages resulting from using objects (such as Opay and Succ
@@ -7700,15 +9930,17 @@ Generated: Wed Jan 13 04:15:48 2016
   have a chance to match it.  Objects whose Listen attribute is set to
   anything will be listed when a @sweep command is run by someone in the
   same room.
- 
+   
   If the @listen pattern is matched, then the object's contents will
   hear the message also, prefixed by the text in @inprefix if it is set.  Any
   text that matches any pattern specified in @infilter will not be sent to
   the contents.
- 
+   
   Optional switches are /quiet to suppress output or /noisy to give 
   verbose output.
- 
+  
+  You may specify command based listens with the ^ syntax (help ^-listens)  
+  
   Example: @listen camera = * has arrived.
            @ahear camera = @va me = %va %0
   
@@ -7753,7 +9985,12 @@ Generated: Wed Jan 13 04:15:48 2016
          help @lock type &lt;lock&gt; - give detailed help on the specific lock.
          help userlocks   - a special way to define user-defined locking.
   
-  See Also: @chown, @unlock
+  Note: For evaluation locks, %0 is passed as a boolean (0/1) on if the lock
+        is a $command match or a ^listen match.  %1 will be passed as the
+        *unevaluated* conditional that the eval lock is matching against.
+  
+  See Also: @unlock, @lset, @chown, lock(), elock(), testlock(), 
+            lockencode(), lockdecode(), lockcheck()
   
 </PRE>
 <A HREF="#@listmotd">[PREV]</A>
@@ -7883,6 +10120,10 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; @lock divisible_by_five_club = checkdiv/0
     &gt; &amp;checkdiv divisible_by_five_club = [mod(mid(%#,2,20),5)]
     Only objects whose db-number is divisible by 5 may pass.
+  
+  Special passing:
+    %1 will be passed as the key that eval locks will match against.  This
+       is an unevaluated string.
   
   See Also: @lock attributes
   
@@ -8136,7 +10377,7 @@ Generated: Wed Jan 13 04:15:48 2016
      player passes the lock, that room will be considered NOT DARK for that
      player.  If the lock does not exist, the dark room will be treated
      normally.  Please note that all items inside that room that are dark
-     are treated on a seperate basis for the DarkLocks.
+     are treated on a separate basis for the DarkLocks.
   
 </PRE>
 <A HREF="#@lock type chownlock">[PREV]</A>
@@ -8443,6 +10684,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="@lock type twinklock"><H3>@lock type TwinkLock</H3></A><PRE>
   Lock Type: TwinkLock
   Syntax   : @lock/twink &lt;target&gt;=&lt;key&gt;
+  Special  : %w -- The target that is being checked in a @lock/twink
   
   Rooms, Objects, Exits:
      The twinklock is a unique lock in that it will allow anyone who passes
@@ -8452,7 +10694,9 @@ Generated: Wed Jan 13 04:15:48 2016
      or anything else on the object.  It is generally wise to have objects
      twinklocked be !INHERIT so that abuse will be limited.  If the lock
      does not exist, then NO ONE other than the owner will be able to modify
-     that target.
+     that target.  TwinkLock allows you to control @toggles, @name, @alias
+     and attribute control (@mvattr/@cpattr/@set (attributes)/&amp;/etc).  It 
+     does NOT however allow you to set/remove locks or flags.
   
   Players:
      Players are special in that just like Rooms, Objects, and Exits, it
@@ -8461,8 +10705,17 @@ Generated: Wed Jan 13 04:15:48 2016
      This means if you pass the twinklock of a player, you automatically
      pass that lock on everything that player owns.
   
+     Example Lock to block player editing but allows all other owned:
+     &gt; say num(player)
+     You say &quot;#123&quot;
+     &gt; &amp;CANUSE Player=[and(match(v(list),%#),!match(%w,#123))]
+     &gt; &amp;LIST Player=#5 #7 #9 #11         (list of target dbref#'s allowed)
+     &gt; @lock/twink player=CANUSE/1
+  
   Special note:  You can set the item NOMODIFY if you want it to just have
-                 examine privalages and not modify privalages.
+                 examine privileges and not modify privileges.  You may
+                 also customize your @lock/twink to check %w against the
+                 target player dbref# with a complex lock.
   
 </PRE>
 <A HREF="#@lock type tportlock">[PREV]</A>
@@ -8556,6 +10809,683 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#@lock type zonetolock">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/chownlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/chownlock"><H3>@lock/chownlock</H3></A><PRE>
+  Lock Type: ChownLock
+  Syntax   : @lock/chown &lt;target&gt;=&lt;key&gt;
+  
+  Rooms, Objects, Exits:
+    This controls who may @chown an item if it was previously set with
+    the CHOWN_OK flag.  If this lock does not exist, then anyone may
+    chown an item set CHOWN_OK.  This lock works on all types except
+    players who always own themselves.
+  
+  Players:
+    This lock is meaningless for players, as is the CHOWN_OK flag.
+  
+</PRE>
+<A HREF="#@lock type zonewizlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/darklock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/darklock"><H3>@lock/darklock</H3></A><PRE>
+  Lock Type: DarkLock
+  Syntax   : @lock/dark &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Players, Exits:
+     This controls who may see the item if it is DARK at the location they
+     look at.  If they already had control of the object, this lock is
+     meaningless.  If the lock does not exist, DARK items are treated
+     normally.
+  
+  Rooms:
+     This controls the darkness level of the room to the player.  If the
+     player passes the lock, that room will be considered NOT DARK for that
+     player.  If the lock does not exist, the dark room will be treated
+     normally.  Please note that all items inside that room that are dark
+     are treated on a separate basis for the DarkLocks.
+  
+</PRE>
+<A HREF="#@lock/chownlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/defaultlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/defaultlock"><H3>@lock/defaultlock</H3></A><PRE>
+  Lock Type: Defaultlock 
+  Syntax   : @lock &lt;target&gt;=&lt;key&gt;
+             @lock/default &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Players:
+     This lock specifies who is able to pick up (GET/TAKE) the target.  If
+     you do not pass the lock, you will not be able to pick up the target.
+     If this lock is not set, then anyone will be able to pick it up.
+  
+  Rooms:
+     Controls if the player is able to see the SUCC (@succ) or FAIL (@fail)
+     messages of the room when they look at the room.
+  
+  Exits:
+     Controls who may pass through the exit to it's destination.  If you
+     do not pass the lock, you will not be able to go through that exit.
+     An exit with no lock is freely accessable.
+  
+</PRE>
+<A HREF="#@lock/darklock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/droplock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/droplock"><H3>@lock/droplock</H3></A><PRE>
+  Lock Type: DropLock
+  Syntax   : @lock/drop &lt;target&gt;=&lt;key&gt;
+  
+  Rooms, Exits, Players, Objects:
+     This controls who may drop the target item.  If you do not pass the 
+     lock you will be unable to drop the item.  If no lock exists, you will
+     be able to drop the target freely.
+  
+  
+</PRE>
+<A HREF="#@lock/defaultlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/droptolock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/droptolock"><H3>@lock/droptolock</H3></A><PRE>
+  Lock Type: DropToLock
+  Syntax   : @lock/dropto &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Rooms:
+     This controls who may drop items AT the location.  If the player
+     passes the lock, they will be permitted to drop items at that location.
+     If they do not pass the lock, they will be forbidden to drop anything
+     at that location.  If the lock does not exist, dropping items will
+     behave normally (based on permissions and any DropLocks).
+  
+  Exits, Players:
+     This lock is meaningless on players and exits.
+  
+</PRE>
+<A HREF="#@lock/droplock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/enterlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/enterlock"><H3>@lock/enterlock</H3></A><PRE>
+  Lock Type: EnterLock
+  Syntax   : @lock/enter &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Players:
+     This lock specifies who will be able to enter the target when the 
+     ENTER_OK flag is set on it.  If you do not pass the lock, you will be
+     unable to enter the target.  If the lock does not exist and the 
+     ENTER_OK flag is set, then anyone will be able to enter it.
+  
+  Rooms:
+     This lock specifies who may enter the room from an object (or container)
+     inside that room.  If they do not pass the room's EnterLock, then they
+     will be unable to leave that object.
+  
+  Exits:
+     This lock is meaningless for exits.
+  
+</PRE>
+<A HREF="#@lock/droptolock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/getfromlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/getfromlock"><H3>@lock/getfromlock</H3></A><PRE>
+  Lock Type: GetFromLock
+  Syntax   : @lock/getfrom &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Players, Rooms:
+     This controls who may get things AT the location.  If the target passes
+     the lock, it will be able to get items while at that location.  If they
+     do not pass the lock, they will be forbidden to get anything while at
+     that location.  If the lock does not exist, getting items in that 
+     location behaves normally (based on permissions and locks on items).
+     This checks first the lock at the enactor's location, THEN it checks
+     the lock at the target location.  If either of those locks are not passed
+     then the target may not be gotten by the enactor.
+  
+  Exits:
+     This lock is meaningless on exits.
+  
+</PRE>
+<A HREF="#@lock/enterlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/givelock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/givelock"><H3>@lock/givelock</H3></A><PRE>
+  Lock Type: GiveLock
+  Syntax   : @lock/give &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Players:
+     This lock specifies who may give away the target.  If you do not pass
+     the lock, you will be unable to give the object to anything or anyone.
+     If the lock does not exist, then it can be given away freely.
+  
+  Exits, Rooms:
+     This lock is meaningless on rooms and exits.
+  
+</PRE>
+<A HREF="#@lock/getfromlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/givetolock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/givetolock"><H3>@lock/givetolock</H3></A><PRE>
+  Lock Type: GiveToLock
+  Syntax   : @lock/giveto &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Players, Rooms:
+     This controls who may give things AT the location.  If the target passes
+     the lock, it will be able to give items while at that location.  If they
+     do not pass the lock, they will be forbidden to give anything (except 
+     money) at that location.  If the lock does not exist, giving items in 
+     that location behaves normally (based on permissions and any GiveLocks).
+  
+  Exits:
+     This lock is meaningless on exits.
+  
+</PRE>
+<A HREF="#@lock/givelock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/leavelock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/leavelock"><H3>@lock/leavelock</H3></A><PRE>
+  Lock Type: LeaveLock
+  Syntax   : @lock/leave &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Players:
+     This lock specifies who may leave the target.  If you do not pass the
+     lock, you will be unable to leave the object (via the LEAVE command).
+     If the lock does not exist, then it can be left freely.
+  
+  Exits, Rooms:
+     This lock is meaningless on rooms and exits.
+  
+</PRE>
+<A HREF="#@lock/givetolock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/linklock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/linklock"><H3>@lock/linklock</H3></A><PRE>
+  Lock Type: LinkLock
+  Syntax   : @lock/link &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Players, Rooms:
+     This lock specifies who may link soemthing TO the location if that
+     location is set LINK_OK.  If that location is set ABODE, then that
+     target may also be set as a HOME.  If there is no lock, it will be
+     able to be linked to freely.
+  
+  Exits:
+     This lock is meaningless on exits.
+  
+</PRE>
+<A HREF="#@lock/leavelock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/openlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/openlock"><H3>@lock/openlock</H3></A><PRE>
+  Lock Type: OpenLock
+  Syntax   : @lock/open &lt;target&gt;=&lt;key&gt;
+  
+  Objects, Rooms:
+     This controls who may open exits AT the location.  If the player
+     passes the lock, they will be allowed to open an exit out from that
+     room.  If the lock does not exist, permission to open exits at
+     that location will behave normally.
+  
+  Players, Exits:
+     This lock is meaningless on players and exits.
+  
+</PRE>
+<A HREF="#@lock/linklock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/pagelock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/pagelock"><H3>@lock/pagelock</H3></A><PRE>
+  Lock Type: PageLock
+  Syntax   : @lock/page &lt;target&gt;=&lt;key&gt;
+  
+  Players:
+     This lock determins who is allowed to page you.  If they do not pass the
+     lock, they will be unable to page you and receive your REJECT message
+     (see help on @reject).  If there is no lock, then people can page you
+     freely.
+  
+  Rooms, Exits, Objects:
+     This lock is meaningless on rooms, exits, and objects.
+  
+</PRE>
+<A HREF="#@lock/openlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/parentlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/parentlock"><H3>@lock/parentlock</H3></A><PRE>
+  Lock Type: ParentLock
+  Syntax   : @lock/parent &lt;target&gt;=&lt;key&gt;
+  
+  Players, Rooms, Exits, Objects:
+     This lock determins who may parent (@parent) an item to the target.  If
+     you do not pass the lock, you will be unable to parent something to it.
+  
+</PRE>
+<A HREF="#@lock/pagelock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/receivelock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/receivelock"><H3>@lock/receivelock</H3></A><PRE>
+  Lock Type: ReceiveLock
+  Syntax   : @lock/receive &lt;target&gt;=&lt;key&gt;
+  
+  Players, Objects:
+     This determins who may give things to the target.  If you do not pass
+     the lock, you will be unable to give anything to the target.  If the
+     lock does not exist, you may give things to it freely.  Players need
+     to be ENTER_OK to be given things.
+  
+  Rooms, Exits:
+     This lock is meaningless on exits and rooms.
+  
+</PRE>
+<A HREF="#@lock/parentlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/speechlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/speechlock"><H3>@lock/speechlock</H3></A><PRE>
+  Lock Type: SpeechLock
+  Syntax   : @lock/speech &lt;target&gt;=&lt;key&gt;
+  
+  Rooms, Players, Objects:
+     This defines who may talk at the target location.  If you do not pass
+     the lock, you will be unable to use any type of communication at that
+     location.  This includes, say, pose, @emit, @oemit, and the like.
+     Admin level 4 and higher override this lock automatically.  If the lock
+     does not exist, you will be able to speak freely.
+  
+  Exits:
+     This lock is meaningless on exits.
+  
+</PRE>
+<A HREF="#@lock/receivelock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/teloutlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/teloutlock"><H3>@lock/teloutlock</H3></A><PRE>
+  Lock Type: TeloutLock
+  Syntax   : @lock/telout &lt;target&gt;=&lt;key&gt;
+  
+  Rooms, Players, Objects:
+     This defines who is allowed to teleport OUT of the target location.  If
+     you are unable to pass the lock, you will be unable to @teleport out. 
+     Keep in mind that 'home' overrides this lock.  If the lock does not
+     exist, you may @teleport out freely.  If a room has a TeloutLock, you
+     will be unable to teleport out of objects inside it unless you pass it.
+  
+  Exits:
+     This lock is meaningless on exits.
+  
+</PRE>
+<A HREF="#@lock/speechlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/tportlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/tportlock"><H3>@lock/tportlock</H3></A><PRE>
+  Lock Type: TportLock
+  Syntax   : @lock/tport &lt;target&gt;=&lt;key&gt;
+  
+  Rooms, Objects:
+     This controls who may teleport INTO the target location ONLY if the
+     JUMP_OK flag is set on the room.  If you do not pass the lock, you will
+     be unable to @teleport into the room.  If the room is JUMP_OK and there
+     is no lock, you may @teleport there freely.
+  
+  Players, Exits:
+     This lock is meaningless on players and exits.
+  
+</PRE>
+<A HREF="#@lock/teloutlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/twinklock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/twinklock"><H3>@lock/twinklock</H3></A><PRE>
+  Lock Type: TwinkLock
+  Syntax   : @lock/twink &lt;target&gt;=&lt;key&gt;
+  Special  : %w -- The target that is being checked in a @lock/twink
+  
+  Rooms, Objects, Exits:
+     The twinklock is a unique lock in that it will allow anyone who passes
+     the lock control over that object.  THIS CAN BE A SECURITY RISK SO BE
+     CAREFUL!  The user who passes the lock will ONLY be able to modify/set
+     attributes.  They will be unable to set, modify, or remove flags, locks,
+     or anything else on the object.  It is generally wise to have objects
+     twinklocked be !INHERIT so that abuse will be limited.  If the lock
+     does not exist, then NO ONE other than the owner will be able to modify
+     that target.  TwinkLock allows you to control @toggles, @name, @alias
+     and attribute control (@mvattr/@cpattr/@set (attributes)/&amp;/etc).  It 
+     does NOT however allow you to set/remove locks or flags.
+  
+  Players:
+     Players are special in that just like Rooms, Objects, and Exits, it
+     allows direct modification of them as a player, but also in the case
+     of player, the TwinkLock is special in that it's an inheritable lock.
+     This means if you pass the twinklock of a player, you automatically
+     pass that lock on everything that player owns.
+  
+     Example Lock to block player editing but allows all other owned:
+     &gt; say num(player)
+     You say &quot;#123&quot;
+     &gt; &amp;CANUSE Player=[and(match(v(list),%#),!match(%w,#123))]
+     &gt; &amp;LIST Player=#5 #7 #9 #11         (list of target dbref#'s allowed)
+     &gt; @lock/twink player=CANUSE/1
+  
+  Special note:  You can set the item NOMODIFY if you want it to just have
+                 examine privileges and not modify privileges.  You may
+                 also customize your @lock/twink to check %w against the
+                 target player dbref# with a complex lock.
+  
+</PRE>
+<A HREF="#@lock/tportlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/uselock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/uselock"><H3>@lock/uselock</H3></A><PRE>
+  Lock Type: UseLock
+  Syntax   : @lock/use &lt;target&gt;=&lt;key&gt;
+  
+  Rooms, Objects, Exits, Players:
+     This specifies who may use the object.  Using the object includes giving
+     the object money to trigger PAY/COST (@pay/@cost) attributes, being able 
+     to USE (@use) the object, triggering any type of listen command or being
+     able to use any type of macros (or $-command) commands.  If you do not
+     pass the lock, you will be unable to use that object.  If the lock does
+     not exist, then anyone will be able to use that object.
+  
+  Special:  %0 is passed into evaluation locks for uselocks.  The values exist:
+     0 -- Default.  Neither a $command or a ^listen (like when you do 'use')
+     1 -- $command was triggered
+     2 -- ^listen was triggered
+    
+  See Also: SHOWFAILCMD
+ 
+</PRE>
+<A HREF="#@lock/twinklock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/userlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/userlock"><H3>@lock/userlock</H3></A><PRE>
+  Lock Type: UserLock
+  Syntax   : @lock/user &lt;target&gt;=&lt;key&gt;
+  
+  Rooms, Objects, Exits, Players:
+     This is a dummy lock that has no special purpose inside the MUSH.  This
+     is meant entirilly for a user-preference.  This is to be used if you 
+     have need to set up a lock-mechanism without having to 'block' locks
+     on that particular target.
+  
+  Special Enhancement:  If enabled, this lock also serves as a reality level
+     lock.  This in effect allows special 'tweeking' of reality levels so
+     that you may specify additional passes through the reality  The target
+     must be set CHKREALITY for this lock to work.  The CHKREALITY toggle is
+     only settable by WIZARD and higher.  Depending on the current 
+     configuration of the locktype (@list options to see) the lock will check 
+     if enactor passes lock on target, or if target passes lock on enactor.  It
+     will also check if the values are anded or or'd.  The following options 
+     exist:
+               0 - Reality level or'd with lock pass based on target
+               1 - Reailty level or'd with lock pass based on enactor
+               2 - Reality level and'd with lock fail based on target
+               3 - Reality level and'd with lock fail based on enactor
+     
+     In condition 2 and 3, if the lock doesn't exist, it assumes pass 
+     automatically.
+  
+</PRE>
+<A HREF="#@lock/uselock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/zonetolock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/zonetolock"><H3>@lock/zonetolock</H3></A><PRE>
+  Lock Type: ZoneToLock
+  Syntax   : @lock/zoneto &lt;target&gt;=&lt;key&gt;
+  
+  Rooms, Objects, Exits, Players:
+     This allows people who pass the lock to be able to @zone items to your
+     zone.  This works similiar to the ParentLock with regards to @parents.
+     If the lock does not exist, only those who control the item may @zone it.
+  
+</PRE>
+<A HREF="#@lock/userlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/zonewizlock">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/zonewizlock"><H3>@lock/zonewizlock</H3></A><PRE>
+  Lock Type: ZoneWizLock
+  Syntax   : @lock/zonewiz &lt;target&gt;=&lt;key&gt;
+  
+  Rooms, Objects, Exits, Players:
+     This allows people the ability to control and modify anything within that
+     zone's realm.  If you pass the lock you will have control, otherwise 
+     it will be off limits to you.  If the lock does not exist, only those
+     who have power over the target may be able to control and modify it.
+     The ZoneWizLock allows the target to modify/examine anything that is
+     in that zone as long as it is not WIZARD (bitlevel 5) or higher owned.
+     If it is WIZARD or higher owned, then it follows normal permissions on
+     that target to what they can do with it.
+  
+</PRE>
+<A HREF="#@lock/zonetolock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lset">[NEXT]</A>
+<BR>
+<HR><A NAME="@lset"><H3>@lset</H3></A><PRE>
+  Command: @lset[/&lt;switches&gt;] &lt;object&gt;[/&lt;lock&gt;] [=&lt;permission&gt;]
+  
+  The default &lt;lock&gt; if not specified will be the DefaultLock.  An alias
+  for DefaultLock is BasicLock.
+  
+  This function will display or set/unset a &lt;permission&gt; on a lock.  The
+  following permissions are available (depending on your permission to set):
+    god         -- Only #1 is allowed to set/unset this lock
+    immortal    -- Only immortal or higher is allowed ot set/unset this lock
+    wizard      -- Only wizard or higher is allowed to set/unset this lock
+    councilor   -- Only councilor or higher is allowed to set/unset this lock
+    architect   -- Only architect or higher is allowed to set/unset this lock
+    guildmaster -- Only guildmaster or higher is allowed to set/unset this lock
+    hidden      -- This lock is hidden based on above permission levels
+    no_inherit  -- if the @admin config parameter parentable_control_lock is 
+                   enabled, stops the lock from being inherited to its children
+    visual      -- Makes the lock globally visible
+    pinvisible  -- Hides the lock but makes it fetchable/checkable
+    no_clone    -- Lock is not copied with a @clone
+    
+  The following &lt;switches&gt; are available:
+    /list       -- List the special permissions on the specified target lock.
+  
+  Examples:
+    &gt; @lset/list *Tester/default
+    @lset: [DefaultLock] on Tester(#123): No additional flags set.
+    &gt; @lset *Tester/default=no_inherit
+    @lset: [DefaultLock] set NO_INHERIT on Tester(#123)
+    &gt; @lset/list *Tester/default
+    @lset: [DefaultLock] on Tester(#123): no_inherit
+    
+  See Also: @lock, @unlock, @set, lock(), elock(), lset(), set()
+ 
+</PRE>
+<A HREF="#@lock/zonewizlock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@ltag">[NEXT]</A>
+<BR>
+<HR><A NAME="@ltag"><H3>@ltag</H3></A><PRE>
+  Command: @ltag[&lt;/switch&gt;] &lt;args&gt;
+  
+  This command gets used to manage and list the named tags of Rhost's tag
+  system (see wizhelp tags).  This is your local tag list.  You may only
+  have 5 tags maximum per dbref#.  If the global tags on the target dbref#
+  exceeds 5 (which it can), then you may no longer set local tags on it.
+  
+  The following switches exist to @ltag:
+    /list   - List your localized tags. (allows search strings)
+    /add    - add a localized tag to the dbref# (permanent until removed)
+    /remove - remove the local named tag.
+  
+  If a tag does not exist, #-1 gets returned.  When an item is destroyed, 
+  the tags will be destroyed with the item.
+  
+  With the /list switch, you may specify wildcards for the search pattern. 
+  
+  The following sanity checks are performend for tags:
+  
+  * Tagnames cannot be more than 30 characters in length
+  * Tagnames cannot cointain whitespace.
+  * Tags need to be supplied with a valid, existing object's #dbref on
+    creation.  This object you must own or control in some manner.
+  * Up to 5 tags can reference the same #dbref.  If global tags exceed
+    this number, local tags can no longer be assigned.
+  * Unicode is valid in tagnames!
+  * On destruction of an object, all referencing tags get also removed.
+  * Global tags have precidence over local tags.
+  
+  Examples:
+    &gt; think %#
+      You say &quot;#123&quot;
+    &gt; @tag/add samson=#123
+      Tag added.
+    &gt; @tag/add test=#123
+      Tag added.
+    &gt; @ltag/list
+                  Tag Name              | Personal | #dbref  
+    ====================================|==========|==========
+       samson                           | - Yes -  | #123
+    W  test                             | - Yes -  | #123
+    ==========================================================
+    W -- Warning that a global tag overrides your local tag
+
+  See Also: istag()
+
+</PRE>
+<A HREF="#@lset">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@mail">[NEXT]</A>
+<BR>
+<HR><A NAME="@mail"><H3>@mail</H3></A><PRE>
+  Command: mail [@]&lt;player-list&gt;=&lt;subject&gt; (with BRANDY_MAIL toggle)
+           mail [@]&lt;player-list&gt;=[&lt;subj&gt;/]&lt;body&gt; (with PENN_MAIL toggle)
+           mail [@]&lt;player-list&gt;=[&lt;subj&gt;//]&lt;body&gt; (with no toggle)
+           mail [&lt;mesg#&gt;|new|unread|nall|uall|ball|1-N]
+  
+   ---- For the main mail help file please see:  HELP MAIL MAIN ----
+  
+   Note: For folder help please type 'help folder'
+  
+   Important topics:
+      'HELP MAIL MAIN' for main index.    -- this is very helpful
+      'HELP MAIL TOPICS' for topical help.
+  
+   Important initial help entries:
+      'HELP MAIL CMDLIST' for the mail command listing and descriptions
+      'HELP FOLDER CMDLIST' for the folder command listing and descriptions
+      'HELP MAIL DTUTOR' for a quick tutorial on how to use mail
+      'HELP MAIL BTUTOR' for a quick tutorial on the mail editor (optional)
+      'HELP MAIL PTUTOR' for a quick tutorial on Penn @mail syntax (optional)
+  
+  If you are used to the MUX standard of @mail or the softcoded BrandyMail
+  you will want to use the BRANDY_MAIL toggle.  
+  
+  If you are used to the PENN standard of @mail, you will want to use
+  the PENN_MAIL toggle.  The BRANDY_MAIL toggle will take presidence.
+  
+  For using the line editor, you may use the MAIL_STRIPRETURN toggle.  This
+  will convert the carriage return between lines to a space when combining.
+   
+  To set a toggle, you would type: @toggle me=&lt;toggle&gt;.  An example would be:
+                        @toggle me=BRANDY_MAIL
+ 
+  Examples:
+    &gt; mail me=My Subject//My Body
+    Mail: You have new mail from -&gt; &lt;your name&gt;
+    Mail: Message sent to -&gt; &lt;your name&gt;
+    Mail: Done
+  
+  See Also: mail main, mail topics, folder
+  
+</PRE>
+<A HREF="#@ltag">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@mailfilter">[NEXT]</A>
+<BR>
+<HR><A NAME="@mailfilter"><H3>@MAILFILTER</H3></A><PRE>
+  Attribute: &amp;MAILFILTER
+  
+  This attribute, when set on a player, will allow that player individual
+  control of where the mail will go.  This allows the player to redirect
+  incoming mail into pre-existing folders.  The following are passed:
+              %0  - the dbref# of the player (or #-1 if anonymous)
+              %1  - the subject of the message
+              %2  - the body of the message
+              %3  - the date/time of the message
+  Examples:
+    &gt; folder/list
+      Mail: You have the following folders -&gt;
+      Incoming Testing Junk
+    &gt; &amp;MAILFILTER me=[switch(%0,#123,Testing,#234,Junk)]
+      Set.
+    &gt; think [num(me)] [name(me)]
+      #123 Yourself
+    &gt; mail me=A Test//A Test
+      Mail: You have new mail from -&gt; Yourself [Subj: A Test]
+      Mail: Auto-Moved to folder -&gt; Testing
+      Mail: Message sent to -&gt; Yourself
+    &gt; (recieving mail from Bob, dbref #999)
+      Mail: You have new mail from -&gt; Bob [Subj: Hey!]
+    &gt; (recieving mail from Tony, dbref #234)
+      Mail: You have new mail from -&gt; Tony [Subj: You smell]
+      Mail: Auto-Moved to folder -&gt; Junk
+  
+  See Also: @mailsig, &amp;mailnotify
+ 
+</PRE>
+<A HREF="#@mail">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@mailnotify">[NEXT]</A>
+<BR>
+<HR><A NAME="@mailnotify"><H3>@MAILNOTIFY</H3></A><PRE>
+  Attribute: &amp;MAILNOTIFY
+  
+  This attribute, when set on a player, will send a message to the person
+  mailing them depending on the evaluated text in the attribute.
+  
+  If the message evaluates to an empty string, no message is sent.
+  
+  The following arguments are passed for evaluation:
+              %0  - the dbref# of the player (or #-1 if anonymous)
+              %1  - the subject of the message
+              %2  - the body of the message
+              %3  - the date/time of the message
+  
+  Examples:
+    &gt; &amp;mailnotify me=Hi, [name(%0)]!  You sent me mail!
+    Set.
+    &gt; think [name(me)]
+    Bob
+    &gt; mail me=Test!
+    Hi, Bob!  You sent me mail!
+    Mail: You have new mail from -&gt; Bob
+    Mail: Message sent to -&gt; Bob
+    Mail: Done
+    &gt; think [name(me)]
+    Betty
+    &gt; mail bob=Test!
+    Hi, Betty! You sent me mail!
+    Mail: Message sent to -&gt; Bob
+    Mail: Done
+  
+  See Also: @mailsig, &amp;mailfilter
+
+</PRE>
+<A HREF="#@mailfilter">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@mailsig">[NEXT]</A>
 <BR>
 <HR><A NAME="@mailsig"><H3>@mailsig</H3></A><PRE>
@@ -8575,7 +11505,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: mail, folder, MAILFILTER
   
 </PRE>
-<A HREF="#@lock type zonewizlock">[PREV]</A>
+<A HREF="#@mailnotify">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@moniker">[NEXT]</A>
 <BR>
@@ -8636,13 +11566,28 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#@name">[NEXT]</A>
 <BR>
 <HR><A NAME="@name"><H3>@name</H3></A><PRE>
-  Command: @name &lt;object&gt; = &lt;new name&gt;
+  Command: @name[/&lt;switch&gt;] &lt;object&gt; = &lt;new name&gt;
   
   Changes the name of &lt;object&gt;.  &lt;object&gt; can be a thing, player, exit, or
   room, specified as &lt;name&gt; or #&lt;dbref&gt; or 'me' or 'here'.
  
   See '@list options' as to whether or not a player name may contain 
   spaces.  The default for RhostMUSH is to disallow spaces in player names.
+  
+  The following switches exist for name:
+    /ansi - combine @name and @extansi to both (re)name the item and
+            set the specified ansiname for it at the same time.
+            It does this by stripping all special characters for the real
+            name then applying the accented/ansified name entered for the
+            extansified name.  This follows permissions for @extansi.
+            This will auto-set the EXTANSI flag.
+    
+  Examples:
+    &gt; @name me=Bob
+      Name set.
+    &gt; @name/ansi me=[ansi(hr,B,hb,o,hr,b)]
+      Ansi string entered for Bob of 'Bob'.  (note: 'Bob' would be colorized)
+      Name set.
   
   See Also: name(), @protect, @list options, @alias, @ansiname, @extansi, 
             @caption, @titlecaption
@@ -8676,7 +11621,11 @@ Generated: Wed Jan 13 04:15:48 2016
    
   The mush has to be configured to enable this to work.  '@list options'
   
-  See Also: @exitformat, @conformat
+  Note: For contents, inventory, and names of things at location, you can
+        specify the NONAME flag (wizard settable only) to allow @nameformat
+        to work in those conditions.
+  
+  See Also: @exitformat, @conformat, invformat
   
 </PRE>
 <A HREF="#@name">[PREV]</A>
@@ -9033,14 +11982,21 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="@open"><H3>@open</H3></A><PRE>
   Command: @open[/&lt;switches&gt;] &lt;direction list&gt; [=&lt;number&gt;[,&lt;direction list&gt;]]
+  
   Creates an exit in the specified direction(s). If &lt;number&gt; is specified,
   it is linked to that room. Otherwise, it is created unlinked. You or anyone
   else may use the '@link' command to specify where the unlinked exit leads.
-  Opening an exit costs 1 coin. If you specify &lt;number&gt;, linking costs 1 more
-  coin.  You can specify a second direction list (after the comma), which is 
+  Opening an exit costs 1 coin. 
+  
+  If you specify &lt;number&gt;, linking costs 1 more coin.  
+  
+  You can specify a second direction list (after the comma), which is 
   automatically opened in the room that the new exit goes TO and which is
-  linked back to where you are.  I.e.  @open north;n=#1234,south;s
-  would open exit 'north;n' from here to #1234, and an exit 'south;s'
+  linked back to where you are.  
+  
+              I.e.  @open north;n=#1234,south;s
+  
+  This would open exit 'north;n' from here to #1234, and an exit 'south;s'
   from #1234 to here, assuming you have rights to open exits and link to
   the rooms in question.
   
@@ -9050,8 +12006,28 @@ Generated: Wed Jan 13 04:15:48 2016
   The following switches are available:
      /location  - Create the exit in your location (default).
      /inventory - Create the exit on yourself.
-   
-  See Also: @dig, @link, LINKING
+     /ansi      - Combine @open and @extansi to colorize with the names.
+                  This follows the permissions of @extansi.
+                  This will auto-set the EXTANSI flag.
+  
+  You may use the lastcreate() function to see the last thing @open'd
+  
+  Examples:
+    &gt; @open North &lt;N&gt;;north;n=#1234,South &lt;S&gt;;south;s
+    Opened.
+    Linked.
+    Opened.
+    Linked.
+  
+    &gt; @open/ansi [ansi(hb,North &lt;N&gt;)];north;n=#1234,[ansi(hr,South &lt;S&gt;)];south;s
+    Ansi string entered for North &lt;N&gt; of 'North &lt;N&gt;'. (this is in blue)
+    Opened.
+    Linked.
+    Ansi string entered for South &lt;S&gt; of 'South &lt;S&gt;'. (this is in red)
+    Opened.
+    Linked.
+  
+  See Also: @dig, @link, LINKING, lastcreate()
   
 </PRE>
 <A HREF="#@opay">[PREV]</A>
@@ -9237,6 +12213,27 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#@oufail">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@outpageformat">[NEXT]</A>
+<BR>
+<HR><A NAME="@outpageformat"><H3>@OUTPAGEFORMAT</H3></A><PRE>
+  Attribute: &amp;outpageformat &lt;object&gt;[=&lt;message&gt;]
+             &amp;pageformat &lt;object&gt;[=&lt;message&gt;]
+  
+  &amp;PAGEFORMAT changes the message seen by &lt;object&gt; when it receives a page.
+  &amp;OUTPAGEFORMAT sets the message seen by &lt;object&gt; when it sends a page.
+  
+  %0 - will be set to the page message (not including :, ; or &quot;).
+  %1 - will be set to ':' ';' or '&quot;' for pose, semipose and normal page, 
+       reespectively.
+  %2 - will be set to the alias of the pager, if any.
+  %3 - will be a space-separated list of recipient dbrefs.
+  %4 - will be set to the default message (based on pageformat/outpageformat).
+  
+  { See 'help &amp;pageformat2' for examples. }
+
+</PRE>
+<A HREF="#@ouse">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@oxenter">[NEXT]</A>
 <BR>
 <HR><A NAME="@oxenter"><H3>@oxenter</H3></A><PRE>
@@ -9259,7 +12256,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: enter, @aenter, @enter, @oenter
   
 </PRE>
-<A HREF="#@ouse">[PREV]</A>
+<A HREF="#@outpageformat">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@oxleave">[NEXT]</A>
 <BR>
@@ -9308,6 +12305,60 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#@oxleave">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@pageformat">[NEXT]</A>
+<BR>
+<HR><A NAME="@pageformat"><H3>@PAGEFORMAT</H3></A><PRE>
+  Attribute: &amp;outpageformat &lt;object&gt;[=&lt;message&gt;]
+             &amp;pageformat &lt;object&gt;[=&lt;message&gt;]
+  
+  &amp;PAGEFORMAT changes the message seen by &lt;object&gt; when it receives a page.
+  &amp;OUTPAGEFORMAT sets the message seen by &lt;object&gt; when it sends a page.
+  
+  %0 - will be set to the page message (not including :, ; or &quot;).
+  %1 - will be set to ':' ';' or '&quot;' for pose, semipose and normal page, 
+       reespectively.
+  %2 - will be set to the alias of the pager, if any.
+  %3 - will be a space-separated list of recipient dbrefs.
+  %4 - will be set to the default message (based on pageformat/outpageformat).
+  
+  { See 'help &amp;pageformat2' for examples. }
+
+</PRE>
+<A HREF="#@oxtport">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@pageformat2">[NEXT]</A>
+<BR>
+<HR><A NAME="@pageformat2"><H3>@pageformat2</H3></A><PRE>
+  Attribute: &amp;outpageformat &lt;object&gt;[=&lt;message&gt;]    (CONTINUED)
+             &amp;pageformat &lt;object&gt;[=&lt;message&gt;]
+  
+  Examples:
+    &gt; &amp;pageformat me=\[[time()]\] %4
+    Set.
+    &gt; @outpageformat me=\[[time()]\] %4
+    Set.
+
+    (To obtain @toggle vpage behavior:)
+    &gt; &amp;pageformat me=[setq(0,%n[if(%2,%b(%2))],1,switch(%3,%!,,elist(iter(%3,
+                     name(##),%b,|),,|)))][switch(%1,&quot;,%q0 pages[if(%q1,%b%q1)]:
+                     %0,:,From afar[if(%q1,%b(to %q1))]\, %q0 %0,
+                     From afar[if(%q1, %b(to %q1))]\, %q0%0)]
+    Set.
+
+    (To obtain no @toggle vpage behavior:)
+    &gt; &amp;pageformat me=[setq(1,switch(%3,%!,,elist(iter(%3,name(##),%b,|),,|)))]
+                     [switch(%1,&quot;,%n pages[if(%q1,%b%q1)]: %0,:,From 
+                     afar[if(%q1,%b(to %q1))]\, %n %0,From 
+                     afar[if(%q1,%b(to %q1))]\, %n%0)]
+    Set.
+  
+    Both examples above will return how 'page' would normally show.
+  
+  See Also: page, lpage, rpage, mrpage
+
+</PRE>
+<A HREF="#@pageformat">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@parent">[NEXT]</A>
 <BR>
 <HR><A NAME="@parent"><H3>@parent</H3></A><PRE>
@@ -9321,16 +12372,65 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: PARENT OBJECTS., parents(), parent(), children()
   
 </PRE>
-<A HREF="#@oxtport">[PREV]</A>
+<A HREF="#@pageformat2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@password">[NEXT]</A>
 <BR>
 <HR><A NAME="@password"><H3>@password</H3></A><PRE>
   Command: @password &lt;old password&gt;=&lt;new password&gt;
+           @password/attribute &lt;target&gt;/&lt;attribute&gt;=&lt;password&gt;
  
-  This command changes your password.
-   
-  See Also: @name
+  This command changes your password.  This will also optionally set
+  a password into a user-defined attribute that they have access to.
+  
+  The following switches are available:
+    /attribute -- Set the specified attribute into the attribute.
+                  Note: &lt;password&gt; can't exceed 2048 characters.
+                        This may change based on crypto settings.
+  
+  If the system uses the old DES style of passwords, you are limited
+  to 8 character passwords.
+  
+  If the system uses the newer SHA512 style of passwords, you may have
+  a password up to 160 characters in length.
+  
+  No white space characters (spaces, tabs, carrage returns, etc) are 
+  allowed in the password.
+  
+  If secured passwords are enabled, it will enforce a minimum length
+  of 5 characters (with DES encryption) or 14 characters (for SHA512
+  encryption) for passwords and require at least one lowercase letter,
+  one uppercase letter, and require a special character which is
+  non-alphanumeric or ', or -.  It will also use a lose-based entropy
+  check which does simplistic validation for tougher guessing password
+  entries.  It will also require passing an entropy check.  Entropy
+  requires unique non-repeating sequences.
+  
+  Please see @list options system to see what method of password
+  algo is currently in place.
+ 
+  Of interest, breaking apart the SHA512 password segment, you will 
+  see a string in the form:
+      $6$&lt;seed&gt;$&lt;passwd&gt; 
+  
+  The breakdown:
+      $6$      -- The type of encryption.  In this case SHA2 format.
+      &lt;seed&gt;   -- the randomized seed that is applied to the passwd.
+      &lt;passwd&gt; -- the encrypted SHA512 hashed password
+  
+  Examples:
+    &gt; @password myoldeasypass=Ui8^lpV4.Tx2n@vwy   (set a very complex pass)
+    Set.
+    &gt; @password/attribute me/va=test
+    Set - Bob/VA: set with encrypted password.
+    &gt; say v(va)
+    You say &quot;$6$MDf;-r|gv$Uiwe7VYT6zy5XIjKQb1AeVFWZrih62L..&quot; (90+ chars)
+    &gt; say attrpass(me/va,notest,chk)
+    You say &quot;0&quot;
+    &gt; say attrpass(me/va,test,chk)
+    You say &quot;1&quot;
+  
+  See Also: @name, attrpass()
   
 </PRE>
 <A HREF="#@parent">[PREV]</A>
@@ -9356,6 +12456,14 @@ Generated: Wed Jan 13 04:15:48 2016
   
 </PRE>
 <A HREF="#@password">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@pcreate">[NEXT]</A>
+<BR>
+<HR><A NAME="@pcreate"><H3>@pcreate</H3></A><PRE>
+  See wizhelp @pcreate
+
+</PRE>
+<A HREF="#@pay">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@pemit">[NEXT]</A>
 <BR>
@@ -9385,7 +12493,7 @@ Generated: Wed Jan 13 04:15:48 2016
 { help @pemit2 to continue switches listing }
   
 </PRE>
-<A HREF="#@pay">[PREV]</A>
+<A HREF="#@pcreate">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@pemit2">[NEXT]</A>
 <BR>
@@ -9434,6 +12542,7 @@ Generated: Wed Jan 13 04:15:48 2016
     /off    -- Turn off piping to the attribute.
     /tee    -- This turns on piping but also allows viewing output normally.
     /status -- This gives the current status of your piping.
+    /quiet  -- snuff the messages of using the /on and /off switches
   
   Please note, you obviously can not pipe to multiple attributes at once,
   and once the attribute is filled to capacity, piping to that attribute
@@ -9505,12 +12614,21 @@ Generated: Wed Jan 13 04:15:48 2016
   
   This specifies a string (from 1 to 40 characters) that you may specify 
   for a player going through a program instead of the base '-'.  If you 
-  specify a 'NULL' as the string, there will be no prompt.  
+  specify a 'NULL' as the string, there will be no prompt.    
   
   The @progprompt does not end the string with a &gt;.  If you wish to have
   one, you'll have to add it to the end of the defined prompt.
   
+  This is limited to 80 characters total.  You may have an ansified string.  
+  
+  Example:
+    &gt; @progprompt me=Prompt&gt;
+    Set.
+    &gt; @wait 0=@progprompt me=[ansi(hr,Red&gt;)]   (need the @wait to evaluate it) 
+    Set.
+  
   See Also: @program, @quitprogram
+  
 </PRE>
 <A HREF="#@prefix">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -9518,6 +12636,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="@program"><H3>@program</H3></A><PRE>
   Command: @program &lt;player&gt;=&lt;obj/attr&gt;[:&lt;prefix&gt;]
+  
+  Note:  The PROG @toggle is required for anything that will use @program.
   
   This command allows for small 'programs' within RhostMUSH. To understand this
   command, you must first understand the fact that it completely bypasses any
@@ -9552,7 +12672,7 @@ Generated: Wed Jan 13 04:15:48 2016
   r-registers are NOT preserved when @program triggers an attribute.  This
   is an unfortunate side-effect from allowing @program to be done across
   reboots and shutdowns.  Keep in mind that this will work differently 
-  than MUX's @program by splitting up arguments that were seperated by 
+  than MUX's @program by splitting up arguments that were separated by 
   commas into %0 - %9.  Any argument after the 10th is ignored.  
   Check @list options to see if it is using this method, or the MUX method 
   where it's only %0.
@@ -9609,38 +12729,83 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="@protect"><H3>@protect</H3></A><PRE>
   Command: @protect[/&lt;switch&gt;] [&lt;player-name&gt;]
   
-  This command 'protects' your current user name from being used by anyone
-  else.  Essentially this 'locks in' your name so that if you ever switch
-  your name to something else, no one else will be able to use the name
-  that you have marked for protection.  You have full access to any name
-  you protect.  You can only protect your currently active name.  You may
-  delete any name you, yourself, have protected.  Wizards may remove any
-  protected name.  Immortals bypass protected names.
+  This command 'protects' your current user name or if enabled the specified
+  player name from being used by anyone else.  Essentially this 'locks in' 
+  your name so that if you ever switch your name to something else, no one 
+  else will be able to use the name that you have marked for protection.  
+  You have full access to any name you protect.  
   
+  You can only protect your currently active name unless the enhanced 
+  options are enabled.  You may delete any name you, yourself, have protected.
+  Wizards may remove any protected name.  Immortals bypass protected names and
+  may also remove them.
+  
+  Any name that you have already added you may /alias or /unalias by name
+  regardless of the enhanced option being enabled.
+  
+  Notes: 
+    - See @list options system to see if the enhanced option is enabled.
+    - An @alias is already a protected name, but you can NOT switch to it.
+    - You can @protect/add or /del an @alias'd name, but can not /alias it.
+    - If you @protect/del an @alias name, it does not remove the @alias
+   
   Switches available:
     /list    - (default) - list the names you current have protected.  This
                does not take any arguments.
     /add     - Add your current name to your protected name list.  This does
-               not take any arguments.
+               not take any arguments unless protect_addenh is enabled.
     /del     - Remove the specified name from your protected name list.  This
                requires an argument.
     /alias   - Adds the protected name as an alias.  This will work like 
                @alias with regards to player lookups.
     /unalias - This removes the protected name as an alias.  You can not
                remove the active playername as an alias.
+ 
+{ 'help @protect2' for examples and @admin params effective } 
+
+</PRE>
+<A HREF="#@program3">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@protect2">[NEXT]</A>
+<BR>
+<HR><A NAME="@protect2"><H3>@protect2</H3></A><PRE>
+  (CONTINUED)
+  Command: @protect[/&lt;switch&gt;] [&lt;player-name&gt;]  
+  
+  The following wizard @admin parameters exist (see wizhelp for help):
+    protect_addenh   -- this is the toggle that enables/disables enhanced adds
+    max_name_protect -- this controls total number of names to be protected
   
   Examples:
-    &gt; say name(me)
-    You say &quot;Bob&quot;
+    &gt; say [name(me)] [num(me)]
+    You say &quot;Bob #123&quot;
     &gt; @protect/add
     Your current name has been added to your protect list.
+    &gt; @protect/add Simon            (if enhanced mode enabled)
+    The name has been added to your protect list.
+    &gt; @protect/add Fred             (if enhanced mode enabled)
+    The name has been added to your protect list.
     &gt; @protect/del Bob
     You have successfully deleted 'Bob' from your protect list.
+    &gt; @protect/alias Simon
+    You have successfully activated 'simon' as an alias.
+    &gt; @protect/alias Fred
+    You have successfully activated 'fred' as an alias.
+    &gt; @protect/unalias Fred
+    You have successfully de-activated 'fred' as an alias.
+    &gt; @protect/list
+    +------------------------------+----------------------------------+-------+
+    | Player Name Protected        | Dbref#   [ Player Name         ] | Alias |
+    +------------------------------+----------------------------------+-------+
+    | Simon                        | #123     [ Bob                 ] |   Y   |
+    | Fred                         | #123     [ Bob                 ] |   N   |
+    +------------------------------+----------------------------------+-------+
+    You have 2 out of 10 names protected.
   
   See Also: @name, @alias, listprotection()
   
 </PRE>
-<A HREF="#@program3">[PREV]</A>
+<A HREF="#@protect">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@ps">[NEXT]</A>
 <BR>
@@ -9673,21 +12838,26 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @notify, @wait, @drain, @halt, pid()
   
 </PRE>
-<A HREF="#@protect">[PREV]</A>
+<A HREF="#@protect2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@quitprogram">[NEXT]</A>
 <BR>
 <HR><A NAME="@quitprogram"><H3>@quitprogram</H3></A><PRE>
-  Command: @quitprogram &lt;player&gt;
+  Command: @quitprogram[/&lt;switch&gt;] &lt;player&gt;
   
   Terminates the @program for player. If &lt;player&gt; is not specified, then it
   works upon the enactor (a player may quit a program while they are in it
   by piping out @quitprogram, see 'help @program').
   
+  Available switches:
+    /quiet - do not notify the target (or yourself) of quitprogramming.
+             Note: errors are still displayed.
+  
   Example:
     &gt; @quitprogram *TinyPlayer
     @program cleared.
- 
+    &gt; @quitprogram/quiet *TinyPlayer  (notice no output)
+   
   See also: @program, @progprompt.
  
 </PRE>
@@ -9789,12 +12959,41 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#@register">[NEXT]</A>
 <BR>
 <HR><A NAME="@register"><H3>@register</H3></A><PRE>
-  Command: @register &lt;character&gt;=&lt;email&gt;
-  This registers a character on-line and mails the specified &lt;email&gt; the 
-  password for the character you created.  This can only be done by GUEST and
+  Command: @register[/&lt;switch&gt;] &lt;player&gt;=&lt;email&gt;
+
+  Note:  &lt;player&gt; should not contain &quot; even if the player name is multi-word
+         as this command will auto recognize a multi-word player name.
+  
+  This registers a player on-line and mails the specified &lt;email&gt; the 
+  password for the player you created.  This can only be done by GUEST and
   only if the autoregistration is enabled.  Depending on configurations, you
   may be able to do this at the connect screen as well, except it's just
   'register'.
+  
+  The online @register also supports the following switches:
+    /message - in addition to emailing the user the password, message the
+               user online what their password is.  This switch may be
+               disabled on the RhostMUSH you connect to.
+    /ansi    - Combines @register with @extansi to colorize the player
+               name.  This follows @extansi permissions.
+               This will auto-set the EXTANSI flag.
+  
+  The switches will only affect the online @register command and will not
+  impact the offline method at all.
+  
+  Examples:
+    &gt; @register player=my@email
+    Autoregistration completed.   
+    &gt; @register A Player With Spaces=my@email
+    Autoregistration completed.   
+    &gt; @register/ansi [ansi(hb,Player)]=my@email
+    Ansi string entered for Player of 'Player' (this would be in blue)
+    Autoregistration completed.   
+    &gt; @register/message player=my@email
+    Autoregistration completed.   
+    Your password for account 'player' is: MTIvYrPT
+  
+  See Also: connect, cdark, chidden, create, register, @hide
   
 </PRE>
 <A HREF="#@race">[PREV]</A>
@@ -9841,6 +13040,41 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#@reject">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@retry">[NEXT]</A>
+<BR>
+<HR><A NAME="@retry"><H3>@retry</H3></A><PRE>
+  Command: 1. @rollback &lt;count&gt;[/&lt;repeats&gt;] [=&lt;arg0, ..., argN&gt;]
+           2. @rollback/wait &lt;count&gt;[/&lt;repeats&gt;/&lt;wait&gt;] [=&lt;arg0, ..., argN&gt;]
+           3. @rollback/retry &lt;boolean&gt; [=&lt;arg0, ..., argN&gt;]
+           4. @rollback/label[/&lt;switch&gt;] &lt;label&gt;|&lt;args...&gt; [=&lt;arg0, ..., argN&gt;]
+  
+  You may specify the /label switch with any other syntax with @rollback.  To
+  utilize a label, you would prepend the argument with &lt;label&gt;|.  So for
+  example, instead of @rollback &lt;count&gt; you would do 
+  @rollback/label &lt;label&gt;|&lt;count&gt;.  And instead of @rollback/retry &lt;boolean&gt;
+  you would use @rollback/retry/label &lt;label&gt;|&lt;boolean&gt;.  All other arguments
+  will align after the &lt;label&gt;| portion.
+  
+  The rollback command has multiple facets that allow you flexibility to
+  'roll back' the current queue and re-issue the command sequence a number
+  of times.  There's three distinct flavors of the @rollback command that can
+  be used.  On most RhostMUSH's, the @rollback/retry will be aliased to @retry
+  which for the most part mimic's penn's @retry command.  You may optionally
+  pass 10 arguments to @rollback.  The arguments as well as the &lt;boolean&gt; wil
+  be re-evaluated on every pass.
+  
+  NOTE:  All %0-%9 arguments are RESET TO THEIR ORIGINAL VALUES after the end
+         of the rollback segment.  This is intentional.
+  
+{ see 'help @rollback2' for the arguments that can be passed}
+{ see 'help @rollback3' for examples on condition 1 &lt;default&gt; }
+{ see 'help @rollback4' for examples on condition 2 [/wait] }
+{ see 'help @rollback5' for examples on condition 3 [/retry] }
+{ see 'help @rollback6' for examples on condition 4 [/label] }
+
+</PRE>
+<A HREF="#@remit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@rfail">[NEXT]</A>
 <BR>
 <HR><A NAME="@rfail"><H3>@rfail</H3></A><PRE>
@@ -9868,12 +13102,13 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: give, @agfail, @arfail, @gfail, @ogfail, @orfail, @lock
   
 </PRE>
-<A HREF="#@remit">[PREV]</A>
+<A HREF="#@retry">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@robot">[NEXT]</A>
 <BR>
 <HR><A NAME="@robot"><H3>@robot</H3></A><PRE>
   Command: @robot &lt;name&gt;=&lt;password&gt;
+  
   Creates a robot player owned by you.  The robot has its ROBOT flag set, so
   it may use the OUTPUTPREFIX and OUTPUTSUFFIX commands that most publicly
   available robot programs require.  This command costs 1000 coins.
@@ -9884,6 +13119,323 @@ Generated: Wed Jan 13 04:15:48 2016
   
 </PRE>
 <A HREF="#@rfail">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@rollback">[NEXT]</A>
+<BR>
+<HR><A NAME="@rollback"><H3>@rollback</H3></A><PRE>
+  Command: 1. @rollback &lt;count&gt;[/&lt;repeats&gt;] [=&lt;arg0, ..., argN&gt;]
+           2. @rollback/wait &lt;count&gt;[/&lt;repeats&gt;/&lt;wait&gt;] [=&lt;arg0, ..., argN&gt;]
+           3. @rollback/retry &lt;boolean&gt; [=&lt;arg0, ..., argN&gt;]
+           4. @rollback/label[/&lt;switch&gt;] &lt;label&gt;|&lt;args...&gt; [=&lt;arg0, ..., argN&gt;]
+  
+  You may specify the /label switch with any other syntax with @rollback.  To
+  utilize a label, you would prepend the argument with &lt;label&gt;|.  So for
+  example, instead of @rollback &lt;count&gt; you would do 
+  @rollback/label &lt;label&gt;|&lt;count&gt;.  And instead of @rollback/retry &lt;boolean&gt;
+  you would use @rollback/retry/label &lt;label&gt;|&lt;boolean&gt;.  All other arguments
+  will align after the &lt;label&gt;| portion.
+  
+  The rollback command has multiple facets that allow you flexibility to
+  'roll back' the current queue and re-issue the command sequence a number
+  of times.  There's three distinct flavors of the @rollback command that can
+  be used.  On most RhostMUSH's, the @rollback/retry will be aliased to @retry
+  which for the most part mimic's penn's @retry command.  You may optionally
+  pass 10 arguments to @rollback.  The arguments as well as the &lt;boolean&gt; wil
+  be re-evaluated on every pass.
+  
+  NOTE:  All %0-%9 arguments are RESET TO THEIR ORIGINAL VALUES after the end
+         of the rollback segment.  This is intentional.
+  
+{ see 'help @rollback2' for the arguments that can be passed}
+{ see 'help @rollback3' for examples on condition 1 &lt;default&gt; }
+{ see 'help @rollback4' for examples on condition 2 [/wait] }
+{ see 'help @rollback5' for examples on condition 3 [/retry] }
+{ see 'help @rollback6' for examples on condition 4 [/label] }
+
+</PRE>
+<A HREF="#@robot">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@rollback2">[NEXT]</A>
+<BR>
+<HR><A NAME="@rollback2"><H3>@rollback2</H3></A><PRE>
+  (CONTINUED)
+  Command: 1. @rollback &lt;count&gt;[/&lt;repeats&gt;] [=&lt;arg0, ..., argN&gt;]
+           2. @rollback/wait &lt;count&gt;[/&lt;repeats&gt;/&lt;wait&gt;] [=&lt;arg0, ..., argN&gt;]
+           3. @rollback/retry &lt;boolean&gt; [=&lt;arg0, ..., argN&gt;]
+           4. @rollback/label[/&lt;switch&gt;] &lt;label&gt;|&lt;args...&gt; [=&lt;arg0, ..., argN&gt;]
+  
+  The arguments that are passed are:
+    &lt;label&gt;    - The optional label (@goto label) you wish to pass to the
+                 @rollback.  The label and other arguments will be separated
+                 by the pipe(|) character.
+    &lt;count&gt;    - The number of arguments you wish to roll back to.  If you
+                 specify the /retry it ignores this option and always rolls
+                 back to the start of the command queue.  This is only
+                 evaluated once.  Must be greater than zero(0).
+    &lt;repeats&gt;  - The number of times you wish to repeat the rolled back
+                 segment.  The default maximum is 1000 retries, regardless
+                 of the option you specify.  This is only evaluated once.
+                 This value defaults to '1'.  Must be greater than zero(0).
+    &lt;wait&gt;     - The wait time that you wish to use in the @wait for the
+                 rolled back segment.  Defaults to '0'.  This is evaluated
+                 for every rollback.  Must be zero(0) or greater.
+    &lt;boolean&gt;  - This is evaluated to a 'true(1)' or 'false(0)' value on
+                 every rollback pass.  The retry will continue until a
+                 false condition is met or until the MAX (1000 default)
+                 rollback count threshold is met.
+  
+  The switches available are:
+    /wait      - Slice the rolled back section into its own waited queue.
+    /retry     - retry everything from before the @rollback segment.  
+    /label     - specify a @goto label that @rollback will apply.
+  
+{ see 'help @rollback3' for examples on condition 1 &lt;default&gt; }
+{ see 'help @rollback4' for examples on condition 2 [/wait] }
+{ see 'help @rollback5' for examples on condition 3 [/retry] }
+{ see 'help @rollback6' for examples on condition 4 [/label] }
+
+</PRE>
+<A HREF="#@rollback">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@rollback3">[NEXT]</A>
+<BR>
+<HR><A NAME="@rollback3"><H3>@rollback3</H3></A><PRE>
+(CONTINUED)
+  Command: 1. @rollback &lt;count&gt;[/&lt;repeats&gt;] [=&lt;arg0, ..., argN&gt;]
+           2. @rollback/wait &lt;count&gt;[/&lt;repeats&gt;/&lt;wait&gt;] [=&lt;arg0, ..., argN&gt;]
+           3. @rollback/retry &lt;boolean&gt; [=&lt;arg0, ..., argN&gt;]
+           4. @rollback/label[/&lt;switch&gt;] &lt;label&gt;|&lt;args...&gt; [=&lt;arg0, ..., argN&gt;]
+  
+  The first condition is the standard default method for @rollback.  With
+  this method you specify a &lt;count&gt; of how many arguments you wish to roll
+  back to.  If &lt;count&gt; exceeds the total number of commands in the argument
+  list, it grabs the all the arguments.  If the value is zero, it ignores
+  the @rollback in the entirity and continues on to the next command.
+   
+  You may specify a &lt;repeats&gt; value if you wish to have more than one repeat
+  of the subset of previous commands.  The default value for this is one(1).
+  
+  You may specify optional arguments to pass to the retried commands.  This
+  will override the originally passed arguments and will be evaluated for
+  every rollback.  This allows you to specify a new set of arguments for
+  every rollback run.  Once the rollback is completed, the arguments are
+  reset to their original values.
+  
+  All passed arguments are re-evaluated on every retry.
+   
+  Examples: (condition 1)
+    &gt; &amp;FOO me=$foo *:think 1-%0;think 2-%0;think 3-%0;
+              @rollback 2/2=[add(%0,5)];think end-%0
+    Set.
+    &gt; foo 5
+      1-5
+      2-5
+      3-5
+      2-10
+      3-10
+      2-15
+      3-15
+      END-5
+  
+    &gt; &amp;FOO me=$foo *:think 1-%0;think 2-%0;think 3-%0;
+              @rollback 2=[add(%0,5)];think end-%0
+    Set.
+    &gt; foo 5
+      1-5
+      2-5
+      3-5
+      2-10
+      3-10
+      END-5
+  
+    &gt; &amp;FOO me=$foo *:think 1-%0;@goto/label foo;think 2-%0;think 3-%0;
+              @rollback/label foo|5=[add(%0,5)];think end-%0
+    Set.
+    &gt; foo 5
+      1-5
+      2-5
+      3-5
+      2-10
+      3-10
+      end-5
+
+  
+{ see 'help @rollback3' for examples on condition 1 &lt;default&gt; }
+{ see 'help @rollback4' for examples on condition 2 [/wait] }
+{ see 'help @rollback5' for examples on condition 3 [/retry] }
+{ see 'help @rollback6' for examples on condition 4 [/label] }
+
+</PRE>
+<A HREF="#@rollback2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@rollback4">[NEXT]</A>
+<BR>
+<HR><A NAME="@rollback4"><H3>@rollback4</H3></A><PRE>
+(CONTINUED)
+  Command: 1. @rollback &lt;count&gt;[/&lt;repeats&gt;] [=&lt;arg0, ..., argN&gt;]
+           2. @rollback/wait &lt;count&gt;[/&lt;repeats&gt;/&lt;wait&gt;] [=&lt;arg0, ..., argN&gt;]
+           3. @rollback/retry &lt;boolean&gt; [=&lt;arg0, ..., argN&gt;]
+           4. @rollback/label[/&lt;switch&gt;] &lt;label&gt;|&lt;args...&gt; [=&lt;arg0, ..., argN&gt;]
+  
+  The second condition allows you to toss the rolled back segment of code into
+  its own separate wait queue.  The &lt;count&gt; and &lt;repeats&gt; are set initially on
+  the first pass and will not be re-evaluated.  The actual wait time is 
+  re-evaluated for every rollback segment, meaning for every rollback you can 
+  give it a unique wait time.  Be aware that once the &lt;wait&gt; is a negative 
+  number, the @rollback will abort itself.
+  
+  All passed arguments are re-evaluated on every retry.
+  
+  Examples: (condition 2)
+    &gt; &amp;FOO me=$foo *:think 1-%0;think 2-%0;think 3-%0;
+              @rollback/wait 2/2/100=[add(%0,5)];think end-%0
+    Set.
+    &gt; foo 5
+    1-5
+    2-5
+    3-5
+    end-5
+
+    (then 100 seconds later -- specified by the wait value)
+    2-10
+    3-10
+    2-15
+    3-15
+
+    &gt; &amp;FOO me=$foo *:think 1-%0;think 2-%0;@goto/label foo;think 3-%0;
+              @rollback/wait/label foo|2/2/100=[add(%0,5)];think end-%0
+    Set.
+    &gt; foo 5
+    1-5
+    2-5
+    3-5
+    end-5
+ 
+    (then 100 seconds later)
+    3-10
+    3-15
+
+  
+{ see 'help @rollback3' for examples on condition 1 &lt;default&gt; }
+{ see 'help @rollback4' for examples on condition 2 [/wait] }
+{ see 'help @rollback5' for examples on condition 3 [/retry] }
+{ see 'help @rollback6' for examples on condition 4 [/label] }
+
+</PRE>
+<A HREF="#@rollback3">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@rollback5">[NEXT]</A>
+<BR>
+<HR><A NAME="@rollback5"><H3>@rollback5</H3></A><PRE>
+(CONTINUED)
+  Command: 1. @rollback &lt;count&gt;[/&lt;repeats&gt;] [=&lt;arg0, ..., argN&gt;]
+           2. @rollback/wait &lt;count&gt;[/&lt;repeats&gt;/&lt;wait&gt;] [=&lt;arg0, ..., argN&gt;]
+           3. @rollback/retry &lt;boolean&gt; [=&lt;arg0, ..., argN&gt;]
+           4. @rollback/label[/&lt;switch&gt;] &lt;label&gt;|&lt;args...&gt; [=&lt;arg0, ..., argN&gt;]
+  
+  The third condition is commonly referred to as the @retry option.  This will
+  effectively retry the entire code segment prior to the @rollback in the
+  entirity until &lt;boolean&gt; is false(0) or until the maximum rollback threshold
+  is met, which by default is 1000 retries.  The &lt;boolean&gt; value is evaluated
+  for every rollback pass to see if the new condition will be true or false.
+  
+  All passed arguments are re-evaluated on every retry.
+  
+  Examples: (condition 3)  
+    &gt; &amp;FOO me=$foo *:think 1-%0;think 2-%0;think 3-%0;
+              @rollback/retry [gt(%0,1)]=[sub(%0,1)];think end-%0
+    Set.
+    &gt; foo 3
+    1-3
+    2-3
+    3-3
+    1-2
+    2-2
+    3-2
+    1-1
+    2-1
+    3-1
+    end-3
+  
+    &gt; &amp;FOO me=$foo *:think 1-%0;@goto/label foo;think 2-%0;think 3-%0;
+              @rollback/retry/label foo|[gt(%0,1)]=[sub(%0,1)];think end-%0
+    Set.
+    &gt; foo 3
+    1-3
+    2-3
+    3-3
+    2-2
+    3-2
+    2-1
+    3-1
+    end-3
+  
+
+</PRE>
+<A HREF="#@rollback4">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@rollback6">[NEXT]</A>
+<BR>
+<HR><A NAME="@rollback6"><H3>@rollback6</H3></A><PRE>
+(CONTINUED)
+  Command: 1. @rollback &lt;count&gt;[/&lt;repeats&gt;] [=&lt;arg0, ..., argN&gt;]
+           2. @rollback/wait &lt;count&gt;[/&lt;repeats&gt;/&lt;wait&gt;] [=&lt;arg0, ..., argN&gt;]
+           3. @rollback/retry &lt;boolean&gt; [=&lt;arg0, ..., argN&gt;]
+           4. @rollback/label[/&lt;switch&gt;] &lt;label&gt;|&lt;args...&gt; [=&lt;arg0, ..., argN&gt;]
+  
+  The forth argument is the  /label option to @rollback.  The given syntax
+  requires you to use the label|args syntax where 'args' will be the arguments
+  passed from condition 1, 2, or 3 depending on the additional switch you
+  provide (or not provide).
+  
+  This will roll back to the label defined with @goto/label previously in the
+  command list.
+  
+  Examples:
+  ---- Condition 1 (rollback 5, look for foo label, 1 repeat (default))
+    &gt; &amp;FOO me=$foo *:think 1-%0;@goto/label foo;think 2-%0;think 3-%0;
+              @rollback/label foo|5=[add(%0,5)];think end-%0
+    Set.
+    &gt; foo 5
+      1-5
+      2-5
+      3-5
+      2-10
+      3-10
+      end-5
+
+  ---- Condition 2 (roll back 2 to label, repeat 2 with 100 second wait)
+    &gt; &amp;FOO me=$foo *:think 1-%0;think 2-%0;@goto/label foo;think 3-%0;
+              @rollback/wait/label foo|2/2/100=[add(%0,5)];think end-%0
+    Set.
+    &gt; foo 5
+    1-5
+    2-5
+    3-5
+    end-5
+ 
+    (then 100 seconds later)
+    3-10
+    3-15
+  
+  ---- Condition 3 (roll back to start, look for foo label, while %0 &gt; 1)
+    &gt; &amp;FOO me=$foo *:think 1-%0;@goto/label foo;think 2-%0;think 3-%0;
+              @rollback/retry/label foo|[gt(%0,1)]=[sub(%0,1)];think end-%0
+    Set.
+    &gt; foo 3
+    1-3
+    2-3
+    3-3
+    2-2
+    3-2
+    2-1
+    3-1
+    end-3
+
+  See Also: @jump, @skip, @include, @break, @assert, @sudo, @switch @goto
+  
+</PRE>
+<A HREF="#@rollback5">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@runout">[NEXT]</A>
 <BR>
@@ -9904,7 +13456,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @charges
   
 </PRE>
-<A HREF="#@robot">[PREV]</A>
+<A HREF="#@rollback6">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@salisten">[NEXT]</A>
 <BR>
@@ -10018,6 +13570,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="@search"><H3>@search</H3></A><PRE>
   Command: @search[/&lt;switch&gt; [&lt;player&gt;] [&lt;class&gt;=&lt;restrict&gt;[,&lt;low&gt;[,&lt;high&gt;]]]
  
+  Note: See 'help search classes' to see what searches are available.
+  
   Displays information about objects that meet the search criteria.
   Because this command is computationally expensive, it costs 200 coins.
   &lt;player&gt; restricts the search to the named player, while &lt;class&gt;
@@ -10041,7 +13595,8 @@ Generated: Wed Jan 13 04:15:48 2016
     @search object=Test,5000       &lt;-- Things starting with Test from object
                                        #5000 to the end of the database.
   
-  See Also: @find, search(), searchng(), SEARCH CLASSES
+  See Also: @find, search(), searchng(), searchobjid(), searchngobjid(), 
+            SEARCH CLASSES
   
 </PRE>
 <A HREF="#@saystring">[PREV]</A>
@@ -10078,11 +13633,13 @@ Generated: Wed Jan 13 04:15:48 2016
            @set[/&lt;switches&gt;] &lt;object&gt;=&lt;attribute&gt;:_&lt;fromobj&gt;/&lt;fromattr&gt;
            @set[/&lt;switches&gt;] &lt;object&gt;/&lt;attr&gt;=[!]&lt;attrflag&gt;
   Synonym: &amp;&lt;attribute&gt; &lt;object&gt;[=&lt;value&gt;]
+           &amp;`&lt;tree`attribute&gt; &lt;object&gt;[=&lt;value&gt;] (for setting a tree variable)
  
   The available switches are:
-        /QUIET - sets/removes the target without the 'Set.' or 'Cleared.' 
-        /NOISY - sets/removes the target with a verbose SET message.
-        /TREE  - sets a TREE (with branches) of a given attribute.
+        /QUIET  - sets/removes the target without the 'Set.' or 'Cleared.' 
+        /NOISY  - sets/removes the target with a verbose SET message.
+        /TREE   - sets a TREE (with branches) of a given attribute.
+        /STRICT - bypasses special meaning of '_' on attribute setting.
    
   The first form sets (or clears) the indicated flag(s) on &lt;object&gt;, It 
   accepts multiple flags for arguments if so desired. the second form sets 
@@ -10090,6 +13647,8 @@ Generated: Wed Jan 13 04:15:48 2016
   attribute if there is no attribute named &lt;attribute&gt;.  The third form 
   copies an attribute from another object, and the fourth form sets 
   (or clears) an attribute flag on the &lt;attr&gt; attribute of &lt;object&gt;.
+  
+  Note: the third form will be ignored if using /strict.
    
   When setting attributes on an object, you may also use the command
   '@&lt;attribute&gt; &lt;object&gt; = &lt;value&gt;' if the attribute is a predefined
@@ -10137,7 +13696,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Please note, you can not set multiple attributes or flags at once this way.
   Reference: ATTRIBUTE FLAGS
   
-  See Also: @lock, examine, FLAGS, &amp;, @guild, @race, ATTRIBUTE FLAGS,
+  See Also: @lset, @lock, examine, FLAGS, &amp;, @guild, @race, ATTRIBUTE FLAGS,
             ATTRIBUTE TREES
   
 </PRE>
@@ -10213,7 +13772,9 @@ Generated: Wed Jan 13 04:15:48 2016
     2
     4
   
-  See Also: @include, @force, @trigger, @skip, @break, @assert, @switch
+  See Also: @include, @force, @trigger, @skip, @break, @assert, @switch,
+            @jump, @rollback, @goto
+
 
 </PRE>
 <A HREF="#@sfail">[PREV]</A>
@@ -10424,9 +13985,18 @@ Generated: Wed Jan 13 04:15:48 2016
  
   Optional switches are /quiet to suppress output or /noisy to give 
   verbose output.
- 
-  Example: @startup me = @vz me=MUSH was last restarted at [time()].
-           @startup me = home
+  
+  Be aware that @startup could potentially have a race condition on some
+  functions and commands.  This is because at the time of the @startup
+  the game is still in a 'starting state' which limits some features,
+  such as new sockets.  To get around this limitation, please put a small
+  wait before the @startup.
+   
+  Examples: 
+    &gt; @startup me = @vz me=MUSH was last restarted at [time()].
+    &gt; @startup me = home
+    &gt; @startup me = @wait 1=think [execscript(runme.sh)]
+        
   
 </PRE>
 <A HREF="#@ssmell">[PREV]</A>
@@ -10551,7 +14121,7 @@ Generated: Wed Jan 13 04:15:48 2016
     Player says &quot;boo&quot;
     Player says &quot;baa&quot;
   
-  See Also: @include, @force, @trigger, @skip 
+  See Also: @include, @force, @trigger, @skip, @jump, @rollback, @goto
   
 </PRE>
 <A HREF="#@success">[PREV]</A>
@@ -10615,7 +14185,11 @@ Generated: Wed Jan 13 04:15:48 2016
   have a short-hand way of getting at the matched value.  Case does not do
   wildcard matches.
   
-  Please check @list options if this has been enabled. 
+  Note: The following config parameters effect how this functions.
+        penn_switches  -- if enabled allows &gt;, &lt;, &gt;=. &lt;= for math.
+        float_switches -- if enabled allows floating values as well.
+  
+  Refer: '@list options boolean *switch*' to check switch options.
   
 { help @switch2 for examples }
 
@@ -10640,8 +14214,16 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;no&quot;
     &gt; @switch/first FooFoo=*boo*,say yes,*oo*,say maybe,say no
     You say &quot;maybe&quot;
+   -------- If penn_switches enabled
+    &gt; @switch/first 3=&gt;=2,say yes,say no
+    You say &quot;yes&quot;
+   -------- If float_switches also enabled
+    &gt; @switch/first 2.23=&gt;=2.22,say yes,say no
+    You say &quot;yes&quot;
+   
   
-  See Also: switch(), case(), ifelse()
+  See Also: switch(), case(), ifelse(), @skip, @break, @assert, @jump,
+            @rollback, @goto
   
 </PRE>
 <A HREF="#@switch">[PREV]</A>
@@ -10654,9 +14236,21 @@ Generated: Wed Jan 13 04:15:48 2016
            @teleport[/switch] [&lt;obj1,obj2,...&gt;=[dest1, dest2,...]] &lt;exit&gt;
            @teleport[/switch] [&lt;obj1,obj2,...&gt;=[dest1, dest2,...]] home
    
-  The first form of the complex command moves &lt;object&gt; (or you) to the named
-  room or thing.  The second form sends &lt;object&gt; (or you) to the destination
-  of the named exit, while the third form sends &lt;object&gt; (or you) home.
+  Complex teleports accept the source list with spaces or commas.  If it
+  detects a comma, it will ignore spaces as the separator.  This is to allow
+  teleporting things with multi-word names.
+  
+  The destination list (if more than one) must have commas.
+  
+  The first form of the complex command moves &lt;object&gt; (or you), and/or the 
+  list of space or comma delimited objects to the named room or thing.  
+  
+  The second form sends &lt;object&gt; (or you), and/or the list of space or comma
+  delimited objects to the destination of the named exit. 
+  
+  The third form sends &lt;object&gt; (or you), and/or the list of space or comma
+  delimited objects home.
+  
   If the destination room has a drop-to, the object will go to the drop-to
   instead of the named location.
   
@@ -10700,6 +14294,7 @@ Generated: Wed Jan 13 04:15:48 2016
     @tel #45=home                 - teleport #45 home
     @tel home                     - teleport the enactor home
     @tel/list/quiet #45 #56=#59   - teleport #45 and #56 to #59 quietly
+    @tel/list a space, bar=home   - teleport 'a space' and 'bar' home
     @tel/quiet #45=home           - teleport #45 home quietly
   
   See Also: JUMP_OK, @lock (tport and telout), @tfail, @otfail, @atfail
@@ -10745,7 +14340,9 @@ Generated: Wed Jan 13 04:15:48 2016
   This attribute sets up a title (prefix) for the target player when
   they are looked at or looked at in a given location.  You may set
   a large title, but only the first 40 characters will be displayed.
-  No carrage returns are allowed in this string and it is only useful
+  If ZENTY_ANSI compiletime is not used, ansi is stripped.
+   
+  No carriage returns are allowed in this string and it is only useful
   for players.
   
   Example:
@@ -10812,6 +14409,60 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#@tofail">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem"><H3>@totem</H3></A><PRE>
+  Command: @totem[/switch] &lt;target&gt; [=&lt;totem1&gt; &lt;totem2&gt; &lt;!totem3&gt; ... &lt;totemN&gt;]
+  
+  This command will control the totem subsystem.  Totems are essentially
+  flags.  However, unlike normal flags these can be dynamically added or
+  removed on the fly by the administrative staff allowing a more flexible
+  grid system.
+  
+  The following switches exist for @totem:
+    /list -- list all @totems that you have access to.
+    /slot -- list the number of totems that are assigned to each slot
+  
+  When setting @totems, you would just specify the totem in question.  When
+  you wish to remove the @totem, you would preceed the @totem flagname with
+  a '!'.  Such as '@totem me=!totem'.
+  
+  When you list totems, you will see the flag letter that is assigned it.
+  They will  mean:
+    ?  - default flag.  This generally means none was assigned.
+   [ ] - a second tier flag character.  The character is between the []'s.
+   { } - a third tier flag character.  The character is between the {}'s.
+  
+  @totem/list is equivelant to doing '@list totems' 
+  
+  When using @totem/list (or @list totem) you may specify a slot number
+  or a wildcard.  The slot number is the slot position for the word
+  of flags.  By default Rhost comes with 10 slots (0-9).  An example
+  of a wildcard is like mark* or *0.
+  
+  Totems will be displayed with examine and @decompile.
+    
+  Examples:
+    &gt; think name(me)
+      Bob
+    &gt; @totem/list
+    Totems : INLINE1([1]) INLINE2([2]) TOTEM1({1}) TOTEM2({2}) TOTEMINIT(i)
+    &gt; @totem/list in*
+    Totems : INLINE1([1]) INLINE2([2])
+    &gt; @totem me=inline1 totem1
+    Set - Bob (set totem INLINE1).
+    Set - Bob (set totem TOTEM1).
+    &gt; @totem me=inline1 totem1
+    Set - Bob (set totem [again] INLINE1).
+    Set - Bob (set totem [again] TOTEM1).
+    &gt; @totem me=!totem1
+    Set - Bob (cleared totem TOTEM1).
+  
+  See Also: @set, @toggle
+ 
+</PRE>
+<A HREF="#@toggle">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@tport">[NEXT]</A>
 <BR>
 <HR><A NAME="@tport"><H3>@tport</H3></A><PRE>
@@ -10832,12 +14483,13 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @atport, @otport, @oxtport, @teleport
   
 </PRE>
-<A HREF="#@toggle">[PREV]</A>
+<A HREF="#@totem">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@trigger">[NEXT]</A>
 <BR>
 <HR><A NAME="@trigger"><H3>@trigger</H3></A><PRE>
   Command: @trigger &lt;object&gt;/&lt;attr&gt; [=&lt;param&gt; [, &lt;param&gt;]... ]
+  
   Invokes an action list stored in an attribute on an object.  The triggering
   object becomes the enactor and the positional parameters %0 through %9
   are set to the supplied parameters.  If a @charges attribute exists on 
@@ -10877,7 +14529,7 @@ Generated: Wed Jan 13 04:15:48 2016
  
   Example: @ufail robot = The robot pointedly ignores you.
    
-  See Also: @aufail, @oufail, @use
+  See Also: @aufail, @oufail, @use, SHOWFAILCMD
   
 </PRE>
 <A HREF="#@trigger">[PREV]</A>
@@ -10913,7 +14565,7 @@ Generated: Wed Jan 13 04:15:48 2016
          help mail lock   - help on how to remove a mail lock.
          help @lock locks - list of available locks you can @unlock.
   
-  See Also: @chown, @lock, ATTRIBUTE OWNERSHIP
+  See Also: @lock, @lset, @chown, lock(), elock(), ATTRIBUTE OWNERSHIP
   
 </PRE>
 <A HREF="#@unlink">[PREV]</A>
@@ -11139,7 +14791,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#@wipe">[NEXT]</A>
 <BR>
 <HR><A NAME="@wipe"><H3>@wipe</H3></A><PRE>
-  Command: @wipe[/&lt;switch&gt;] &lt;object&gt;[/&lt;wild-attr&gt;]
+  Command: @wipe[/&lt;switch(es)&gt;] &lt;object&gt;[/&lt;wild-attr&gt;]
+           @wipe/owner[/&lt;switch(es)&gt;] &lt;owner&gt;/&lt;object&gt;[/&lt;wild-attr&gt;]
  
   This command erases attributes from an object.  All attributes that match
   &lt;wild-attr&gt; (or all attributes, if &lt;wild-attr&gt; is not specified) are removed
@@ -11149,18 +14802,26 @@ Generated: Wed Jan 13 04:15:48 2016
   This only works on objects set SAFE if the config options safe_wipe is set
   to 0.
   
+  Notice that &lt;owner&gt; needs to be specified if you use the /owner switch.
+   
   The following switches exist:
     /preserve    - wipe everything EXCEPT the wild-attr matches.  This in 
                    effect does the reverse of normal @wipe.
     /regexp      - use regular expression instead of standard glob-matching
+    /owner       - use an owner argument to wipe only attribs that is owned
+                   by the specified player.  You can use wild-attrs with
+                   this options.
+                   
   
   Example:
     &gt; @wipe me/va*
     Wiped - 1 attributes.
     &gt; @wipe/reg me/^.a$
     Wiped - 4 attributes.
+    &gt; @wipe/owner Corum/me/za*  (wipe all attribs matching za* owned by Corum)
+    Wiped - 1 attributes.
   
-  See Also: wipe(), @edit, @grep  
+  See Also: wipe(), @edit, @grep, @cluster, cluster_wipe()
 
 </PRE>
 <A HREF="#@whereis">[PREV]</A>
@@ -11168,40 +14829,170 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#@zone">[NEXT]</A>
 <BR>
 <HR><A NAME="@zone"><H3>@zone</H3></A><PRE>
- Usage:
-  1) @zone &lt;object or zonemaster&gt;
-  2) @zone/add &lt;object&gt;=&lt;zonemaster&gt;
-  3) @zone/del &lt;object or zonemaster&gt;=&lt;zonemaster or object&gt;
-  4) @zone/purge &lt;object or zonemaster&gt;
+  Command: @zone[/&lt;switch&gt;] &lt;target&gt; [=&lt;zone string&gt;]
+  
+  Note: A zonemaster can not belong as a member to another zonemaster.  If
+        you wish to chain commands to zonemasters, use parents or zone local
+        master rooms (help zonemaster,  help zonecontents).
+  
+  Usage:
+    1) @zone[/list] &lt;object or zonemaster&gt;
+    2) @zone/add &lt;object&gt;=&lt;zonemaster&gt;
+    3) @zone/del &lt;object or zonemaster&gt;=&lt;zonemaster or object&gt;
+    4) @zone/purge &lt;object or zonemaster&gt;
+    5) @zone/replace &lt;object&gt;=&lt;old zonemaster&gt;/&lt;new zonemaster&gt;
   
   The @zone command adds and removes zone master entries from objects.
   An object may be a member of multiple zones.
- 
-  * Usage 1 will list the zones an object belongs to, or the objects that
-    belong to a zonemaster.
-  * Usage 2 will add a zone to an object.
-  * Usage 3 will delete an object from a zone, or zone from an object. These
-    are essentially the same, but from different directions.
-  * Usage 4 will remove all references to zones from an object or
-    zone master.  
- 
-  See Also: @lock, ZONES, lzone(), ZONEMASTER, ZONECONTENTS
+   
+    * Usage 1 will list the zones an object belongs to, or the objects that
+      belong to a zonemaster.
+    * Usage 2 will add a zone to an object.
+    * Usage 3 will delete an object from a zone, or zone from an object. These
+      are essentially the same, but from different directions.
+    * Usage 4 will remove all references to zones from an object or
+      zone master.  
+    * Usage 5 will replace the old zonemaster with the new zonemaster on the
+      target object.
+  
+  The config param 'zones_like_parents' can also be enabled to allow @zones
+  to function $commands to its members as if it was a @parent.
+   
+  Example:
+    &gt; @set #2=zonemaster
+    Set.
+    &gt; @set #2=zonecontents (for when we want a zone to have zonemastery fun)
+    Set.
+    &gt; @zone/add #1=#2 
+    Zone Master added to object.
+  
+  See Also: @lock, ZONES, zonecmd(), lzone(), ZONEMASTER, ZONECONTENTS
   
 </PRE>
 <A HREF="#@wipe">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#\*">[NEXT]</A>
+<BR>
+<HR><A NAME="\*"><H3>\*</H3></A><PRE>
+  Topic:  WILDCARDS [* and ?]  (also referred to as GLOBBING)
+  
+  Note: RhostMUSH also supports regular expressions.  Please refer to 
+        'help REGEXPS'
+  
+  Wildcards are the standard globbing mechanism for the mush engine.  With the
+  wildcards, the '*' character is considered 0 or more characters and the '?'
+  character is considered a single character.  These are used primarilly in
+  commands and functions that allow mulit-matching based on wild card support.
+  
+  Example:
+    &gt; say match(this is a test,?es*)
+    You say &quot;4&quot;
+  
+  Wildcards, however, are most useful for $command substitution matching.
+  When you create your own softcoded command, any argument you want
+  substituted you would place a '*' or a '?' for that argument.  Each argument
+  is then matched up with a numerical argument for each wildcard used.  The
+  first argument being %0, second being %1, and so forth.
+  
+  Example:
+    &gt; &amp;TEST1 me=$test1*:@emit Your First Test:%0
+    &gt; &amp;TEST2 me=$test2?:@emit Your Second Test:%0
+    &gt; &amp;TEST3 me=$test3 *:@emit Your Third Test:%0
+    &gt; test1
+    Your First Test:
+    &gt; test1 abc
+    Your First Test: abc  [notice the space between ':' and 'a']
+    &gt; test2
+    Huh? (Type 'help' for help)  [Because ? requires 1 character exactly]
+    &gt; test2X
+    Your Second Test:X
+    &gt; test2abc
+    Huh? (Type 'help' for help)  [Because ? required 1 character exactly]
+    &gt; test3
+    Huh? (Type 'help' for help)  [because you have a space in the command]
+    &gt; test3 abc
+    Your Third Test:abc  [notice no space between ':' and 'a']
+    
+  { See 'help wildcards2' for clarification and extended explainations }
+ 
+</PRE>
+<A HREF="#@zone">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#\?">[NEXT]</A>
+<BR>
+<HR><A NAME="\?"><H3>\?</H3></A><PRE>
+  Topic:  WILDCARDS [* and ?]  (also referred to as GLOBBING)
+  
+  Note: RhostMUSH also supports regular expressions.  Please refer to 
+        'help REGEXPS'
+  
+  Wildcards are the standard globbing mechanism for the mush engine.  With the
+  wildcards, the '*' character is considered 0 or more characters and the '?'
+  character is considered a single character.  These are used primarilly in
+  commands and functions that allow mulit-matching based on wild card support.
+  
+  Example:
+    &gt; say match(this is a test,?es*)
+    You say &quot;4&quot;
+  
+  Wildcards, however, are most useful for $command substitution matching.
+  When you create your own softcoded command, any argument you want
+  substituted you would place a '*' or a '?' for that argument.  Each argument
+  is then matched up with a numerical argument for each wildcard used.  The
+  first argument being %0, second being %1, and so forth.
+  
+  Example:
+    &gt; &amp;TEST1 me=$test1*:@emit Your First Test:%0
+    &gt; &amp;TEST2 me=$test2?:@emit Your Second Test:%0
+    &gt; &amp;TEST3 me=$test3 *:@emit Your Third Test:%0
+    &gt; test1
+    Your First Test:
+    &gt; test1 abc
+    Your First Test: abc  [notice the space between ':' and 'a']
+    &gt; test2
+    Huh? (Type 'help' for help)  [Because ? requires 1 character exactly]
+    &gt; test2X
+    Your Second Test:X
+    &gt; test2abc
+    Huh? (Type 'help' for help)  [Because ? required 1 character exactly]
+    &gt; test3
+    Huh? (Type 'help' for help)  [because you have a space in the command]
+    &gt; test3 abc
+    Your Third Test:abc  [notice no space between ':' and 'a']
+    
+  { See 'help wildcards2' for clarification and extended explainations }
+ 
+</PRE>
+<A HREF="#\*">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#\\">[NEXT]</A>
 <BR>
 <HR><A NAME="\\"><H3>\\</H3></A><PRE>
   Command: \\&lt;message&gt;
+  
   Outputs &lt;message&gt; to everyone in your current room without embellishment.
-  Example: the command '\\A chill falls over the room.' produces
-  'A chill falls over the room.'
+  
+  You may use two special attributes for pre and post processing of any
+  emits you receive.  These attributes will have substitutions evaluated
+  but will not evaluate functions.  If these attributes are set NO_COMMAND
+  then they will not be processed.
+    SPEECH_PREFIX  -- Contents will be evaluated before the @emit.
+    SPEECH_SUFFIX  -- Contents will be evaluated after the @emit.
+  
+  Both of these attributes handle three arguments.  These are:
+    %0 - The original @emit that triggered the attribute.
+    %1 - The date in the form MM/DD/YYYY
+    %2 - The time in the form HH:MM:SS
+    %3 - The dbref# of the player issuing the say/pose/emit (#-1 if spoofed)
+  
+  Example: 
+    &gt; \\A chill falls over the room.
+    A chill falls over the room.
   
   See Also: @emit, @oemit, NOSPOOF
   
 </PRE>
-<A HREF="#@zone">[PREV]</A>
+<A HREF="#\?">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#]">[NEXT]</A>
 <BR>
@@ -11215,6 +15006,96 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#\\">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#^MINUScommand">[NEXT]</A>
+<BR>
+<HR><A NAME="^MINUScommand"><H3>^-command</H3></A><PRE>
+  Flag: MONITOR(M)
+    
+  This flag does NOT return player connection/disconnection information.
+  Check help @toggle for that.
+   
+  When set, anytime the object hears something from someone who passes the
+  object's use lock, the object's attributes are scanned for attributes
+  of the form '^&lt;pattern&gt;:&lt;commandlist&gt;'.  If the message matches the
+  wildcarded &lt;pattern&gt;, then &lt;commandlist&gt; is executed, substituting %0 for
+  the text that matched the first wildcard, %1 for the second, and so on.
+  All matching attributes are executed, not just the first.
+  
+  ^-listens are never checked on players.
+  
+  Note: Parents of MONITOR objects by default are never checked 
+        for ^-patterns.  This can be enabled with the 'listen_parents'
+        config parameter, but there will be a computational cost involved.
+   
+  Example:
+    &gt; say %n
+    You say &quot;Bob&quot;
+    &gt; &amp;MY_LISTEN MyObject=^* says &quot;*&quot;:@pemit %#=Object: %0 said '%1'
+    &gt; say &quot;Moo&quot;
+    You say &quot;Moo&quot;
+    Object: Bob said 'Moo'
+    
+  See Also: LISTENING, PUPPET, @listen, @ahear, $-commands, lcmds(), lattr()
+  
+</PRE>
+<A HREF="#]">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#^MINUSlisten">[NEXT]</A>
+<BR>
+<HR><A NAME="^MINUSlisten"><H3>^-listen</H3></A><PRE>
+  Flag: MONITOR(M)
+    
+  This flag does NOT return player connection/disconnection information.
+  Check help @toggle for that.
+   
+  When set, anytime the object hears something from someone who passes the
+  object's use lock, the object's attributes are scanned for attributes
+  of the form '^&lt;pattern&gt;:&lt;commandlist&gt;'.  If the message matches the
+  wildcarded &lt;pattern&gt;, then &lt;commandlist&gt; is executed, substituting %0 for
+  the text that matched the first wildcard, %1 for the second, and so on.
+  All matching attributes are executed, not just the first.
+  
+  ^-listens are never checked on players.
+  
+  Note: Parents of MONITOR objects by default are never checked 
+        for ^-patterns.  This can be enabled with the 'listen_parents'
+        config parameter, but there will be a computational cost involved.
+   
+  Example:
+    &gt; say %n
+    You say &quot;Bob&quot;
+    &gt; &amp;MY_LISTEN MyObject=^* says &quot;*&quot;:@pemit %#=Object: %0 said '%1'
+    &gt; say &quot;Moo&quot;
+    You say &quot;Moo&quot;
+    Object: Bob said 'Moo'
+    
+  See Also: LISTENING, PUPPET, @listen, @ahear, $-commands, lcmds(), lattr()
+  
+</PRE>
+<A HREF="#^MINUScommand">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#_">[NEXT]</A>
+<BR>
+<HR><A NAME="_"><H3>_</H3></A><PRE>
+  Topic: WIZARD ATTRIBUTES
+  
+  This is a backward compatible ability to set attributes that are
+  wizard settable and seeable.  This is obsoleted now with the addition
+  of the wizard command '@aflags'.
+  
+  Examples: 
+    &gt; &amp;_foo me=Only a wiz can see or set this.
+    Set.
+    &gt; @aflags _foo
+    (Attribute 231028) Flags are: private [hidden wizard] 
+  
+  Wizard help: @aflags, _
+  
+  See Also: &amp;, @set
+
+</PRE>
+<A HREF="#^MINUSlisten">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#abode">[NEXT]</A>
 <BR>
 <HR><A NAME="abode"><H3>ABODE</H3></A><PRE>
@@ -11226,7 +15107,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: LINK_OK
   
 </PRE>
-<A HREF="#]">[PREV]</A>
+<A HREF="#_">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#abs()">[NEXT]</A>
 <BR>
@@ -11353,7 +15234,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say %f^Khazad ai-menu!%fn
     You say &quot;Kh(a-with-^)z(a-with-^)d (ai-with-^)-m(e-with-^)n(u-with-^)!&quot;
   
-  See Also: ACCENTS, chr(), asc(), tr(), stripaccents(), substitutions.
+  See Also: ACCENTS, chr(), asc(), tr(), stripaccents(), substitutions,
+            UNICODE SUPPORT
 
 </PRE>
 <A HREF="#accent3">[PREV]</A>
@@ -11369,6 +15251,10 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Accents are displayed by using the accent() function or the %f
   substitution.
+  
+  You can not set this when already toggled UTF8.
+  
+  See Also: accents(), UTF8 TOGGLE, UNICODE SUPPORT
 
 </PRE>
 <A HREF="#accent4">[PREV]</A>
@@ -11521,10 +15407,10 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="allof()"><H3>ALLOF()</H3></A><PRE>
   Function: ofparse(&lt;type&gt;, [&lt;eval1&gt; [,&lt;eval2&gt; ... &lt;evalN or delim&gt;]])
 
-  Type 1&amp;3: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 2&amp;4: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
-  Type 5&amp;7: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 6&amp;8: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
+  Type 1&amp;3: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 2&amp;4: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
+  Type 5&amp;7: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 6&amp;8: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
   
   This function will take each &lt;eval&gt; and returns it based on the &lt;type&gt;.
   
@@ -11764,6 +15650,72 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#andflag()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#andtotem()">[NEXT]</A>
+<BR>
+<HR><A NAME="andtotem()"><H3>ANDTOTEM()</H3></A><PRE>
+  Function: andtotem(&lt;target&gt;, &lt;flag1&gt; [&lt;flag2&gt; ... &lt;flagN&gt;])
+  
+  This function checks if the target has all of the specified totems.
+  
+  You may specify if the target does not have a given totem with the not (!)
+  operator.
+  
+  Examples:
+    &gt; say ltotems(me)
+    You say &quot;ONE TWO THREE FOUR&quot;
+    &gt; say andtotem(me,one three)
+    You say &quot;1&quot;
+    &gt; say andtotem(me,one zero seventeen)
+    You say &quot;0&quot;
+    &gt; say andtotem(me,one !zero !notatotem)
+    You say &quot;1&quot;
+    &gt; say andtotem(me,!zero !notatotem)
+    You say &quot;1&quot;
+  
+  See Also: andtotems(), ortotems(), ortotem(), ltotems(), totems(),
+            hastotem(), @totem
+  
+</PRE>
+<A HREF="#andflags()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#andtotems()">[NEXT]</A>
+<BR>
+<HR><A NAME="andtotems()"><H3>ANDTOTEMS()</H3></A><PRE>
+  Function: andtotems(&lt;target&gt;, &lt;flag-list1&gt; [,&lt;flag-list2&gt;, [,&lt;flag-list3&gt;]])
+  
+  This function checks if the target has all of the specified totems.  You may
+  also specify the !&lt;letter&gt; to check if it does not have the specified totem.
+  
+  If there is a totem that contains a '\' or a '!' you must escape it out
+  with the '\' escape character.
+  
+  Any inclusion of a '!' character will do reverse checking of the letter
+  following it.
+  
+  Normal totems will be in the flag-list1.
+  Any totem letters surrounded by []'s will be in the flag-list2.
+  Any totem letters surrounded by {}'s will be in the flag-list3.
+  
+  Examples:
+    &gt; say totems(me)
+    You say &quot;123[456]{789}&quot;
+    &gt; say andtotems(me,1,4,7)
+    You say &quot;1&quot;
+    &gt; say andtotems(me,,,9)
+    You say &quot;1&quot;
+    &gt; say andtotems(me,X,Y,8)
+    You say &quot;0&quot;
+    &gt; say andtotems(me,X,Y,Z)
+    You say &quot;0&quot;
+    &gt; say andtotems(me,1,!Y,!Z)
+    You say &quot;1&quot;
+  
+  See Also: ortotems(), ortotem(), andtotem(), ltotems(), totems(),
+            hastotem(), @totem
+
+</PRE>
+<A HREF="#andtotem()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#ansi">[NEXT]</A>
 <BR>
 <HR><A NAME="ansi"><H3>ANSI</H3></A><PRE>
@@ -11775,12 +15727,20 @@ Generated: Wed Jan 13 04:15:48 2016
   ANSICOLOR flag.  Without this flag, all ansi codes are stripped before
   you see them.
   
+  You may use ansi with ansi() or %c (or if configured %x/%m substitutions).
+  See '@list options system' to see what options are configured for ANSI.
+  
   You need both the ANSI and ANSICOLOR flags to see ansi color.
+  
+  For 256 color you need the XTERMCOLOR flag in addition to ANSI and 
+  ANSICOLOR.
+  
+{ 'help ansi usage' on how to use ansi}
   
   See Also: ANSICOLOR, XTERMCOLOR, SUBSTITUTIONS, ANSI(), NOFLASH, COLORS()
   
 </PRE>
-<A HREF="#andflags()">[PREV]</A>
+<A HREF="#andtotems()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#ansi functions">[NEXT]</A>
 <BR>
@@ -11788,8 +15748,10 @@ Generated: Wed Jan 13 04:15:48 2016
   Function Lists: Ansi Functions
       
   ansi()        - ANSI formats a string.
-  stripansi()   - Strips ANSI characters from a string.
+  ansipos()     - ANSI substitutions based on the position of the ansi string.
   colors()      - List colors or optionally display value of color.
+  editansi()    - Edit the ANSI of a string.
+  stripansi()   - Strips ANSI characters from a string.
 
 </PRE>
 <A HREF="#ansi">[PREV]</A>
@@ -11829,12 +15791,49 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;%cn&quot;                              (the %cn is highlight red)
     &gt; say ansi(hr,chr(37))                     
     You say &quot;%&quot;                                (the % is highlight red)
+  
+{ 'help ansi usage' on how to use ansi}
     
   See Also: ansi(), stripansi(), ANSI, ANSICOLOR, XTERMCOLOR, NO_FLASH, 
             SUBSTITUTIONS, XTERMCOLOR LIST, COLORS()
 
 </PRE>
 <A HREF="#ansi functions">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ansi usage">[NEXT]</A>
+<BR>
+<HR><A NAME="ansi usage"><H3>ANSI USAGE</H3></A><PRE>
+  Topic: ANSI USAGE
+  
+  Note: Make sure to @list options to see what percent subs handle ANSI!
+  
+  To use ANSI, you may use the ansi() function or ANSI substitutions.  You
+  may reference 'help ansi()' to see what syntaxes are allowed for ANSI.
+  
+  To enable ansi, you would set up the flags to see ansi.
+  The following flags are required:
+    ANSI       - This is the central ansi handler.  This handles base ANSI 
+                 codes like hilight, flash, and underscore but not color.
+    ANSICOLOR  - This, in addition to ANSI, will enable you the base set 
+                 of ansicodes.  This is the base 16 color set.
+    XTERMCOLOR - This, with the addition of ANSI and ANSICOLOR, allows
+                 the extended 256 color set.
+  
+  To use the ANSI function you would use:
+    16 color mode:
+    &gt; think ansi(hr,this is highlight red)
+    &gt; think %ch%crthis is highlight red%cn
+  
+  Do note that as far as the parser is concerned, ansi() and the %c subs
+  are exactly the same.  Also be aware that if ANSI subs are %x only, 
+  use %x instead of %c.
+  
+    256 color mode: 
+    &gt; think ansi(+pink,this is pink)
+    &gt; think ansi(0xda,this is also pink)
+    
+</PRE>
+<A HREF="#ansi quirks">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#ansi()">[NEXT]</A>
 <BR>
@@ -11869,9 +15868,10 @@ Generated: Wed Jan 13 04:15:48 2016
   
 { 'help ansi2' for more -- The 256 Color Support}
 { 'help ansi quirks' for work arounds on weird ansi problems}
+{ 'help ansi usage' on how to use ansi}
 
 </PRE>
-<A HREF="#ansi quirks">[PREV]</A>
+<A HREF="#ansi usage">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#ansi2">[NEXT]</A>
 <BR>
@@ -11914,6 +15914,7 @@ Generated: Wed Jan 13 04:15:48 2016
      
 { 'help ansi3' for more -- about XTERMCOLOR and ANSI examples }
 { 'help ansi quirks' for work arounds on weird ansi problems}
+{ 'help ansi usage' on how to use ansi}
   
 </PRE>
 <A HREF="#ansi()">[PREV]</A>
@@ -11958,6 +15959,7 @@ Generated: Wed Jan 13 04:15:48 2016
    
 { 'help ansi4' for more -- Flags required and information }
 { 'help ansi quirks' for work arounds on weird ansi problems}
+{ 'help ansi usage' on how to use ansi}
 
 </PRE>
 <A HREF="#ansi2">[PREV]</A>
@@ -11982,6 +15984,7 @@ Generated: Wed Jan 13 04:15:48 2016
             SUBSTITUTIONS, XTERMCOLOR LIST, COLORS()
 
 { 'help ansi quirks' for work arounds on weird ansi problems}
+{ 'help ansi usage' on how to use ansi}
   
 </PRE>
 <A HREF="#ansi3">[PREV]</A>
@@ -12016,6 +16019,104 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#ansicolor">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#ansipos()">[NEXT]</A>
+<BR>
+<HR><A NAME="ansipos()"><H3>ANSIPOS()</H3></A><PRE>
+  Function: ansipos(&lt;string&gt;, &lt;position&gt;)
+  
+  This function returns the markup of the ansified string based on the
+  position specified.  This will return the foreground, background, 
+  accents and UTF8 encoding for that position.
+  
+  Examples:
+    &gt; think [ansipos([ansi(+orange,orange)],5)]This string is orange%cn
+  
+  See Also: editansi(), pos(), ansi(), stripansi()
+  
+</PRE>
+<A HREF="#ansinames">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#api">[NEXT]</A>
+<BR>
+<HR><A NAME="api"><H3>API</H3></A><PRE>
+  Topic: API
+  
+  RhostMUSH has a process where it allows API connections to happen on another
+  port.  It requires to have the api_port specified to a unique port for the
+  API handler, then various optional config parameters to optimize how the
+  API works.  The API, unlike normal connections, allows any valid dbref# to
+  talk to the mush from the API engine.  It does this through multi-factor
+  authentication including host match and password authentication.
+  
+  Keep in mind, the API port is NOT the mush port.  It is a different port.
+  There is also quite a lot of protection on the API port which will
+  automatically disable the object or the IP from connecting if abused.
+  
+  It uses Basic Authorization and encapsulates.  Example of using curl for
+  login authentication to the API's object would be:
+             curl --user &quot;#123:foobar&quot;
+  
+  The dbref# would be #123, and the password you want to authenticate would
+  be 'foobar'.
+  
+  Example curl commands that are used for the API handler are:
+  GET Examples (this is from a command line using the 'curl' application)
+&gt; curl -X GET --user &quot;#12:ya&quot; -H &quot;Exec: [lnum(10)]&quot; --head http://localhost:2222
+  
+  POST Example: (this is from a command line using the 'curl' application)
+&gt; curl -X POST --user &quot;#12:ya&quot; -H &quot;Exec: @emit hi.&quot; --head http://localhost:2222
+  
+  To have a target dbref# enabled for API processing, please alert a staff
+  on your game as it requires staff approval and authentication to enable
+  the dbref# to be useable for the API sub engine.
+  
+{ see 'help api return' for expected return codes }
+
+</PRE>
+<A HREF="#ansipos()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#api return">[NEXT]</A>
+<BR>
+<HR><A NAME="api return"><H3>API RETURN</H3></A><PRE>
+  Topic: API RETURN
+
+  When the mush responds to your API requests, it will do so with headers
+  only.  There is no data submitted.  If there is header data it does not
+  recognize or is malformed, it will return an appropiate error message.
+
+  The following return encoding can be expected
+  POST:
+      HTTP/1.1 &lt;CODE&gt; OK
+      Content-type: text/plain
+      Date: Thu Jul  6 14:37:52 2017
+      Exec: &lt;STRING&gt;
+
+  GET:
+      HTTP/1.1 &lt;CODE&gt; OK
+      Content-type: text/plain
+      Date: Thu Jul  6 14:51:16 2017
+      Exec: &lt;STRING&gt;
+      Return: &lt;VALUE&gt;
+
+
+      -- &lt;CODE&gt; may be any of the following with matching &lt;STRING&gt;
+         200 - OK            &lt;STRING&gt;: Ok - Executed
+         400 - Bad Request   &lt;STRING&gt;: Error - Invalid Headers Supplied
+         400 - Bad Request   &lt;STRING&gt;: Error - Empty String
+         404 - Not Found     &lt;STRING&gt;: Error - Invalid target
+         403 - Forbidden     &lt;STRING&gt;: Error - Permission Denied
+         403 - Forbidden     &lt;STRING&gt;: Error - IP not allowed
+         403 - Forbidden     &lt;STRING&gt;: Error - Malformed User or Password
+
+      -- &lt;VALUE&gt; is the actual return value for a GET fetch.  This is what
+         the evaluated string will have been.
+  
+  For help on setting up, authentication, or administration of the API 
+  engine, please refer to the wizhelp topics for the API.
+
+</PRE>
+<A HREF="#api">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#aposs()">[NEXT]</A>
 <BR>
 <HR><A NAME="aposs()"><H3>APOSS()</H3></A><PRE>
@@ -12034,13 +16135,16 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: SUBSTITUTIONS, obj(), subj(), poss()
   
 </PRE>
-<A HREF="#ansinames">[PREV]</A>
+<A HREF="#api return">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#arbitrary commands">[NEXT]</A>
 <BR>
 <HR><A NAME="arbitrary commands"><H3>ARBITRARY COMMANDS</H3></A><PRE>
   Topic: ARBITRARY COMMANDS
  
+  If you wish to see the help for regular expression pattern matching, please
+  refer to 'help REGEXPS'.
+  
   You may define commands that are triggered whenever someone enters a command
   that matches the command template (wildcarding allowed).  These commands
   are called arbitrary commands, user-defined commands, or $-commands (for how
@@ -12049,9 +16153,11 @@ Generated: Wed Jan 13 04:15:48 2016
   and have failed (so an arbitrary command that matches 'page *' will never
   be performed).
  
-  You define an arbitrary command by storing a string of the form
-  '$&lt;template&gt;:&lt;commandlist&gt;' in an attribute of an object, then the command
-  will be available to anyone who carries the object, is in the same room as
+  You define an arbitrary command by storing a string of the form:
+              '$&lt;template&gt;:&lt;commandlist&gt;' 
+  
+  This will go in an attribute of an object, then the command will be 
+  available to anyone who carries the object, is in the same room as
   the object, or is inside the object.  Only use user-named attributes and
   VA-VZ for arbitrary commands, as many of the predefined attributes are not
   for arbitrary commands.  &lt;template&gt; is the pattern to check for (it may
@@ -12081,7 +16187,10 @@ Generated: Wed Jan 13 04:15:48 2016
   The following attributes are never checked for $-commands: ALIAS CHARGES
   DESC DROP FAIL IDESC ODESC ODROP OFAIL OSUCC SEX SUCC.
   
-  All $commands and ^listen pairs may be parsed using regular expressions.   
+  You may set the attribute with the $command or ^listen REGEXP which will
+  allow matching against regular expressions instead of globbing.  In 
+  such a case, all $commands and ^listen pairs would be parsed using 
+  regular expressions.   
   
   See Also: @set, &amp;, VATOVZ, ZATOZZ, $-COMMANDS, REGEXPS
   
@@ -12123,6 +16232,7 @@ Generated: Wed Jan 13 04:15:48 2016
   fdiv()      - Division with floating point support.
   floordiv()  - Returns the integer quotient from dividing two values.
   inc()       - Increases a value held in a register by 1.
+  mask()      - Applies a specified mask to a value.
   mod()       - Returns the integer remainder from dividing two values.
   modulo()    - Returns the modulo of two values
   mul()       - Multiplies two values.
@@ -12143,55 +16253,100 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="array()"><H3>ARRAY()</H3></A><PRE>
   Function: array(&lt;string&gt;, &lt;reg count&gt;, &lt;width&gt; [[,&lt;delim&gt; [,&lt;type&gt; [,&lt;sep&gt;]])
   
+  Note: Registers split into array are overwritten.  Use with caution or
+        localize().
+  
   This function will take an input string and split it out, based on width,
   rounding to the first viable word (if possible) and spit it out into setq
   registers based on the number of registers you wish to split it in based
   on &lt;reg count&gt;.  Registers start from 0-9 then go to a-z.  Registers
   are cleared automatically before being utilized.
   
-  You may specify an optional delimiter.  By default, it takes any white
-  space.  You may optionally specify the type.  A type of '1' will take
-  the virtual register count down then over.  The default '0' does it
-  in a normal sequential order.
+  You may specify an optional delimiter &lt;delim&gt;.  By default, it takes any 
+  white space.  You may optionally specify the type &lt;type&gt;.  A type of '1' 
+  will take the virtual register count down then over.  A type of '2' will
+  split based on character and not attempt to break on word.  A type of '3'
+  combines the down then over with type '2'.  The default '0' does it in a 
+  normal sequential order.  A &lt;type&gt; of '2' and a &lt;delim&gt; NULL (empty value)
+  will split the string in segments equally based on the number of registers.
   
-  If you specify width of '0' and specify a delimeter, then it will ignore
-  width of the values and split the array based on the delimiter only.
+  If you specify width &lt;width&gt; of '0' and specify a delimeter &lt;delim&gt;, then it 
+  will ignore width of the values and split the array based on the 
+  delimiter &lt;delim&gt; only.
   
   If you wish to store the setq registers prior to this function, please
   utilize the pushregs() function to back-up your registers.
   
-  The defaults seperator is '%r' (carrage return + line feed).  If you do
-  not wish this to be the case, you may specify your own seperator &lt;sep&gt;
+  The default separator is '%r' (carriage return + line feed).  If you do
+  not wish this to be the case, you may specify your own separator &lt;sep&gt;
   which can be one or more characters.
   
   This function is ansi aware. 
   
+{ see 'help array2' for examples }
+ 
+</PRE>
+<A HREF="#arithmetic functions">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#array2">[NEXT]</A>
+<BR>
+<HR><A NAME="array2"><H3>array2</H3></A><PRE>
+  (CONTINUED)
+  Function: array(&lt;string&gt;, &lt;reg count&gt;, &lt;width&gt; [[,&lt;delim&gt; [,&lt;type&gt; [,&lt;sep&gt;]])
+    
+  Fields with '*' are optional:
+      &lt;string&gt;    -- String you wish to split
+      &lt;reg count&gt; -- Number of setq registers to split into (36 max)
+                     This always starts with register '0'.
+      &lt;width&gt;     -- Optional width to cut on, '0' split on &lt;delim&gt;
+ *    &lt;delim&gt;     -- Optional delimiter to split on (NULL/empty value allowed)
+ *    &lt;type&gt;      -- 0 - default -- split in sequential (over then down) order
+                     1 - take the split down then over
+                     2 - Split based on &lt;delim&gt; (or position if &lt;delim&gt; NULL)
+                     3 - Combine type 1 &amp; 2
+ *    &lt;sep&gt;       -- Specify separator you wish for array elements (%r default)
+  
   Examples:
-    &gt; think array(abcdefghij,2,2)%q0
+    @@ split linear based on register count with default carrage return sep
+    @@ show contents of first register 
+    &gt; think array(abcdefghij,2,2)%q0       
     ab
     ef
     ij
-    
+  
+    @@ split linear based on register count with space sep
+    @@ show contents of first register
     &gt; think array(abcdefghij,2,2,,,%b)%q0
     ab ef ij
-
+  
+    @@ split linear based on register count with default carrage return sep
+    @@ show contents of second register
     &gt; think array(abcdefgh,2,2)%q1
     cd
     eh
-
+  
+    @@ split down then over with return sep
+    @@ show contents of first register
     &gt; think array(abcdefghij,2,2,,1)%q0
     ab
     cd
     ef
-
+  
+    @@ split down then over with return sep
+    @@ show contents of second register
     &gt; think array(abcdefghij,2,2,,1)%q1
     gh
     ij
   
-  See Also: printf(), setq(), setr(), r(), substitutions
+    @@ split string equally based on the number of registers
+    @@ show all registers and what they contain
+    &gt; think array(abcdefghij,3,0,,2)%q0 - %q1 - %q2
+    abcd - efg - hij
+  
+  See Also: printf(), setq(), setr(), r(), template(), substitutions
 
 </PRE>
-<A HREF="#arithmetic functions">[PREV]</A>
+<A HREF="#array()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#art()">[NEXT]</A>
 <BR>
@@ -12213,18 +16368,23 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: poss(), subj(), obj()
   
 </PRE>
-<A HREF="#array()">[PREV]</A>
+<A HREF="#array2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#asc()">[NEXT]</A>
 <BR>
 <HR><A NAME="asc()"><H3>ASC()</H3></A><PRE>
-  Function: asc(&lt;character&gt;)
+  Function: asc(&lt;character&gt; [,&lt;key&gt;])
   
   This function returns the ASCII numerical value of the given character.
   
+  If you specify a key of '1', then it will padd zeros (0) to a three
+  character number.  The default is zero '0'.
+   
   Examples:
   &gt; say asc(a)
   You say &quot;97&quot;
+  &gt; say asc(a,1)
+  You say &quot;097&quot;
   
   See Also: CHR()
   
@@ -12327,6 +16487,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="attrcnt()"><H3>ATTRCNT()</H3></A><PRE>
   Function: attrcnt(&lt;object&gt; [,&lt;key&gt;])
+  
   This returns the total number of attributes that the target object has.
   This gets around some limitations of words(lattr(&lt;object&gt;)) due to the
   parser limitation.  This attribute has the sideeffect of repairing
@@ -12351,6 +16512,51 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#atan2()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#attrib formatting">[NEXT]</A>
+<BR>
+<HR><A NAME="attrib formatting"><H3>ATTRIB FORMATTING</H3></A><PRE>
+  All NON-ACTION attributes allowed formatting are in: help attributes
+  
+  Attribute formatting can be accomplished multiple ways.  First, there is
+  a generic local 'format' for most @-attributes.  To process this format,
+  you need to set an attribute of the name 'format&lt;attr&gt;' on the target
+  (or parent, global parent, zone of the target. Use &lt;attr&gt;format if the
+  config parameter format_compatibility is enabled). If this attribute is
+  not found, it will then look at the global default parents for matching
+  attribute inheritance.  Any attribute that you wish to inherit default
+  pattern formatting must be set DEFAULT (attribute flag).  The desc is
+  passed into the formatting as '%0'.  Local formatting has priority
+  over global formatting.
+  
+  The DEFAULT attribute flag can be set in two ways.
+    1.  Individually on the attribute: @set #dbref/attribute=default
+    2.  Set it globally through two methods:
+        A.  Internal (built-in): @admin attr_access=attribute default  
+        B.  User defined:        @attribute/access attribute=default
+  
+  Option #1 will be cleared if or when the attribute is cleared.
+  Option #2-A can be done through the netrhost.conf file for permanence.
+  Option #2-B is always permanent and doesn't have to be re-issued.
+  
+  Note: Most RhostMUSHes will be configured to use &amp;FORMAT&lt;attr&gt;.
+        See '@list options system' to discover which method is in use.
+  
+  Examples:
+    &gt; @desc me=This is a test
+    &gt; @admin player_attr_default=123
+    &gt; @desc #123=-&lt; %0 &gt;-
+    &gt; lo me
+      -&lt; This is a test &gt;-
+    &gt; &amp;formatdesc me===&lt;%0&gt;==
+    &gt; lo me
+      ===&lt;This is a test&gt;===
+
+  See Also: ATTRIBUTES, ATTRIBUTE FLAG DEFAULT, @conformat, 
+            @exitformat, @nameformat, invformat
+
+</PRE>
+<A HREF="#attrcnt()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#attribute flag architect">[NEXT]</A>
 <BR>
 <HR><A NAME="attribute flag architect"><H3>ATTRIBUTE FLAG ARCHITECT</H3></A><PRE>
@@ -12360,7 +16566,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Only architect or higher may modify the attribute.
 
 </PRE>
-<A HREF="#attrcnt()">[PREV]</A>
+<A HREF="#attrib formatting">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#attribute flag atrlock">[NEXT]</A>
 <BR>
@@ -12676,27 +16882,29 @@ Generated: Wed Jan 13 04:15:48 2016
     VISUAL(V)       (this shows up when you set an attribute VISUAL)
     NO_INHERIT(I)   (this shows up when you set an attribute NO_INHERIT)
     LOCK(+)         (this shows when an attribute is @locked)
-    GUILDMASTER(g)  (this shows when an attribute is set GUILDMASTER)
-    ARCHITECT(A)    (this shows when an attribute is set ARCHITECT)
-    COUNCILOR(C)    (this shows when an attribute is set COUNCILOR)
-    ROYALTY(W)      (this shows when an attribute is set WIZARD)    
-    IMMORTAL(i)     (this shows when an attribute is set IMMORTAL)
-    GOD(G)          (this shows when an attribute is set GOD)
-    MDARK(M)        (this shows when an attribute is set HIDDEN)
+  * GUILDMASTER(g)  (this shows when an attribute is set GUILDMASTER)
+  * ARCHITECT(A)    (this shows when an attribute is set ARCHITECT)
+  * COUNCILOR(C)    (this shows when an attribute is set COUNCILOR)
+  * ROYALTY(W)      (this shows when an attribute is set WIZARD)    
+  * IMMORTAL(i)     (this shows when an attribute is set IMMORTAL)
+  * GOD(G)          (this shows when an attribute is set GOD)
+  * MDARK(M)        (this shows when an attribute is set HIDDEN)
     PRIVATE         (this shows when an attribute is set PRIVATE)
     NO_CLONE(N)     (this shows when an attribute is set NO_CLONE)
     NO_PARSE(n)     (this shows when an attribute is set NO_PARSE)
     SAFE(s)         (this shows when an attribute is set SAFE)
-    PINVISIBLE(p)   (this shows when an attribute is set PINVISIBLE)
-    DARK(D)         (this shows when an attribute is set DARK)
-    USELOCK(u)      (this shows when an attribute has a USELOCK)
+  * PINVISIBLE(p)   (this shows when an attribute is set PINVISIBLE)
+  * DARK(D)         (this shows when an attribute is set DARK)
+  * USELOCK(u)      (this shows when an attribute has a USELOCK)
     SINGLETHREAD(S) (this shows when an attribute is set SINGLETHREAD)
     DEFAULT(F)      (this shows when an attribute is set DEFAULT)
-    ATRLOCK(l)      (this shows when an attribute is set ATRLOCK)
-    LOGGED(m)       (this shows when an attribute is set LOGGED)
+  * ATRLOCK(l)      (this shows when an attribute is set ATRLOCK)
+  * LOGGED(m)       (this shows when an attribute is set LOGGED)
     REGEXP(R)       (this shows when REGEXP are enabled on attributes)
-    UNSAFE(U)	    (this shows when attributes bypass safer_ufun)
+  * UNSAFE(U)	    (this shows when attributes bypass safer_ufun)
    
+  Attribute flags marked with a '*' are restricted based on permission level.
+  
 {See 'help attribute flags2' for meanings of the attribute flags}
   
 </PRE>
@@ -12713,33 +16921,80 @@ Generated: Wed Jan 13 04:15:48 2016
     VISUAL              - The attribute is visual to anyone.
     NO_INHERIT          - The attribute is not inherited to it's children
     LOCK                - The attribute was @locked.
-    GUILDMASTER         - The attribute is modifyable by GuildMaster or higher
-    ARCHITECT           - The attribute is modifyable by Architect or higher
-    COUNCILOR           - The attribute is modifyable by Councilor or higher
-    ROYALTY             - The attribute is modifyable by Wizard or higher
-    IMMORTAL            - The attribute is modifyable by Immortal or higher
-    GOD                 - The attribute is modifyable only by #1
-    MDARK (HIDDEN)      - The attribute is wizard-hidden.
+  * GUILDMASTER         - The attribute is modifyable by GuildMaster or higher
+  * ARCHITECT           - The attribute is modifyable by Architect or higher
+  * COUNCILOR           - The attribute is modifyable by Councilor or higher
+  * ROYALTY             - The attribute is modifyable by Wizard or higher
+  * IMMORTAL            - The attribute is modifyable by Immortal or higher
+  * GOD                 - The attribute is modifyable only by #1
+  * MDARK (HIDDEN)      - The attribute is wizard-hidden.
     PRIVATE             - The attribute is private to the item.
     NO_CLONE            - The attribute is not copied on a @clone
     NO_PARSE            - The attribute does not parse %0-%9 with $commands
     SAFE                - The attribute is safe from modification.
-    PINVISIBLE          - The attribute is seeable by wizards/modifyable to any
-    DARK                - The attribute is #1 seeable only
-    USELOCK             - The attribute can have an ~attribute uselock
+  * PINVISIBLE          - The attribute is seeable by wizards/modifyable to any
+  * DARK                - The attribute is #1 seeable only
+  * USELOCK             - The attribute can have an ~attribute uselock
                           (See help on 'attribute uselock' for more info)
     SINGLETHREAD        - The attribute must wait for completion before re-ran
     DEFAULT             - The attribute 'inherits' built-in attr globals.
-    ATRLOCK             - The attribute has a format lock.
-    LOGGED              - The attribute is logged for sets/edits/clears.
+  * ATRLOCK             - The attribute has a format lock.
+  * LOGGED              - The attribute is logged for sets/edits/clears.
     REGEXP              - The attribute $/^ command/listen use regexp parsing
-    UNSAFE              - The attribute evaluates at object's permission level.
+  * UNSAFE              - The attribute evaluates at object's permission level.
                           (this is the default behavior w/o safer_ufun set)
-    
+   
+  Attribute flags marked with a '*' are restricted based on permission level.
+  
   See Also: FLAG LIST
  
 </PRE>
 <A HREF="#attribute flags">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#attribute formatting">[NEXT]</A>
+<BR>
+<HR><A NAME="attribute formatting"><H3>ATTRIBUTE FORMATTING</H3></A><PRE>
+  All NON-ACTION attributes allowed formatting are in: help attributes
+  
+  Attribute formatting can be accomplished multiple ways.  First, there is
+  a generic local 'format' for most @-attributes.  To process this format,
+  you need to set an attribute of the name 'format&lt;attr&gt;' on the target
+  (or parent, global parent, zone of the target. Use &lt;attr&gt;format if the
+  config parameter format_compatibility is enabled). If this attribute is
+  not found, it will then look at the global default parents for matching
+  attribute inheritance.  Any attribute that you wish to inherit default
+  pattern formatting must be set DEFAULT (attribute flag).  The desc is
+  passed into the formatting as '%0'.  Local formatting has priority
+  over global formatting.
+  
+  The DEFAULT attribute flag can be set in two ways.
+    1.  Individually on the attribute: @set #dbref/attribute=default
+    2.  Set it globally through two methods:
+        A.  Internal (built-in): @admin attr_access=attribute default  
+        B.  User defined:        @attribute/access attribute=default
+  
+  Option #1 will be cleared if or when the attribute is cleared.
+  Option #2-A can be done through the netrhost.conf file for permanence.
+  Option #2-B is always permanent and doesn't have to be re-issued.
+  
+  Note: Most RhostMUSHes will be configured to use &amp;FORMAT&lt;attr&gt;.
+        See '@list options system' to discover which method is in use.
+  
+  Examples:
+    &gt; @desc me=This is a test
+    &gt; @admin player_attr_default=123
+    &gt; @desc #123=-&lt; %0 &gt;-
+    &gt; lo me
+      -&lt; This is a test &gt;-
+    &gt; &amp;formatdesc me===&lt;%0&gt;==
+    &gt; lo me
+      ===&lt;This is a test&gt;===
+
+  See Also: ATTRIBUTES, ATTRIBUTE FLAG DEFAULT, @conformat, 
+            @exitformat, @nameformat, invformat
+
+</PRE>
+<A HREF="#attribute flags2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#attribute ownership">[NEXT]</A>
 <BR>
@@ -12763,7 +17018,7 @@ Generated: Wed Jan 13 04:15:48 2016
 { 'help attribute ownership2' for more }
   
 </PRE>
-<A HREF="#attribute flags2">[PREV]</A>
+<A HREF="#attribute formatting">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#attribute ownership2">[NEXT]</A>
 <BR>
@@ -12887,6 +17142,8 @@ Generated: Wed Jan 13 04:15:48 2016
   The following ways allow you to set trees and follow branching.
   Please be aware, @clusters and @wipe ARE NOT TREE AWARE!!!
   
+  If the target is set REQUIRE_TREES then set requires this method.
+ 
   Setting Attributes:
     @set  -- @set has a /tree switch, that when used with attribute setting,
              will set the entire branch list included in the attribute.  The
@@ -12980,7 +17237,7 @@ Generated: Wed Jan 13 04:15:48 2016
   For showing what the current TREE character is:
      @list options system
   
-  See Also: @set, &amp;, set(), rset(), lattr()
+  See Also: @set, &amp;, set(), rset(), lattr(), REQUIRE_TREES
 { wiz help: @aflags, @admin, vlimit, @attribute, lattrp() }
 
 </PRE>
@@ -13004,6 +17261,10 @@ Generated: Wed Jan 13 04:15:48 2016
   
   See @list options to see if USELOCKS are available for attributes.  
   Depending on the configuration of the rhostmush in question, uselocks may
+          - If the uselock attributes returns anything except '1' or null.
+  
+  See @list options to see if USELOCKS are available for attributes.  
+  Depending on the configuration of the rhostmush in question, uselocks may
   be disabled or you may need a wizard to set one up for you.
   
 </PRE>
@@ -13013,6 +17274,14 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="attribute uselocks"><H3>ATTRIBUTE USELOCKS</H3></A><PRE>
   Topic: Attribute uselocks
+  
+  A player must be @toggled ATRUSE in order to set and unset the USELOCK
+  attribute flag on an attribute.  If you need this, please ask a staff
+  about providing this for you.  This can be bypassed if it's configured
+  to globally allow it via the secure_atruselock config parameter.
+  
+  You may specify %0 to %9 as the arguments passed in the ^listen or
+  $command for to this lock.
   
   Attribute uselocks are a method where you can specify individual uselocks
   per command per object.  The path it takes to check uselocks are as 
@@ -13042,6 +17311,110 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#attribute uselock2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#attributeMINUScommands">[NEXT]</A>
+<BR>
+<HR><A NAME="attributeMINUScommands"><H3>attribute-commands</H3></A><PRE>
+  Help available for RhostMUSH Commands (continued):
+ 
+  @aahear    @aclone      @aconnect    @adescribe  @adfail       @adisconnect
+  @adrop     @aefail      @aenter      @afail      @agfail       @ahear
+  @akill     @aleave      @alfail      @alias      @amhear       @amove
+  @ansiname  @apay        @arfail      @asfail     @asuccess     @atfail    
+  @atofail   @atport      @aufail      @ause       @away         @caption 
+  @charges   @conformat   @cost        @cpattr     @describe     @dfail
+  @door      @drop        @ealias      @efail      @enter        @exitformat
+  @fail      @filter      @forwardlist @gfail      @grep         @guild 
+  @idesc     @idle        @infilter    @inprefix   @kill         @lalias    
+  @leave     @lfail       @listen      @move       @nameformat   @odescribe 
+  @odfail    @odrop       @oefail      @oenter     @ofail        @ogfail    
+  @okill     @oleave      @olfail      @omove      @opay         @orfail    
+  @osuccess  @otfail      @otofail     @otport     @oufail       @ouse
+  @oxenter   @oxleave     @oxtport     @pay        @prefix       @race      
+  @reject    @rfail       @runout      @salisten   @sasmell      @sataste
+  @satouch   @saystring   @selfboot    @sex        @sfail        @slisten     
+  @solisten  @sosmell     @sotaste     @sotouch    @ssmell       @startup   
+  @staste    @stouch      @success     @tfail      @titlecaption @tofail
+  @toggle    @tport       @ufail       +uptime     @use          @whereall  
+  @whereis   @zone        
+  
+  
+  See Also: @list
+  
+</PRE>
+<A HREF="#attribute uselocks">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#attributes">[NEXT]</A>
+<BR>
+<HR><A NAME="attributes"><H3>attributes</H3></A><PRE>
+  Help available for RhostMUSH Commands (continued):
+ 
+  @aahear    @aclone      @aconnect    @adescribe  @adfail       @adisconnect
+  @adrop     @aefail      @aenter      @afail      @agfail       @ahear
+  @akill     @aleave      @alfail      @alias      @amhear       @amove
+  @ansiname  @apay        @arfail      @asfail     @asuccess     @atfail    
+  @atofail   @atport      @aufail      @ause       @away         @caption 
+  @charges   @conformat   @cost        @cpattr     @describe     @dfail
+  @door      @drop        @ealias      @efail      @enter        @exitformat
+  @fail      @filter      @forwardlist @gfail      @grep         @guild 
+  @idesc     @idle        @infilter    @inprefix   @kill         @lalias    
+  @leave     @lfail       @listen      @move       @nameformat   @odescribe 
+  @odfail    @odrop       @oefail      @oenter     @ofail        @ogfail    
+  @okill     @oleave      @olfail      @omove      @opay         @orfail    
+  @osuccess  @otfail      @otofail     @otport     @oufail       @ouse
+  @oxenter   @oxleave     @oxtport     @pay        @prefix       @race      
+  @reject    @rfail       @runout      @salisten   @sasmell      @sataste
+  @satouch   @saystring   @selfboot    @sex        @sfail        @slisten     
+  @solisten  @sosmell     @sotaste     @sotouch    @ssmell       @startup   
+  @staste    @stouch      @success     @tfail      @titlecaption @tofail
+  @toggle    @tport       @ufail       +uptime     @use          @whereall  
+  @whereis   @zone        
+  
+  
+  See Also: @list
+  
+</PRE>
+<A HREF="#attributeMINUScommands">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#attrpass()">[NEXT]</A>
+<BR>
+<HR><A NAME="attrpass()"><H3>ATTRPASS()</H3></A><PRE>
+  Function: attrpass(&lt;object&gt;/&lt;attribute&gt;, &lt;password&gt;, &lt;type&gt;)
+ 
+  This function will set or check the password of the given attribute
+  on the given target.  You must control both the target &lt;object&gt; and
+  the destination &lt;attribute&gt; to either set or check the password.
+  
+  You can not use this function to set or check the default player
+  password attribute.  Attempting to do so will fail.  For immortals
+  there is a password function utility to do so.  This does not view
+  the password, as being hashed this is impossible.  It will only
+  allow a comparison of the password to the hashed value for 
+  validation. 
+  
+  A return code for both SET or CHK of '1' means a success.  0 is failure. 
+  
+  The following &lt;type&gt; are available for this function:
+    SET -- this will set the &lt;password&gt;.  You may abbreviate this.
+    CHK -- this will check against &lt;password&gt;.  You may abbreviate this.
+  
+  Note: &lt;password&gt; can not exceed 2048 characters.  DoS/DDoS limitation.
+        This may change based on crypto settings.
+    
+  Examples:
+    &gt; say attrpass(me/va, test, set)
+    You say &quot;1&quot;
+    &gt; say attrpass(me/va, test, chk)
+    You say &quot;1&quot;
+    &gt; say attrpass(me/va, notest, chk)
+    You say &quot;0&quot;
+    &gt; say attrpass(me/_wizonly, test, set)
+    You say &quot;0&quot;     (a normal player can't chk/set wizard attributes)
+  
+  See Also: @password, testlock()
+  
+</PRE>
+<A HREF="#attributes">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#audible">[NEXT]</A>
 <BR>
 <HR><A NAME="audible"><H3>AUDIBLE</H3></A><PRE>
@@ -13060,7 +17433,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @filter, @forwardlist, @prefix, PUPPET, MONITOR
  
 </PRE>
-<A HREF="#attribute uselocks">[PREV]</A>
+<A HREF="#attrpass()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#auditorium">[NEXT]</A>
 <BR>
@@ -13097,17 +17470,60 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#auditorium">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#band()">[NEXT]</A>
+<BR>
+<HR><A NAME="band()"><H3>BAND()</H3></A><PRE>
+  Function: mask(&lt;value&gt;,&lt;value&gt;[,&lt;masktype&gt;])
+            mask(&lt;value&gt;,&lt;value&gt;,...,&lt;value&gt;,&lt;masktype&gt;)
+  
+  This function will apply a specified mask to a value.  This can be
+  useful for bitwise anding/oring values together. (for those mathheads)
+  The values available for masktype are:
+     &amp; -- Bitwise AND 
+     | -- Bitwise OR
+     ^ -- Bitwise XOR
+     ~ -- Bitwise NAND (AND 1's compliment)
+     1 -- Bitwise BNOT (1's Compliment)
+     2 --              (2's Compliment)
+  
+  The default masktype is the bitwise AND (&amp;) (but only with 2 arguments).
+  
+  Please note, if you use more than 2 values, you must specify the masktype,
+  otherwise it'll assume the last argument is always the masktype.
+  
+  Examples:
+    &gt; say mask(3,4)
+    You say &quot;0&quot;
+    &gt; say mask(3,4,|)
+    You say &quot;7&quot;
+    &gt; say mask(3,4,^)
+    You say &quot;7&quot;
+  
+  See Also: edit(), regedit(), pack(), unpack(), packmath(), shl(), shr(),
+            crc32()
+  
+</PRE>
+<A HREF="#avg()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#bang notation">[NEXT]</A>
 <BR>
 <HR><A NAME="bang notation"><H3>BANG NOTATION</H3></A><PRE>
   Bang notation allows you to use '!' and '!!' in functions for 'not' and
   'not-not' functionality.  This works similiarilly to the C equivelant of
-  using 'bangs'.  You may also specify '!$' and '!!$' for FALSE or TRUE
-  conditions on functions that return string values.  Finally, you may
-  specify '!^' and '!!^' for true-boolean FALSE or TRUE conditions on
-  functions that return true-boolean based on the function t()'.
+  using 'bangs'.  A value of '1' means the condition was matched, '0' not.
+  The following formats are available with BANG support ([] is return value):
+    !   - 'not' BOOLEAN/MATH value.         Example:   !match(me,you)   [1]
+    !!  - 'not not' BOOLEAN/MATH value.     Example:  !!match(me,you)   [0]
+    !$  - 'not' STRING value.               Example:  !$grep(me,you)    [1]
+    !!$ - 'not not' STRING value.           Example: !!$grep(me,you)    [0]
+    !^  - 'not' TRUE BOOLEAN (like t())     Example:  !^grep(me,you)    [1]
+    !!^ - 'not not' TRUE BOOLEAN (like t()) Example: !!^grep(me,you)    [0]
   
+  You may also use these in %q&lt;&gt; substitutions,  %-&lt;num&gt; arguments, %i
+  substitutions and %d substitutions.
   
+  See 'help t()' for how TRUE BOOLEAN works.
+    
   Example:
     &gt; say match(one two three four five,four)
     You say &quot;4&quot;
@@ -13123,12 +17539,65 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;0&quot;
     &gt; say !!$space(1000)                  (spaces are not-null strings)
     You say &quot;1&quot; 
+    &gt; say [setq(0,space(1000))]%q&lt;!!$0&gt; // %q&lt;!!^0&gt;     (process register 0)
+    YOu say &quot;1 // 0&quot;     (spaces are not null // spaces are non-boolean)
+    &gt; say u(#lambda/[lit(%-!!$0 // %-!!^0)],space(10))  (process argument 0)
+    YOu say &quot;1 // 0&quot;     (spaces are not null // spaces are non-boolean)
   
   Bang notation may or may not be enabled based on the RhostMUSH that you are
   on.  Please check @list options to see if it is currently enabled.
   
+  See Also: %-, %q, %i, %d, t()
+  
 </PRE>
-<A HREF="#avg()">[PREV]</A>
+<A HREF="#band()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#bangs notation">[NEXT]</A>
+<BR>
+<HR><A NAME="bangs notation"><H3>BANGS NOTATION</H3></A><PRE>
+  Bang notation allows you to use '!' and '!!' in functions for 'not' and
+  'not-not' functionality.  This works similiarilly to the C equivelant of
+  using 'bangs'.  A value of '1' means the condition was matched, '0' not.
+  The following formats are available with BANG support ([] is return value):
+    !   - 'not' BOOLEAN/MATH value.         Example:   !match(me,you)   [1]
+    !!  - 'not not' BOOLEAN/MATH value.     Example:  !!match(me,you)   [0]
+    !$  - 'not' STRING value.               Example:  !$grep(me,you)    [1]
+    !!$ - 'not not' STRING value.           Example: !!$grep(me,you)    [0]
+    !^  - 'not' TRUE BOOLEAN (like t())     Example:  !^grep(me,you)    [1]
+    !!^ - 'not not' TRUE BOOLEAN (like t()) Example: !!^grep(me,you)    [0]
+  
+  You may also use these in %q&lt;&gt; substitutions,  %-&lt;num&gt; arguments, %i
+  substitutions and %d substitutions.
+  
+  See 'help t()' for how TRUE BOOLEAN works.
+    
+  Example:
+    &gt; say match(one two three four five,four)
+    You say &quot;4&quot;
+    &gt; say !match(one two three four five,four)
+    You say &quot;0&quot;
+    &gt; say !!match(one two three four five,four)
+    You say &quot;1&quot;
+    &gt; say !!$grab(this is a test,was)
+    You say &quot;0&quot;
+    &gt; say !!$grab(this is a test,this)
+    You say &quot;1&quot;
+    &gt; say !!^space(1000)                  (spaces are non-boolean strings)
+    You say &quot;0&quot;
+    &gt; say !!$space(1000)                  (spaces are not-null strings)
+    You say &quot;1&quot; 
+    &gt; say [setq(0,space(1000))]%q&lt;!!$0&gt; // %q&lt;!!^0&gt;     (process register 0)
+    YOu say &quot;1 // 0&quot;     (spaces are not null // spaces are non-boolean)
+    &gt; say u(#lambda/[lit(%-!!$0 // %-!!^0)],space(10))  (process argument 0)
+    YOu say &quot;1 // 0&quot;     (spaces are not null // spaces are non-boolean)
+  
+  Bang notation may or may not be enabled based on the RhostMUSH that you are
+  on.  Please check @list options to see if it is currently enabled.
+  
+  See Also: %-, %q, %i, %d, t()
+  
+</PRE>
+<A HREF="#bang notation">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#before()">[NEXT]</A>
 <BR>
@@ -13157,7 +17626,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: after(), first(), rest()
   
 </PRE>
-<A HREF="#bang notation">[PREV]</A>
+<A HREF="#bangs notation">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#being killed">[NEXT]</A>
 <BR>
@@ -13251,6 +17720,76 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#bittype()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#bnand()">[NEXT]</A>
+<BR>
+<HR><A NAME="bnand()"><H3>BNAND()</H3></A><PRE>
+  Function: mask(&lt;value&gt;,&lt;value&gt;[,&lt;masktype&gt;])
+            mask(&lt;value&gt;,&lt;value&gt;,...,&lt;value&gt;,&lt;masktype&gt;)
+  
+  This function will apply a specified mask to a value.  This can be
+  useful for bitwise anding/oring values together. (for those mathheads)
+  The values available for masktype are:
+     &amp; -- Bitwise AND 
+     | -- Bitwise OR
+     ^ -- Bitwise XOR
+     ~ -- Bitwise NAND (AND 1's compliment)
+     1 -- Bitwise BNOT (1's Compliment)
+     2 --              (2's Compliment)
+  
+  The default masktype is the bitwise AND (&amp;) (but only with 2 arguments).
+  
+  Please note, if you use more than 2 values, you must specify the masktype,
+  otherwise it'll assume the last argument is always the masktype.
+  
+  Examples:
+    &gt; say mask(3,4)
+    You say &quot;0&quot;
+    &gt; say mask(3,4,|)
+    You say &quot;7&quot;
+    &gt; say mask(3,4,^)
+    You say &quot;7&quot;
+  
+  See Also: edit(), regedit(), pack(), unpack(), packmath(), shl(), shr(),
+            crc32()
+  
+</PRE>
+<A HREF="#blind">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#bnot()">[NEXT]</A>
+<BR>
+<HR><A NAME="bnot()"><H3>BNOT()</H3></A><PRE>
+  Function: mask(&lt;value&gt;,&lt;value&gt;[,&lt;masktype&gt;])
+            mask(&lt;value&gt;,&lt;value&gt;,...,&lt;value&gt;,&lt;masktype&gt;)
+  
+  This function will apply a specified mask to a value.  This can be
+  useful for bitwise anding/oring values together. (for those mathheads)
+  The values available for masktype are:
+     &amp; -- Bitwise AND 
+     | -- Bitwise OR
+     ^ -- Bitwise XOR
+     ~ -- Bitwise NAND (AND 1's compliment)
+     1 -- Bitwise BNOT (1's Compliment)
+     2 --              (2's Compliment)
+  
+  The default masktype is the bitwise AND (&amp;) (but only with 2 arguments).
+  
+  Please note, if you use more than 2 values, you must specify the masktype,
+  otherwise it'll assume the last argument is always the masktype.
+  
+  Examples:
+    &gt; say mask(3,4)
+    You say &quot;0&quot;
+    &gt; say mask(3,4,|)
+    You say &quot;7&quot;
+    &gt; say mask(3,4,^)
+    You say &quot;7&quot;
+  
+  See Also: edit(), regedit(), pack(), unpack(), packmath(), shl(), shr(),
+            crc32()
+  
+</PRE>
+<A HREF="#bnand()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#bogus commands">[NEXT]</A>
 <BR>
 <HR><A NAME="bogus commands"><H3>BOGUS COMMANDS</H3></A><PRE>
@@ -13270,7 +17809,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @afail, @fail, @link, @lock, @ofail, @open, $-COMMANDS
   
 </PRE>
-<A HREF="#blind">[PREV]</A>
+<A HREF="#bnot()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#boolean values">[NEXT]</A>
 <BR>
@@ -13297,6 +17836,41 @@ Generated: Wed Jan 13 04:15:48 2016
   
 </PRE>
 <A HREF="#bogus commands">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#bor()">[NEXT]</A>
+<BR>
+<HR><A NAME="bor()"><H3>BOR()</H3></A><PRE>
+  Function: mask(&lt;value&gt;,&lt;value&gt;[,&lt;masktype&gt;])
+            mask(&lt;value&gt;,&lt;value&gt;,...,&lt;value&gt;,&lt;masktype&gt;)
+  
+  This function will apply a specified mask to a value.  This can be
+  useful for bitwise anding/oring values together. (for those mathheads)
+  The values available for masktype are:
+     &amp; -- Bitwise AND 
+     | -- Bitwise OR
+     ^ -- Bitwise XOR
+     ~ -- Bitwise NAND (AND 1's compliment)
+     1 -- Bitwise BNOT (1's Compliment)
+     2 --              (2's Compliment)
+  
+  The default masktype is the bitwise AND (&amp;) (but only with 2 arguments).
+  
+  Please note, if you use more than 2 values, you must specify the masktype,
+  otherwise it'll assume the last argument is always the masktype.
+  
+  Examples:
+    &gt; say mask(3,4)
+    You say &quot;0&quot;
+    &gt; say mask(3,4,|)
+    You say &quot;7&quot;
+    &gt; say mask(3,4,^)
+    You say &quot;7&quot;
+  
+  See Also: edit(), regedit(), pack(), unpack(), packmath(), shl(), shr(),
+            crc32()
+  
+</PRE>
+<A HREF="#boolean values">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#bounce">[NEXT]</A>
 <BR>
@@ -13326,7 +17900,7 @@ Generated: Wed Jan 13 04:15:48 2016
     Set.
   
 </PRE>
-<A HREF="#boolean values">[PREV]</A>
+<A HREF="#bor()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#bounceforward">[NEXT]</A>
 <BR>
@@ -13394,7 +17968,8 @@ Generated: Wed Jan 13 04:15:48 2016
   &gt; think brackets(v(desc))
   1 1 2 2 1 0             (This is: 1-[, 1-], 2-(, 2-), 1-{, 0-})
   
-  See Also: totpos(), numpos(), nummatch(), totmatch()
+  See Also: totpos(), numpos(), nummatch(), totmatch(), parenmatch(),
+            parenstr()
   
 </PRE>
 <A HREF="#bound()">[PREV]</A>
@@ -13416,6 +17991,41 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#brackets()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#bxor()">[NEXT]</A>
+<BR>
+<HR><A NAME="bxor()"><H3>BXOR()</H3></A><PRE>
+  Function: mask(&lt;value&gt;,&lt;value&gt;[,&lt;masktype&gt;])
+            mask(&lt;value&gt;,&lt;value&gt;,...,&lt;value&gt;,&lt;masktype&gt;)
+  
+  This function will apply a specified mask to a value.  This can be
+  useful for bitwise anding/oring values together. (for those mathheads)
+  The values available for masktype are:
+     &amp; -- Bitwise AND 
+     | -- Bitwise OR
+     ^ -- Bitwise XOR
+     ~ -- Bitwise NAND (AND 1's compliment)
+     1 -- Bitwise BNOT (1's Compliment)
+     2 --              (2's Compliment)
+  
+  The default masktype is the bitwise AND (&amp;) (but only with 2 arguments).
+  
+  Please note, if you use more than 2 values, you must specify the masktype,
+  otherwise it'll assume the last argument is always the masktype.
+  
+  Examples:
+    &gt; say mask(3,4)
+    You say &quot;0&quot;
+    &gt; say mask(3,4,|)
+    You say &quot;7&quot;
+    &gt; say mask(3,4,^)
+    You say &quot;7&quot;
+  
+  See Also: edit(), regedit(), pack(), unpack(), packmath(), shl(), shr(),
+            crc32()
+  
+</PRE>
+<A HREF="#brandy_mail toggle">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#byeroom">[NEXT]</A>
 <BR>
 <HR><A NAME="byeroom"><H3>BYEROOM</H3></A><PRE>
@@ -13430,7 +18040,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: GOING, @destroy
   
 </PRE>
-<A HREF="#brandy_mail toggle">[PREV]</A>
+<A HREF="#bxor()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#cand()">[NEXT]</A>
 <BR>
@@ -13455,35 +18065,48 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#caplist()">[NEXT]</A>
 <BR>
 <HR><A NAME="caplist()"><H3>CAPLIST()</H3></A><PRE>
-  Function: caplist(&lt;list&gt;[,&lt;delim&gt;[,&lt;osep&gt;[,&lt;key&gt;[,&lt;type&gt;]]]])
-
+  Function: caplist(&lt;list&gt; [,&lt;delim&gt; [,&lt;osep&gt; [,&lt;key&gt; [,&lt;type&gt; [,&lt;chars&gt;]]]]])
+  
   Returns &lt;list&gt; with the first character of each word capitalized.  You may
   specify an optional &lt;delim&gt; as a delimiter for the list input, otherwise the
   default of space will be used.  You may also specify an optional &lt;osep&gt;
-  as a separator for the list that is returned.
+  as a separator for the list that is returned.  If &lt;type&gt; is 512 you may 
+  specify the characters you wish to capitalize after.
   
   Additionally, an optional &lt;key&gt; may be specified which alters the behavior
   of the function slightly.  The key must be one of the following characters:
     - L:    Reduces the entire list to lower case before capitalization is
-            performed.
+            performed.  Allows &lt;type&gt; value.
     - N:    Performs capitalization naturally, and does not affect any other
             characters in the list (default).
     - T:    Performs a 'true' capitalization based on currently English
-            definition for titles.
+            definition for titles.  Allows &lt;type&gt; value.
   
-  A &lt;type&gt; of '1' will work with &lt;key&gt; values of 'L' or 'T' to optionally 
-  capitalize all words contained in a hyphon, optionally.  The default
-  behavior is to capitalize only the start of the word.  This &lt;type&gt; value
-  has no influence on the 'N' &lt;key&gt; type.
+  Note: If you specify a &lt;type&gt; with 'T' the character override will not
+  follow the 'true' capitalization.
+    
+  The following &lt;type&gt; values exist for special handling with &lt;key&gt;
+  'L' or 'T'.  These work as bitmasks so add the values to combine:
+       1  - capitalize all words after a hyphon -
+       2  - capitalize all words after a right parenthesis (
+       4  - capitalize all words after a right bracket [
+       8  - capitalize all words after a right brace {
+      16  - capitalize all words after a double quote &quot;
+      32  - capitalize all words after a single quote '
+      64  - capitalize all words after a period .
+     128  - capitalize all words after an underscore _
+     256  - capitalize all words after a backtick `
+     512  - capitalize all words after the specified character list &lt;chars&gt;
    
-  Example:
+  Examples:
     &gt; say caplist(the mAn in thE mOon).
     You say &quot;The MAn In ThE MOon.&quot;
-
     &gt; say caplist(the mAn in thE mOon,,|,L).
     You say &quot;The|Man|In|The|Moon.&quot;
+    &gt; say caplist(000.abc 111.cde 135.moon,,,L,512,.)
+    You say &quot;000.Abc 111.Cde 135.Moon&quot;
   
-  See Also: capstr()
+  See Also: capstr(), ucstr(), lcstr(), regedit()
 
 </PRE>
 <A HREF="#cand()">[PREV]</A>
@@ -13562,28 +18185,52 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#caseall()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
-<A HREF="#cd">[NEXT]</A>
+<A HREF="#cdark">[NEXT]</A>
 <BR>
-<HR><A NAME="cd"><H3>cd</H3></A><PRE>
-  Command: co &lt;name&gt; &lt;password&gt;
-           cd &lt;name&gt; &lt;password&gt;
-           ch &lt;name&gt; &lt;password&gt;
+<HR><A NAME="cdark"><H3>cdark</H3></A><PRE>
+  Command: co  &lt;name&gt; &lt;password&gt;  (short for connect)
+           cd  &lt;name&gt; &lt;password&gt;  (short for cdark)
+           ch  &lt;name&gt; &lt;password&gt;  (short for chidden)
+           cr  &lt;name&gt; &lt;password&gt;  (short for create)
+           reg &lt;name&gt; &lt;password&gt;  (short for register)
+  
+  Note:  To create/log in a character with spaces in their name, please use
+         &quot;&lt;name&gt;&quot;.  Ergo, surround your name with double quotes.
+         The 'register' command does not allow creation with spaces.
   
   These commands are only useful on the connect screen.  They are used to
-  connect to your account &lt;name&gt; with the provided &lt;password&gt;.  There are
-  currently three methods to do so.
+  create/connect to your account &lt;name&gt; with the provided &lt;password&gt;.  
+  These commands are not useable once you are connected to the mush.
   
-  They are as follows:
+  These commands are as follows:
      co  -- This option is the default and normal method to connect.
             This option has no special conditions or privilages.
+            Syntax: co player password
+                    co &quot;Player With Spaces&quot; password
+  
      ch  -- Wizards and anyone with the NOWHO @power (to @hide) can use this.
             This option will auto-hide the player when connecting.
             It defaults to the 'co' option if you can't @hide.
+            Syntax: ch player password
+                    ch &quot;Player With Spaces&quot; password
+  
      cd  -- Wizards and higher can use this to connect dark to the game.
             This effectively connects wiz-cloaked to the game.
             Immortals get auto-added to supercloak.
+            Syntax: cd player password
+                    cd &quot;Player With Spaces&quot; password
+     
+     cr  -- Allows creation of a player from the connect screen.
+            Syntax: cr player password
+                    cr &quot;Player With Spaces&quot; password
   
-  See Also: @aconnect, @adisconnect, @hide
+     reg -- If offline registration is enabled, allows the player to register
+            a character with a supplied email that is then used to email them
+            their password.
+            Syntax: reg player email@address
+                    reg &quot;Player With Spaces&quot; email@address
+  
+  See Also: @aconnect, @adisconnect, @hide, @register
             
 </PRE>
 <A HREF="#cat()">[PREV]</A>
@@ -13609,9 +18256,9 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;-5&quot;
   
   See Also: div(), floor(), mod(), round(), trunc()
-  
+
 </PRE>
-<A HREF="#cd">[PREV]</A>
+<A HREF="#cdark">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#center()">[NEXT]</A>
 <BR>
@@ -13636,65 +18283,67 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say printf($:-:^5s,a)            (the '^' specifies center justify)
     You say &quot;--a--&quot;
   
-  See Also: ljust(), rjust(), ljc(), rjc(), printf()
+  See Also: ljust(), rjust(), ljc(), rjc(), printf(), template()
   
 </PRE>
 <A HREF="#ceil()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
-<A HREF="#ch">[NEXT]</A>
-<BR>
-<HR><A NAME="ch"><H3>ch</H3></A><PRE>
-  Command: co &lt;name&gt; &lt;password&gt;
-           cd &lt;name&gt; &lt;password&gt;
-           ch &lt;name&gt; &lt;password&gt;
-  
-  These commands are only useful on the connect screen.  They are used to
-  connect to your account &lt;name&gt; with the provided &lt;password&gt;.  There are
-  currently three methods to do so.
-  
-  They are as follows:
-     co  -- This option is the default and normal method to connect.
-            This option has no special conditions or privilages.
-     ch  -- Wizards and anyone with the NOWHO @power (to @hide) can use this.
-            This option will auto-hide the player when connecting.
-            It defaults to the 'co' option if you can't @hide.
-     cd  -- Wizards and higher can use this to connect dark to the game.
-            This effectively connects wiz-cloaked to the game.
-            Immortals get auto-added to supercloak.
-  
-  See Also: @aconnect, @adisconnect, @hide
-            
-</PRE>
-<A HREF="#center()">[PREV]</A>
-<A HREF="#topic index">[TOP]</A>
 <A HREF="#changes">[NEXT]</A>
 <BR>
 <HR><A NAME="changes"><H3>changes</H3></A><PRE>
-  For a list of actual changes, see 'help revis'.
+  For historical changes file, please see 'help historical'
   
-  RhostMUSH, first originating in 1989/1990, was founded as a TinyMUD.
-  Though the current code runs a MUSH compatible kernal, we still use
-  the exact same database from that period.  You will find RhostMUSH
-  is nothing like a MUD, MUSH or a MUSE.  It is a hybrid of many systems.
-  The coders for RhostMUSH have put a lot of effort into adding changes 
-  and modifying the server.  You will find that pretty much any code 
-  will work properly here on RhostMUSH.  Another major change is error 
-  messages are randomized.  So if you see something strange, you're 
-  not being spoofed.  Also, if you notice a strange response, don't 
-  think it's a problem.  Talk to a staff person as the option you 
-  may be trying may be disabled.
+  All credits to players, codebases, or other is presented in the RHOST.CHANGES
+  file in the readme directory in the source distribution.  The credits are too
+  diverse and well too detailed to be sufficient as a small snippit in online
+  help.
   
-  The list of changes done to this server goes beyond any document
-  can describe.  The only resemblance this has to TinyMUSH or any
-  other variety of server is in its backward compatibility with
-  how it parses and functionality returns.
+  Beginning with Rhost 3.9.1, the Development team has tracked all changes to
+  the Rhost system in the helpfiles, so that users may see what changes have
+  been made with each revision.  Each change is detailed in bullet-point format
+  in a helpfile specific to its revision, along with the alias for the 
+  developer who completed the change. 
+  
+  Do note, effort was done to backport help as much as possible all the way
+  back to the initial 3.2.4 rewrite that started Rhost for what it is today.
+  
+  Any versioning of Rhost version 1.0 through 3.0 was sadly lost to time.
+  
+  The developers who may appear in these files are:
+     ASH - [Ashen-Shugar]     * AMB -  Ambrosia            EEH - [Noltar]
+     KRK - [Loki]               LNS - [Lensman]            ODN -  Odin
+     SEA - [Seawolf]            THO - [Thorin]             NYS - [Nyctasia]
+     ROK -  Rook                KAG -  Kage
+  
+  The current Lead Developer (which we change up) is marked with a '*'.
+  Developers who are MIA or retired are surrounded in []'s.
    
-  For help on these people, look at CREDITS
+  ***************************************************************************
+  *** Current Revision: 4.1.0p2
+  ***************************************************************************
   
-  See Also: CREDITS
+  Available Revisions:
+    1.0.0: 1.0.0p0 (NycMUD)
+    1.5.0: 1.5.0p0 (NycMUSE
+    2.0.0: 2.0.0p0 (SeawolfMUSE)
+    3.0.0: 3.0.0p0 (alpha - led to 3.2.0)
+    3.2.0: 3.2.0p0 (beta -- led to 3.2.4)
+    3.2.4: 3.2.4p0, 3.2.4p1,  3.2.4p2,  3.2.4p3,  3.2.4p4,  3.2.4p5,  3.2.4p6,
+           3.2.4p7, 3.2.4p8,  3.2.4p9,  3.2.4p10, 3.2.4p11, 3.2.4p12, 3.2.4p13,
+           3.2.4p14, 3.2.4p15, 3.2.4p16, 3.2.4p17, 3.2.4p18
+    3.9.0: 3.9.0p0, 3.9.0p1, 3.9.0p2
+    3.9.1: 3.9.1p0, 3.9.1p1, 3.9.1p2
+    3.9.2: 3.9.2p0, 3.9.2p1
+    3.9.3: 3.9.3p0, 3.9.3p1, 3.9.3p2
+    3.9.4: 3.9.4p0, 3.9.4p1, 3.9.4p2, 3.9.4p3, 3.9.4p4, 3.9.4p5
+    3.9.5: 3.9.5p0, 3.9.5p1, 3.9.5p2, 3.9.5p3, 3.9.5p4
+    4.0.0: 4.0.0p0, 4.0.0p1, 4.0.0p2, 4.0.0p3, 4.0.0p4
+    4.1.0: 4.1.0p0, 4.1.0p1, 4.1.0p2
   
+  See Also: historical, credits
+
 </PRE>
-<A HREF="#ch">[PREV]</A>
+<A HREF="#center()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#channel">[NEXT]</A>
 <BR>
@@ -13748,7 +18397,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="charin()"><H3>CHARIN()</H3></A><PRE>
   Function: charin(&lt;player&gt;[,&lt;type&gt;])
   
-  Charin returns the total number of characters of input that character has
+  Charin returns the total number of characters of input that player has
   received.  If the type is '1', it will return the information in the form
   of PORT:CHARIN.  
   
@@ -13766,7 +18415,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="charout()"><H3>CHAROUT()</H3></A><PRE>
   Function: charout(&lt;player&gt;[,&lt;type&gt;])
   
-  Charout returns the total number of characters of output that the character
+  Charout returns the total number of characters of output that the player
   has sent.  If the type is '1', it will return the information in the form
   of PORT:CHAROUT.
   
@@ -13781,14 +18430,67 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#charin()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#chidden">[NEXT]</A>
+<BR>
+<HR><A NAME="chidden"><H3>chidden</H3></A><PRE>
+  Command: co  &lt;name&gt; &lt;password&gt;  (short for connect)
+           cd  &lt;name&gt; &lt;password&gt;  (short for cdark)
+           ch  &lt;name&gt; &lt;password&gt;  (short for chidden)
+           cr  &lt;name&gt; &lt;password&gt;  (short for create)
+           reg &lt;name&gt; &lt;password&gt;  (short for register)
+  
+  Note:  To create/log in a character with spaces in their name, please use
+         &quot;&lt;name&gt;&quot;.  Ergo, surround your name with double quotes.
+         The 'register' command does not allow creation with spaces.
+  
+  These commands are only useful on the connect screen.  They are used to
+  create/connect to your account &lt;name&gt; with the provided &lt;password&gt;.  
+  These commands are not useable once you are connected to the mush.
+  
+  These commands are as follows:
+     co  -- This option is the default and normal method to connect.
+            This option has no special conditions or privilages.
+            Syntax: co player password
+                    co &quot;Player With Spaces&quot; password
+  
+     ch  -- Wizards and anyone with the NOWHO @power (to @hide) can use this.
+            This option will auto-hide the player when connecting.
+            It defaults to the 'co' option if you can't @hide.
+            Syntax: ch player password
+                    ch &quot;Player With Spaces&quot; password
+  
+     cd  -- Wizards and higher can use this to connect dark to the game.
+            This effectively connects wiz-cloaked to the game.
+            Immortals get auto-added to supercloak.
+            Syntax: cd player password
+                    cd &quot;Player With Spaces&quot; password
+     
+     cr  -- Allows creation of a player from the connect screen.
+            Syntax: cr player password
+                    cr &quot;Player With Spaces&quot; password
+  
+     reg -- If offline registration is enabled, allows the player to register
+            a character with a supplied email that is then used to email them
+            their password.
+            Syntax: reg player email@address
+                    reg &quot;Player With Spaces&quot; email@address
+  
+  See Also: @aconnect, @adisconnect, @hide, @register
+            
+</PRE>
+<A HREF="#charout()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#children()">[NEXT]</A>
 <BR>
 <HR><A NAME="children()"><H3>CHILDREN()</H3></A><PRE>
-  Function: children(&lt;obj&gt; [,&lt;key&gt;])
+  Function: children(&lt;obj&gt; [,&lt;key&gt;] [,&lt;objid&gt;])
   
   Returns all children (objects parented to &lt;obj&gt;) that can be found.
   As this is somewhat extensive on the CPU, it may be limited to wizards
   only in the future.
+  
+  If the optional &lt;objid&gt; is specified as '1', then it will return the
+  objid's instead of dbref#'s.
   
   The following optional keys are available:
     0 - list all children of the target (default)
@@ -13805,11 +18507,13 @@ Generated: Wed Jan 13 04:15:48 2016
   Parent set.
   &gt; say children(#5)
   You say &quot;#10 #15&quot;
+  &gt; say children(#5,,1)
+  You say &quot;#10:8185828282 #15:8282859018&quot;
   
   See Also: parents(), parent()
   
 </PRE>
-<A HREF="#charout()">[PREV]</A>
+<A HREF="#chidden">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#chkreality()">[NEXT]</A>
 <BR>
@@ -13822,7 +18526,7 @@ Generated: Wed Jan 13 04:15:48 2016
   You must control both the &lt;victom&gt; and the &lt;target&gt; to be able to get
   the reality, otherwise, it will return #-1.
   
-  See Also: txlevel(), rxlevel()
+  See Also: txlevel(), rxlevel(), rxdesc()
   
 </PRE>
 <A HREF="#children()">[PREV]</A>
@@ -13839,7 +18543,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Reality levels must be enabled for this function to be of use.
   
-  See Also: hasrxlevel(), hastxlevel(), rxlevel(), txlevel()
+  See Also: hasrxlevel(), hastxlevel(), rxlevel(), txlevel(), rxdesc()
   
 </PRE>
 <A HREF="#chkreality()">[PREV]</A>
@@ -13863,13 +18567,13 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="chomp()"><H3>CHOMP()</H3></A><PRE>
   Function: chomp(&lt;string&gt; [,&lt;option&gt;])
   
-  The chomp() function is used to strip carrage returns from the start,
+  The chomp() function is used to strip carriage returns from the start,
   end, or both sides of a string.
   
   The following options are available:
-    l - strip carrage returns on left side of string.
-    r - strip carrage returns on right side of string.
-    b - strip carrage returns on both sides of string (default).
+    l - strip carriage returns on left side of string.
+    r - strip carriage returns on right side of string.
+    b - strip carriage returns on both sides of string (default).
    
   Examples:
   &gt; say chomp(%rthis is a test%r)
@@ -13952,7 +18656,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say citer(bob,## WHEE ##,@)
     You say &quot;b WHEE b@o WHEE o@b WHEE b&quot;
   
-  See Also: iter(), nsiter(), list(), @dolist, creplace(), foreach()
+  See Also: iter(), nsiter(), list(), @dolist, creplace(), foreach(), inf()
   
 </PRE>
 <A HREF="#chr()">[PREV]</A>
@@ -14820,7 +19524,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Examples:
     &gt; @set cluster#1=royalty (let's assume you're a wizard)
-    &gt; @va cluster#1=[num(*Miriar)] (the ghod character - #1)
+    &gt; @va cluster#1=[num(*Miriar)] (the ghod player - #1)
     &gt; say cluster_ueval(va/royalty)
     You say &quot;#1&quot;
   
@@ -14967,7 +19671,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#cluster_wipe()">[NEXT]</A>
 <BR>
 <HR><A NAME="cluster_wipe()"><H3>CLUSTER_WIPE()</H3></A><PRE>
-  Function: cluster_wipe(&lt;object&gt;[/wildattr] [,&lt;regxp&gt;])
+  Function: cluster_wipe(&lt;obj&gt;[/wildattr] [[,&lt;regexp&gt;] [,&lt;ownkey&gt;] [,&lt;pres&gt;]])
+            cluster_wipe(&lt;owner&gt;/&lt;obj&gt;[/wildattr], [,&lt;regexp&gt;], 1, [,&lt;pres&gt;])
   
   The cluster_wipe() function will remove all matching attributes 
   specified by a wildcard, or, if no attribute is specified, 
@@ -14978,14 +19683,22 @@ Generated: Wed Jan 13 04:15:48 2016
   If &lt;regexp&gt; is specified as '1', then &lt;wildattr&gt; is evaluated as a
   regular expresion instead of the default expresion.
   
+  If &lt;ownkey&gt; is specified as '1', then, as the second syntax example above,
+  it takes the additional &lt;owner&gt; argument as the owner to compare against.
+  
+  If &lt;pres&gt; is specified as '1', it takes the reverse of the wipe and
+  keeps (preserves) the specified wildcard pattern and wipes everything else.
+  
   Check @list options to see if this side-effect is enabled.
   Anything using this side-effect must have the SIDEFX flag set.
   
   Examples:
+    &gt; say cluster_wipe(Corum/#123/*foo,,1)  
+    You say &quot;Wiped: [20 objects: 0 not found, 0 safe] 1 attributes wiped.&quot;
     &gt; say cluster_wipe(#123)
-    You say &quot;&quot;
+    You say &quot;Wiped: [20 objects: 0 not found, 0 safe] 127 attributes wiped.&quot;
     &gt; say cluster_wipe(#123/*foo*)
-    You say &quot;&quot;
+    You say &quot;Wiped: [20 objects: 0 not found, 0 safe] 0 attributes wiped.&quot;
   
   See Also: @cluster, cluster_attrcnt(), cluster_default(), cluster_edefault(),
             cluster_get(), cluster_get_eval(), cluster_grep(), 
@@ -15093,40 +19806,441 @@ Generated: Wed Jan 13 04:15:48 2016
   colorization or accents that they may have.  When called with an exit 
   it returns the only the first alias.
   
+  This will colorize/accent the name using @ansiname or @extansi.
+  
   Example:
     &gt; say cname(me)
     You say &quot;TinyPlayer&quot;  (this would be colorized and/or accented)
    
-  See Also: fullname(), @alias, @name, name()
+  See Also: fullname(), @alias, @name, name(), @ansiname, @extansi, %k
 
 </PRE>
 <A HREF="#cmds()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
-<A HREF="#co">[NEXT]</A>
+<A HREF="#coding">[NEXT]</A>
 <BR>
-<HR><A NAME="co"><H3>co</H3></A><PRE>
-  Command: co &lt;name&gt; &lt;password&gt;
-           cd &lt;name&gt; &lt;password&gt;
-           ch &lt;name&gt; &lt;password&gt;
+<HR><A NAME="coding"><H3>CODING</H3></A><PRE>
+  Topic: CODING
   
-  These commands are only useful on the connect screen.  They are used to
-  connect to your account &lt;name&gt; with the provided &lt;password&gt;.  There are
-  currently three methods to do so.
+  This topic discusses the ins and outs of mush programming.  While not a 
+  complete document by any regard, it should help you understand the basics
+  and get around programming on a mush.
   
-  They are as follows:
-     co  -- This option is the default and normal method to connect.
-            This option has no special conditions or privilages.
-     ch  -- Wizards and anyone with the NOWHO @power (to @hide) can use this.
-            This option will auto-hide the player when connecting.
-            It defaults to the 'co' option if you can't @hide.
-     cd  -- Wizards and higher can use this to connect dark to the game.
-            This effectively connects wiz-cloaked to the game.
-            Immortals get auto-added to supercloak.
+  Note: The INHERIT flag will be required on any item that is intended to
+        modify or fetch attributes from other items than itself.  There 
+        are exceptions to this (like the visual flag) as well as 
+        @powers that may grant the item additional powers.
   
-  See Also: @aconnect, @adisconnect, @hide
-            
+  There are sub-topics available with coding that you may reference at
+  anytime.  These are:
+  
+    CODING QUEUE   -- A quick overview of how the queue works in the mush
+    CODING COMMAND -- A quick overview of what defines a command
+    CODING FUNCT   -- A quick overview of what defines a function
+    CODING NEST    -- A quick overview of operators to nest commands
+    CODING ATTRIB  -- A quick overview of setting attributes
+    CODING REGS    -- A quick overview of temporary registers/arguments
+    CODING SUBS    -- A quick overview of substitutions
+  
+    WILDCARDS      -- Help on how wildcards work
+    REGEXP         -- If you feel adventurous for regular expressions
+  
+  To continue with the overview and explain how a general layout works,
+  please see 'CODING2'.
+  
 </PRE>
 <A HREF="#cname()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding attrib">[NEXT]</A>
+<BR>
+<HR><A NAME="coding attrib"><H3>CODING ATTRIB</H3></A><PRE>
+  Topic: CODING ATTRIB
+  
+  Attributes are a 'permanent' storage of values.  The content that can be
+  stored on attributes are limited by the buffer limit for the mush in
+  question.  The buffer limit can be 4K, 8K, 16K, 32K, or 64K.  You may
+  find out the size of the buffer with the command:
+  
+  &gt; say config(lbuf_size)
+  You say &quot;32768&quot;   (note, this would be 32K) 
+  &gt; say config(sbuf_size)
+  You say &quot;64&quot;
+  
+  When setting attributes, you give it three arguments.  The name of
+  the attribute (which we will be calling ATTRIBUTE), the target that
+  you will set the attribute on (which we will be calling TARGET), and
+  the contents you wish to set to this (which we will be calling CONTENT).
+  The attribute can be most characters (primarilly alpha-numeric) that is
+  under an SBUF in size.  This is by default 32 bytes, but can be extended 
+  to 64 bytes.  
+  
+  When setting attributes there are multiple methods to do so.  First,
+  we will cover commands that allow you to do so.
+  Setting attributes:
+    &gt; &amp;ATTRIBUTE TARGET=CONTENTS     (&amp; is shorthand for '@set')
+    &gt; @set TARGET=ATTRIBUTE:CONTENTS (this works like the &amp; command above)
+  
+  Fetching attributes: (note: examine and @decompile allow wildcards)
+    &gt; examine TARGET
+    &gt; examine TARGET/ATTRIBUTE
+    &gt; @decompile TARGET
+    &gt; @decompile TARGET/ATTRIBUTE
+  
+  Editing attributes: (note: @edit allows wildcards)
+    &gt; @edit TARGET/ATTRIBUTE=OLD,NEW
+  
+  Copying Attributes: (note: @cpattr allows wildcards)
+    &gt; @cpattr TARGET/ATTRIBUTE=DESTINATION
+    &gt; @cpattr TARGET/ATTRIBUTE=DESTINATION/NEWATTRIBUTE
+  
+  Moving Attributes:
+    &gt; @cpattr/clear TARGET/ATTRIBUTE=DESTINATION
+    &gt; @cpattr/clear TARGET/ATTRIBUTE=DESTINATION/NEWATTRIBUTE
+    &gt; @mvattr TARGET=ATTRIBUTE,NEWATTRIBUTE
+  
+  Clearing Attributes: (note: @wipe allows wildcards)
+    &gt; @wipe TARGET/ATTRIBUTE 
+    &gt; &amp;ATTRIBUTE TARGET
+    &gt; @set TARGET=ATTRIBUTE:
+  
+{ See 'help coding attrib2' for functions used to manipulate attributes }
+
+</PRE>
+<A HREF="#coding">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding attrib2">[NEXT]</A>
+<BR>
+<HR><A NAME="coding attrib2"><H3>CODING ATTRIB2</H3></A><PRE>
+  Topic: CODING ATTRIB2
+  
+  Just like commands, you may use functions to set and clear attributes.
+  Since these affect objects and 'events' as a side-effect, these are 
+  considered 'side effect functions' and will require the SIDEFX flag to
+  be set on anything DIRECTLY using these functions.  
+  
+  The following functions are used to manipulate attribute data.
+  Setting attributes:
+    &gt; @eval set(TARGET, ATTRIBUTE:CONTENTS)
+  
+  Fetching attributes: (note: lattr takes wildcards)
+    &gt; @eval lattr(TARGET/ATTRIBUTE)
+    &gt; @eval get(TARGET/ATTRIBUTE)
+    &gt; @eval xget(TARGET,ATTRIBUTE)
+  
+  Fetching &amp; Executing attributes: (not a complete list)
+    &gt; @eval u(TARGET/ATTRIBUTE)
+    &gt; @eval ueval(TARGET/ATTRIBUTE/CITIZEN)
+    &gt; @eval ulocal(TARGET/ATTRIBUTE)
+    &gt; @eval eval(TARGET,ATTRIBUTE)
+    &gt; @eval subeval(TARGET,ATTRIBUTE)
+  
+  Editing attributes:
+    &gt; @eval edit(CONTENTS,OLD,NEW)
+ 
+  Clearing attributes: (note: wipe allows wildcards)
+    &gt; @eval wipe(TARGET/ATTRIBUTE)
+    &gt; @eval set(TARGET,ATTRIBUTE:)
+  
+  This list is not complete and there are quite a few functions that allow
+  manipulation of attributes and data.  Please review help files for these.
+   
+</PRE>
+<A HREF="#coding attrib">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding command">[NEXT]</A>
+<BR>
+<HR><A NAME="coding command"><H3>CODING COMMAND</H3></A><PRE>
+  Topic: CODING COMMAND
+  
+  To see commands please type:  @list commands.  'help' available on each.
+  
+  A 'command' is defined as a call to a process that essentailly forks its
+  own sandbox for running its pre-defined execution.  Examples of commands
+  are 'think', '@emit', '@pemit', 'page', 'say', 'pose', and so forth.  
+  Commands should not be confused with functions, since a segment MUST
+  start with a command, and you can't start a segment with a function.
+  
+  It's easier to consider that each command starts its own sandbox, and
+  functions are used to manipulate the environment of that given command.
+  
+  You may nest commands together and link them one after another, in
+  such a situation, the environment 'pokes holes' into each sandboxed
+  environment and allows the commands that follow the previous command
+  to be able to see and inherit values that may have been manipulated or
+  seen by the previous command.
+  
+  One way that you can preserve values to pass to other commands is with
+  arguments.  Most commands accept arguments to them which you can string
+  and pass along.
+  
+  The other way is setting registers, which are essentially pre-allocated
+  buffers that you may store values into that can be accessed by any
+  command following the previous commands in the sequence.  Once the
+  command sequence is finished, the registers are reset and cleared
+  automatically.  There is no way to preserve these values and it is
+  always considered to be temporary until the process of all the commands
+  in the sequence is completed.
+
+
+</PRE>
+<A HREF="#coding attrib2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding funct">[NEXT]</A>
+<BR>
+<HR><A NAME="coding funct"><H3>CODING FUNCT</H3></A><PRE>
+  Topic: CODING FUNCT
+  
+  'help function type' is very informative and it's requested you check
+  that out for a list of functions for every 'type'.
+  
+  To see functions please type: @list functions.  'help' available on each.
+  
+  A 'function' is considered a method to manipulate, display, or set the
+  environment that the command has set up.  There are literally hundreds
+  of functions that you may use, and with the use of @lfunction 
+  (or @function for wizards) you may define any number of additional
+  functions with softcode for the game and user-space to use.  The mushing
+  language is highly extensible and allows some heavy modifications.
+  
+  You may nest functions or string them together.
+  
+  Example of nesting functions:
+  &gt; say [add(sub(mul(3,3),2,div(10,5)),20)]
+  You say &quot;25&quot;
+  The above example is doing:  ((3 * 3) - 2 - (10 / 5)) + 20
+  
+  Example of stringing functions:
+  &gt; say [add(1,1)][sub(4,3)][mul(10,10)]
+  You say &quot;21100&quot;
+  The above example is displaying '2' '1' and '100' strung together.
+  
+  All functions allow manipulation of the input and/or output of each given
+  command, and some special functions like sideeffects allow you to do 
+  things outside of that given command.  Again, help is available on them all.
+  
+  With the use of functions and commands, you will find MUSH an extensive
+  interpreted language and quite powerful in its own right.
+   
+</PRE>
+<A HREF="#coding command">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding nest">[NEXT]</A>
+<BR>
+<HR><A NAME="coding nest"><H3>CODING NEST</H3></A><PRE>
+  Topic: CODING NEST
+  
+  You may nest commands or functions with the use of {}'s, []'s, or ()'s.  The
+  previous is mostly used for command nesting, and the latter used for
+  function nesting and declaration.
+  
+  Command Nesting: An example of command nesting
+  $foo*:@wait 10={@emit 1;@swi [trim(%0)]=bob,{@emit bob;@emit was;@emit here}}
+  
+  In this example, if you specify 'bob' as the argument to foo, it will
+  display '1', 'bob', 'was', 'here' on separate lines.  Notice the trim()
+  function around the argument (%0).  This is trimming extra spaces around the
+  argument so that you don't have ' bob', ' bob ', or 'bob ' as commands which
+  based on comparisons may or may not work as expected.  It's essentially one 
+  of the ways to control the data that you are being given.
+  
+  If you pass 'foo' anything but 'bob', all you will get is '1' and nothing
+  else.
+  
+  Function Nesting: An example of function nesting 
+  &gt; say [add(sub(1,1),2)]
+  You say '2'
+  
+  You are, in this example, subtracting 1 and 1, passing that nested value to
+  the 'add' function and then adding that result to the number '2'.  So
+  in this case, 1 - 1 is 0, and 0 + 2 is 2, so you will be returning '2'
+  
+</PRE>
+<A HREF="#coding funct">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding queue">[NEXT]</A>
+<BR>
+<HR><A NAME="coding queue"><H3>CODING QUEUE</H3></A><PRE>
+  Topic: CODING QUEUE
+  
+  The mush queue is a single threaded interpreted parser.  It works by pushing
+  and popping entries into and out of the queue based on a timed or event
+  driven engine.  Each time something is pushed onto the queue, it is
+  evaluated then popped off.  If you have a command that has itself other
+  commands, then it queues those results, so please keep that in mind when
+  programming.
+  
+  An example of how you would queue a command is as follows.
+  
+  &gt; @wait 0={think 1;think 2;@switch 1=1,think 3;think 4}
+  1
+  2
+  4
+  3
+
+  WAAIIIIT a minute.  Why was this out of order?  The reason why is because
+  of how the queue works.  The command 'think' pushes the contents on the
+  queue.  The command '@switch' pushes the contents on the queue.  However,
+  the contents of @switch is, itself, a command and the @switch command
+  then queues and executes its own arguments.  This requires a SECOND call
+  to the queue.  Remember, the queue is processed linearilly and in order.
+  
+  So to wrap up, the first order of queue would be:
+  -&gt; think, think, @switch, think
+  
+  The second order of queue would be:
+  -&gt; think
+
+</PRE>
+<A HREF="#coding nest">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding regs">[NEXT]</A>
+<BR>
+<HR><A NAME="coding regs"><H3>CODING REGS</H3></A><PRE>
+  Topic: CODING REGS
+  
+  Registers (and arguments) are special substitutions that hold the values
+  that you have either set before time or are passing into a command or
+  function.  To store temporary values, you use two functions to do so:
+  &gt; say setq(0,bob)
+  You say &quot;&quot;
+   
+  This will store 'bob' to register '0'.  This function as seen returns
+  nothing.  You have 36 registers that you can use.  0-9 and a-z.  
+  You may label these registers with any name you want that is 32 characters 
+  or less in length.  The label may contain spaces.
+  
+  &gt; say setr(0,bob)
+  You say &quot;bob&quot;
+  
+  This function works just like setq(), but notice it not only stores the 
+  value, but it returns the value you have set.  This is intentional and
+  used when you plan to store the value but still need to have the results
+  returned for evaluation.  Like setq(), you may specify labels where the
+  same rules apply.
+  
+  Arguments are temporary only for the runtime of that given command or
+  function.   With commands you can have:
+  $foo *=*:@emit Args: %0 and %1.
+  
+  The command 'foo' has two arguments.  argument 0 (%0) will be before the
+  '=' and argument 1 (%1) will be after the '='.  You may pass this multiple
+  words.  You can use '*' or '?' for wildcards.  You may also use regular
+  expressions if you feel adventerous, but that is for advanced coding.
+  
+  See 'help wildcard' to see more on normal wildcarding.
+  See 'help regexp' to see more on regular expressions.
+
+</PRE>
+<A HREF="#coding queue">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding subs">[NEXT]</A>
+<BR>
+<HR><A NAME="coding subs"><H3>CODING SUBS</H3></A><PRE>
+  Topic: CODING SUBS
+  
+  Substitutions are a quick reference to call a value that may dynamically
+  change.  For example, '%n' will reference the name of whatever is 
+  executing the code, and '%#' is the dbref# that is calling.  For a list
+  of all substitutions, please see 'help substitutions'.  It lists all
+  the subs as well as a short description of how they work.  Don't hesitate
+  to play with the values to see how they work.  You won't hurt anything
+  by doing so :)
+  
+  Examples:
+  &gt; say %# %n
+  You say &quot;#123 Bob&quot;
+  &gt; say [setq(0,foo)]Register is: %q0
+  You say &quot;Register is: foo&quot;
+  
+</PRE>
+<A HREF="#coding regs">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding2">[NEXT]</A>
+<BR>
+<HR><A NAME="coding2"><H3>CODING2</H3></A><PRE>
+  Topic: CODING2
+  
+  When you start coding on a mush, each sequence usually starts with a
+  command, which then uses functions to manipulate the data the command
+  is calling.  You may also make soft-coded commands ($-commands in help)
+  by starting a command with a '$' and then any wildcards with '*' for
+  1 or more characters or '?' meaning one character only.  You may use
+  the ^ command for having objects listen for a word sequence.  Please
+  refer to 'help monitor' to explain a bit more on how ^ sequences work.
+  
+  When you establish a softcoded command, the sequence works as follows:
+  &amp;ATTRIBUTE TARGET=$command *:COMMAND1;COMMAND2;...;COMMANDx
+  
+  Example: (assuming you own an object 'Fred' with dbref #123)
+  &amp;BOO #123=$boo *:@pemit %#=You have booed '%0'.
+  
+  Breaking this down.  #123 is the dbref# of 'Fred'.  The dbref# will
+  always be unique in a mush database.  BOO is the attribute that you
+  set with the '&amp;' command.  'boo' is the command it will be looking
+  for, identified with the '$' starter character.  You have one argument
+  being passed signified with the '*' character.  The command it is
+  executing is '@pemit', and it's using the percent substitutions '%#'
+  which is specifying the dbref# of whatever is enacting the command,
+  which in this case would be you.  The '%0' at the end is the argument
+  that aligns with the wildcard.  All arguments start at '0' and go
+  from 0-9.  You can have more than 9 arguments but that becomes more
+  complex code.  So if you had two *'s and one ?, the first two *'s 
+  would be %0 and %1 respectively, and the ? would be %2.
+  
+  So, we have set our BOO attribute to the 'boo' command.  Let's now
+  execute the command:
+  &gt; boo
+  Huh? (Type 'help' for help)
+  
+  Ok, wait a second.  Why didn't it see the command?  The answer if
+  you look at the command makes sense.  It's expecting an argument
+  AFTER a space.  If you wanted the argument to be optional you would
+  instead set it like:
+  &amp;BOO #123=$boo*:@pemit %#=You have booed '%0'.
+  
+  Notice no space between 'boo' and '*'.  So let's try it again:
+  &gt; boo
+  You have booed ''
+  &gt; boo abc123
+  You have booed 'abc123'
+  
+{ help coding3 to learn how to nest commands }
+
+</PRE>
+<A HREF="#coding subs">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#coding3">[NEXT]</A>
+<BR>
+<HR><A NAME="coding3"><H3>CODING3</H3></A><PRE>
+  Topic: CODING3
+  
+  You may nest commands together with the ';' identifier.  This will
+  link commands together.  If you with to 'cluster' commands together,
+  you may use the {}'s characters to surround a list of commands you
+  wish to link together.
+  
+  For example:
+  $foo *:@switch %0=yes,{@emit 1;@emit 2;@emit 3},no,{@emit A;@emit B;@emit C}
+  
+  In this example, if you typed 'foo yes' it would display 1, 2, and 3.
+  If you typed 'foo no' it would instead display A, B, and C.
+  
+  The @switch command (which you may shorten to @swi), executes a 'switch'
+  or evaluation based on what you specified.  In this case you are comparing
+  '%0' (or what is typed after foo), to two expected arguments.  'yes' or
+  'no'.  @switch allows multiple arguments, as well as a default value.
+  Note with how it's set up above, if foo does not have a 'yes' or 'no' value
+  you will get no output since @switch is expecting 'yes' or 'no' only and
+  has no default case to fall back on.
+  
+  You may notice that you use {}'s to cluster the commands for each separate
+  conditional.  You may nest {}'s inside each other for nested @switches or
+  other commands that allow arguments passed to them of commands.  Such
+  example commands are @switch, @ifelse, @skip, @sudo, @force, @wait, and
+  so forth.
+
+</PRE>
+<A HREF="#coding2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#colors">[NEXT]</A>
 <BR>
@@ -15148,7 +20262,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: SUBSTITUTIONS, ANSI, ANSICOLOR, XTERMCOLOR, ANSI()
   
 </PRE>
-<A HREF="#co">[PREV]</A>
+<A HREF="#coding3">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#colors()">[NEXT]</A>
 <BR>
@@ -15162,7 +20276,10 @@ Generated: Wed Jan 13 04:15:48 2016
   Valid optional &lt;value&gt; parameters:
     0-2     - page value of the total list of colornames available. (0 def)
     string  - the string of the color name you wish to see the value of.
+              You may use the literal string or +string (like pink or +pink)
     *wild*  - the list of colors that match the wildcard (* and ? accepted)
+   any ansi - With the '(n)ame' option you may specify anything you'd pass
+              ansi() and have it return the names matching the encoding.
   
   Valid &lt;key&gt; parameters:
     d       - show the decimal value (0-255) of the XTERM specific color (def).
@@ -15170,6 +20287,9 @@ Generated: Wed Jan 13 04:15:48 2016
     c       - show the 16 color code translation of the XTERM specific color.
     x       - show the 24bit (#000000-#FFFFFF) color code XTERM translation.
     r       - show the RGB (0 0 0 - 255 255 255) color code XTERM translation.
+    n       - show the name of the ansi() encoding passed.
+  
+  Note: you can not use wildcards with a key.
   
   Examples:
     &gt; say colors()
@@ -15204,7 +20324,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * &lt;ct&gt;     - Specifies that the word be cut off if over maximum columns size.
                Arguments: 1 to cut, 0 for no cutting (default).
   * &lt;lb&gt;     - What text you want displayed as the left border of the line.
-  * &lt;mb&gt;     - What text you want as the seperator between columns on the line.
+  * &lt;mb&gt;     - What text you want as the separator between columns on the line.
   * &lt;rb&gt;     - What text you want displayed as the right border of the line.
   * &lt;dsp&gt;    - What display type you want.  Down then over or over then down.
                Arguments: 1 for over then down, 0 for down then over (default)
@@ -15276,7 +20396,7 @@ Generated: Wed Jan 13 04:15:48 2016
       &lt;*-=*=--this|-=*=--=*is|-=*=--=*=a*&gt;
       &lt;*-=*=--test|-=*=--=*of|-=*columns*&gt;
   
-  See Also: wrapcolumns(), wrap(), array(), printf()
+  See Also: wrapcolumns(), wrap(), array(), printf(), template()
   
 </PRE>
 <A HREF="#columns2">[PREV]</A>
@@ -15363,32 +20483,34 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="commands"><H3>commands</H3></A><PRE>
   Help available for RhostMUSH Commands:
    
-  ]          &quot;            :            ;            &amp;              #
-  \\         &gt;
+  ]         &quot;           :            ;            &amp;             #
+  \\        &gt;
   
-  +channel   doing        drop         enter        examine        folder     
-  get        give         goto         grab         help           +help 
-  idle       INFO         inventory    join         kill           leave      
-  listen     LOGOUT       look         lpage        mail           move       
-  mrpage     news         OUTPUTPREFIX OUTPUTSUFFIX page           pose       
-  QUIT       read         rpage        say          score          SESSION    
-  smell      take         taste        think        throw          touch      
-  train      use          version      wield        whisper        who        
+  +channel  doing       drop         enter        examine       folder     
+  get       give        goto         grab         help          +help 
+  idle      INFO        inventory    join         kill          leave      
+  listen    LOGOUT      look         lpage        mail          move       
+  mrpage    news        OUTPUTPREFIX OUTPUTSUFFIX page          pose       
+  QUIT      read        rpage        say          score         SESSION    
+  smell     take        taste        think        throw         touch      
+  train     use         version      wield        whisper       who        
   worn
   
-  @@         @break       @chown       @clone       @create        @decompile
-  @destroy   @dig         @doing       @dolist      @drain         @edit 
-  @emit      @entrances   @eval        @extansi     @femit         @find      
-  @force     @fpose       @fsay        @halt        @hide          @include
-  @last      @link        @list        @listmotd    @lfunction     @lock      
-  @mailsig   @mvattr      @name        @notify      @oemit         @open      
-  @parent    @password    @pemit       @pipe        @program       @protect   
-  @ps        @quitprogram @quota       @register    @robot         @search    
-  @set       @skip        @sql         @sqlconnect  @sqldisconnect @stats     
-  @sudo      @sweep       @switch      @teleport    @trigger       @unlink    
-  @unlock    @verb        @wait        @wall        @wipe        
+  @@           @break      @chown      @clone         @create       @decompile
+  @destroy     @dig        @doing      @dolist        @drain        @edit 
+  @emit        @entrances  @eval       @extansi       @femit        @find      
+  @force       @fpose      @fsay       @goto          @halt         @hide
+  @include     @jump       @label      @last          @link         @list
+  @listmotd    @lfunction  @lock       @lset          @ltag         @mailsig 
+  @mvattr      @name       @notify     @oemit         @open         @parent  
+  @password    @pemit      @pipe       @program       @protect      @ps      
+  @quitprogram @quota      @register   @robot         @search       @set     
+  @skip        @sql        @sqlconnect @sqldisconnect @stats        @sudo
+  @sweep       @switch     @teleport   @totem         @trigger      @unlink     
+  @unlock      @verb       @wait       @wall          @wipe        
   
 { 'help commands2' for more (attribute-commands) }
+
 </PRE>
 <A HREF="#command evaluation2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -15443,14 +20565,27 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#comp()">[NEXT]</A>
 <BR>
 <HR><A NAME="comp()"><H3>COMP()</H3></A><PRE>
-  Function: comp(&lt;string1&gt;, &lt;string2&gt;)
- 
-  Comp compares two strings.  It returns 0 if they are the same, 1 if
+  Function: comp(&lt;string1&gt;, &lt;string2&gt; [,&lt;type&gt;])
+   
+  Comp compares two values.  It returns 0 if they are the same, 1 if
   string2 is less than/precedes alphabetically string1, and -1 
   otherwise.
   
+  The following &lt;type&gt; types are available:
+    A - Always case-sensitive (default)
+    I - Always case-insensitive 
+    D - Dbrefs of valid objects (warns if invalid dbref#'s)
+    N - Integers
+    F - Floating point numbers
+  
   Example:
     &gt; say comp(is,is)
+    You say &quot;0&quot;
+    &gt; say comp(is,is,a)
+    You say &quot;0&quot;
+    &gt; say comp(is,IS)
+    You say &quot;1&quot;
+    &gt; say comp(is,IS,i)
     You say &quot;0&quot;
   
   See Also: alphamin(), alphamax(), ncomp(), strdistance()
@@ -15488,6 +20623,9 @@ Generated: Wed Jan 13 04:15:48 2016
   With no arguments, this function returns a list of config option names.
   
   Given a config option name, this function returns its value.
+  
+  Special values 'lbuf_size', 'mbuf_size' and 'sbuf_size' exist to pull
+  the sizes of the various buffers for compatibility to other codebases.
   
   The available special arguments can be used:
     0 - show all config options pushing extras on additional stack (default)
@@ -15536,6 +20674,56 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#config()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#connect">[NEXT]</A>
+<BR>
+<HR><A NAME="connect"><H3>connect</H3></A><PRE>
+  Command: co  &lt;name&gt; &lt;password&gt;  (short for connect)
+           cd  &lt;name&gt; &lt;password&gt;  (short for cdark)
+           ch  &lt;name&gt; &lt;password&gt;  (short for chidden)
+           cr  &lt;name&gt; &lt;password&gt;  (short for create)
+           reg &lt;name&gt; &lt;password&gt;  (short for register)
+  
+  Note:  To create/log in a character with spaces in their name, please use
+         &quot;&lt;name&gt;&quot;.  Ergo, surround your name with double quotes.
+         The 'register' command does not allow creation with spaces.
+  
+  These commands are only useful on the connect screen.  They are used to
+  create/connect to your account &lt;name&gt; with the provided &lt;password&gt;.  
+  These commands are not useable once you are connected to the mush.
+  
+  These commands are as follows:
+     co  -- This option is the default and normal method to connect.
+            This option has no special conditions or privilages.
+            Syntax: co player password
+                    co &quot;Player With Spaces&quot; password
+  
+     ch  -- Wizards and anyone with the NOWHO @power (to @hide) can use this.
+            This option will auto-hide the player when connecting.
+            It defaults to the 'co' option if you can't @hide.
+            Syntax: ch player password
+                    ch &quot;Player With Spaces&quot; password
+  
+     cd  -- Wizards and higher can use this to connect dark to the game.
+            This effectively connects wiz-cloaked to the game.
+            Immortals get auto-added to supercloak.
+            Syntax: cd player password
+                    cd &quot;Player With Spaces&quot; password
+     
+     cr  -- Allows creation of a player from the connect screen.
+            Syntax: cr player password
+                    cr &quot;Player With Spaces&quot; password
+  
+     reg -- If offline registration is enabled, allows the player to register
+            a character with a supplied email that is then used to email them
+            their password.
+            Syntax: reg player email@address
+                    reg &quot;Player With Spaces&quot; email@address
+  
+  See Also: @aconnect, @adisconnect, @hide, @register
+            
+</PRE>
+<A HREF="#conn()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#connected">[NEXT]</A>
 <BR>
 <HR><A NAME="connected"><H3>CONNECTED</H3></A><PRE>
@@ -15548,7 +20736,7 @@ Generated: Wed Jan 13 04:15:48 2016
   for things like tabulating players for the WHO list, etc.
   
 </PRE>
-<A HREF="#conn()">[PREV]</A>
+<A HREF="#connect">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#control">[NEXT]</A>
 <BR>
@@ -15660,13 +20848,9 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#copyright">[NEXT]</A>
 <BR>
 <HR><A NAME="copyright"><H3>COPYRIGHT</H3></A><PRE>
-  All modifications and changes to the hardcode of this mush called RhostMUSH
-  are privileged. Any copying of code in part or in full of the changes we have
-  done is not allowed.  If concepts or ideas are borrowed, it is requested
-  that permission be gotten first and required that credits be given to this
-  mush for ideas gotten from this server.  This text can not be modified,
-  changed, or removed on other servers.
-  
+  RhostMUSH is open source and freely distributed.  You can get it
+  on github at https://github.com/RhostMUSH/trunk
+
 </PRE>
 <A HREF="#convtime()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -15781,20 +20965,26 @@ Generated: Wed Jan 13 04:15:48 2016
     
       - This will copy the given attribute to 'attr1' and 'attr2' of the
         the destination object.  You may specify from one to any number
-        of destination attributes.
+        of destination attributes.  You may use the /verify switch to
+        enforce destination attribute validation.
   
   Syntax: @cpattr &lt;object&gt;/&lt;attribute&gt;=&lt;object1&gt;,&lt;object2&gt;/&lt;attr1&gt;
   
       - This will copy the given attribute to an attribute of the same name
         on the first object and copy it with the name 'attr1' on the second
         object.  Any number of objects may be listed.  You may specify
-        multiple attributes per object as well.
- 
+        multiple attributes per object as well.  You may use the /verify
+        switch to enforce destination attribute validation.
+   
   Syntax: @cpattr &lt;object&gt;/&lt;wildcard&gt;=&lt;object1&gt;,...,&lt;objectX&gt;
  
       - This will copy all attributes matching the wildcard to the destination
         object(s).  You may specify from one to any number of destination
-        objects but must control the objects to copy the attributes.
+        objects but must control the objects to copy the attributes.  You may
+        use the /verbose switch to expand wildcards to all the attributes that
+        matched, and you may use the /verify switch to validate attributes.
+        However, in this syntax, using /validate is redundant as source 
+        attributes will all be valid.
    
 { 'help cpattr3' for more }
   
@@ -15808,18 +20998,22 @@ Generated: Wed Jan 13 04:15:48 2016
   Syntax: @cpattr &lt;attribute&gt;=&lt;object&gt;/&lt;attrib&gt;,...
   
       - This copies the attribute on the ENACTOR to the target.  You can
-        specify multiple targets.
+        specify multiple targets.  You may usethe /verify switch to enforce
+        attribute validation.
   
   Syntax: @cpattr/clear &lt;args&gt;
- 
+   
       - The clear switch is usable with all the previous mentioned @cpattr
         commands. (help cpattr2 for help on these).  This will work just like
         the prior, except this will also purge (remove) the attributes that
         are being copied from the original object.  This acts basically like
-        a move.
+        a move.  You may use the /verify switch to verify on the /clear to
+        enforce clearing will not happen on bad destination naming.
  
   @cpattr returns detailed information of objects copied from and to and
-  any attributes successfully copied.
+  any attributes successfully copied.  With the /verify switch it will also
+  list any invalid attributes attempting to be copied.  /verbose will expand
+  all wildcards on source being copied.
    
   See Also: @mvattr, @set, &amp;
   
@@ -15850,9 +21044,10 @@ Generated: Wed Jan 13 04:15:48 2016
     Set.
     &gt; timehog
     Toy says &quot;1040&quot;
-    Toy&gt; [CPU:  7.74  EVALS: 2005  FUNCS: 1003  ATRFETCH:    1]
+    Toy&gt; [CPU:  7.74  EVALS: 2005  FUNCS: 1003  ATRFETCH:    1  Allocs:   176]
   
-  For explanations of what CPU, EVALS, FUNCS, and ATRFETCH is, see CPUTIME2
+  For explanations of what CPU, EVALS, FUNCS, ATRFETCH, and ALLOCS are, 
+  see CPUTIME2
   
 </PRE>
 <A HREF="#cpattr3">[PREV]</A>
@@ -15873,6 +21068,9 @@ Generated: Wed Jan 13 04:15:48 2016
   
   ATRFETCH    - The total number of attribute fetches (IE: the number of
                 times it has to read any attribute)
+  ALLOCS      - The total number of buffer allocations that occurred with
+                the running of the command.  While this is a minor overhead
+                it still remains an overhead.
                 
 </PRE>
 <A HREF="#cputime toggle">[PREV]</A>
@@ -15895,17 +21093,72 @@ Generated: Wed Jan 13 04:15:48 2016
     629126998
   
   See Also: pack(), unpack(), mask(), tobin(), tohex(), tooct(), todec(),
-            digest()
+            digest(), packmath()
   
 </PRE>
 <A HREF="#cputime2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#create">[NEXT]</A>
+<BR>
+<HR><A NAME="create"><H3>create</H3></A><PRE>
+  Command: co  &lt;name&gt; &lt;password&gt;  (short for connect)
+           cd  &lt;name&gt; &lt;password&gt;  (short for cdark)
+           ch  &lt;name&gt; &lt;password&gt;  (short for chidden)
+           cr  &lt;name&gt; &lt;password&gt;  (short for create)
+           reg &lt;name&gt; &lt;password&gt;  (short for register)
+  
+  Note:  To create/log in a character with spaces in their name, please use
+         &quot;&lt;name&gt;&quot;.  Ergo, surround your name with double quotes.
+         The 'register' command does not allow creation with spaces.
+  
+  These commands are only useful on the connect screen.  They are used to
+  create/connect to your account &lt;name&gt; with the provided &lt;password&gt;.  
+  These commands are not useable once you are connected to the mush.
+  
+  These commands are as follows:
+     co  -- This option is the default and normal method to connect.
+            This option has no special conditions or privilages.
+            Syntax: co player password
+                    co &quot;Player With Spaces&quot; password
+  
+     ch  -- Wizards and anyone with the NOWHO @power (to @hide) can use this.
+            This option will auto-hide the player when connecting.
+            It defaults to the 'co' option if you can't @hide.
+            Syntax: ch player password
+                    ch &quot;Player With Spaces&quot; password
+  
+     cd  -- Wizards and higher can use this to connect dark to the game.
+            This effectively connects wiz-cloaked to the game.
+            Immortals get auto-added to supercloak.
+            Syntax: cd player password
+                    cd &quot;Player With Spaces&quot; password
+     
+     cr  -- Allows creation of a player from the connect screen.
+            Syntax: cr player password
+                    cr &quot;Player With Spaces&quot; password
+  
+     reg -- If offline registration is enabled, allows the player to register
+            a character with a supplied email that is then used to email them
+            their password.
+            Syntax: reg player email@address
+                    reg &quot;Player With Spaces&quot; email@address
+  
+  See Also: @aconnect, @adisconnect, @hide, @register
+            
+</PRE>
+<A HREF="#crc32()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#create()">[NEXT]</A>
 <BR>
 <HR><A NAME="create()"><H3>CREATE()</H3></A><PRE>
-  Function: create(&lt;name&gt;, [&lt;arguments&gt; [,&lt;type&gt;]])
+  Function: create(&lt;name&gt;, [&lt;arguments&gt; [,&lt;type&gt; [,&lt;target-owner&gt; [,key]]])
   
-  @create:  create(&lt;name&gt;,&lt;value&gt;,t) (default)
+  If 'key' is specified as '1', and the &lt;name&gt; starts with a dbref# and is
+  enacted by an immortal, it enforces strict mode and verifies the dbref#
+  as valid to be used for creation.
+  
+  @create:  create(&lt;name&gt;, &lt;value&gt;, t) (default)
+            create(&lt;dbref#&gt; &lt;name&gt;, &lt;value&gt;, t,, 1)  (enforce free dbref#)
     This will create an object with name &lt;name&gt; of value &lt;value&gt;.  The 't'
     &lt;type&gt; is optional for this as it is the default.  For more help on
     creating objects, please refer to 'help @create'.  If &lt;value&gt; is null
@@ -15914,15 +21167,30 @@ Generated: Wed Jan 13 04:15:48 2016
     If no arguments are given, the default money value is taken for this 
     option only.
   
-  @dig:     create(&lt;name&gt;,&lt;[exit-in],[exit-out]&gt;,r)
+  @dig:     create(&lt;name&gt;, &lt;[exit-in], [exit-out]&gt;, r)
+            create(&lt;dbref#&gt; &lt;name&gt;, &lt;[exit-in], [exit-out]&gt;, r,, 1)
+            dig(&lt;name&gt;, &lt;[exit-in], [exit-out]&gt;)
     This will dig a room with name &lt;name&gt; and OPTIONAL in-exit 'exit-in' and
     OPTIONAL out-exit 'exit-out'.  You may specify both, either, or no exits.
     For more help on digging rooms, please refer to 'help @dig'.
   
-  @open:    create(&lt;name&gt;,&lt;link&gt;,e)
+  @open:    create(&lt;name&gt;, &lt;link&gt;, e)
+            create(&lt;dbref#&gt; &lt;name&gt;, &lt;link&gt;, e,, 1)
+            open(&lt;name&gt;, &lt;link&gt;)
     This will open an exit with name &lt;name&gt; to OPTIONAL target &lt;link&gt;.  If
     &lt;link&gt; is unspecified, then the exit will be un-linked and will need to
     be @linked later (if so desired).
+  
+  @pcreate: create(&lt;name&gt;, &lt;password&gt;, p)
+            create(&lt;dref#&gt; &lt;name&gt;, &lt;password&gt;, p,, 1)
+    This will create the target player.  You need to have access to @pcreate
+    to be able to use this feature of create().
+  
+  @robot:   create(&lt;name&gt;, &lt;password&gt;, p, &lt;target-owner&gt;)
+            create(&lt;dbref#&gt; &lt;name&gt;, &lt;password&gt;, p, &lt;target-owner&gt;, 1)
+    This will create the target robot player.  You need to have access to
+    both the @robot feature as well as control the target-owner to create
+    a robot.  To create a robot that you own, make target-owner yourself.
   
   The SIDEFX flag needs to be set to use this function. 
   Type @list options to see if this side-effect is enabled.
@@ -15930,11 +21198,12 @@ Generated: Wed Jan 13 04:15:48 2016
   Example:
   &gt; say create(An Object,10)  (this will create 'An Object' with value of '10')
   &gt; say create(An Object)     (this will create 'An Object' with default cost)
+  &gt; say create(#123 An Object,10,,,1) (create 'An Object' with dbref #123)
   
-  See Also: @create, @dig, @open, dig(), open(), SIDEEFFECTS
+  See Also: @create, @dig, @open, @pcreate, dig(), open(), SIDEEFFECTS
   
 </PRE>
-<A HREF="#crc32()">[PREV]</A>
+<A HREF="#create">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#createtime()">[NEXT]</A>
 <BR>
@@ -16148,7 +21417,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say creplace(this is a test,1 3 4,XYZ)
     You say &quot;XhYZ is a test&quot;
   
-  See Also: replace(), lreplace(), totpos(), elementpos()
+  See Also: replace(), lreplace(), totpos(), elementpos(), ruler()
   
 </PRE>
 <A HREF="#credits5">[PREV]</A>
@@ -16223,17 +21492,21 @@ Generated: Wed Jan 13 04:15:48 2016
   nearby()         - Tests if two different objects are near eachother.
   next()           - Returns the next object in a con()/exit() list.
   num()            - Returns the DbRef of an object.
+  objid()          - Returns the DbRef Object ID of an object.
   owner()          - Returns the owner of an object or an attribute.
   rloc()           - Returns the location of an objects location.
   room()           - Returns the dbref of the (absolute) room an object is in.
   search()         - Returns a list of objects that match search criteria.
   searchng()       - Like search but do not search garbage/recover.
+  searchobjid()    - Like search() but returns objid's.
+  searchngobjid()  - Like searchng() but returns objid's.
   sees()           - Returns true if an object is able to see a target object.
   stats()          - Shows information about the number of objects on the MUSH.
   where()          - Returns the true location of an object.
   listcommands()   - Lists all commands that you have access to.
   listflags()      - Lists all flags that you have access to.
   listtoggles()    - List all togglees you have access to.
+  listtotems()     - List all totems you have access to.
   pmatch()         - Returns the dbref of a matching player.
   rnum()           - Returns the dbref of an object, from a target perspective.
   valid()          - Tests validity of certain values for various options.
@@ -16277,9 +21550,13 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="dec()"><H3>DEC()</H3></A><PRE>
   Function: dec(&lt;number&gt;)
   
+  DEC() and XDEC() may be reversed.  to check if they are, Please reference:  
+                           @list options system  
+  
   The dec() function is used to decrement numerical values in local registers.
-  The valid registers are 0 through 9.  If the value in the register is a
-  string, it will return the string without any changes.
+  The valid registers are 0-9, and a-z.  You may also use setq labels.
+  If the value in the register is a string, it will return the string without
+  any changes.
   
   Example:
     &gt; say [setq(0,10)] 1: [r(0)] [dec(0)] 2: [r(0)]
@@ -16417,6 +21694,51 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#delete()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#descformat">[NEXT]</A>
+<BR>
+<HR><A NAME="descformat"><H3>descformat</H3></A><PRE>
+  All NON-ACTION attributes allowed formatting are in: help attributes
+  
+  Attribute formatting can be accomplished multiple ways.  First, there is
+  a generic local 'format' for most @-attributes.  To process this format,
+  you need to set an attribute of the name 'format&lt;attr&gt;' on the target
+  (or parent, global parent, zone of the target. Use &lt;attr&gt;format if the
+  config parameter format_compatibility is enabled). If this attribute is
+  not found, it will then look at the global default parents for matching
+  attribute inheritance.  Any attribute that you wish to inherit default
+  pattern formatting must be set DEFAULT (attribute flag).  The desc is
+  passed into the formatting as '%0'.  Local formatting has priority
+  over global formatting.
+  
+  The DEFAULT attribute flag can be set in two ways.
+    1.  Individually on the attribute: @set #dbref/attribute=default
+    2.  Set it globally through two methods:
+        A.  Internal (built-in): @admin attr_access=attribute default  
+        B.  User defined:        @attribute/access attribute=default
+  
+  Option #1 will be cleared if or when the attribute is cleared.
+  Option #2-A can be done through the netrhost.conf file for permanence.
+  Option #2-B is always permanent and doesn't have to be re-issued.
+  
+  Note: Most RhostMUSHes will be configured to use &amp;FORMAT&lt;attr&gt;.
+        See '@list options system' to discover which method is in use.
+  
+  Examples:
+    &gt; @desc me=This is a test
+    &gt; @admin player_attr_default=123
+    &gt; @desc #123=-&lt; %0 &gt;-
+    &gt; lo me
+      -&lt; This is a test &gt;-
+    &gt; &amp;formatdesc me===&lt;%0&gt;==
+    &gt; lo me
+      ===&lt;This is a test&gt;===
+
+  See Also: ATTRIBUTES, ATTRIBUTE FLAG DEFAULT, @conformat, 
+            @exitformat, @nameformat, invformat
+
+</PRE>
+<A HREF="#delextract()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#destroy()">[NEXT]</A>
 <BR>
 <HR><A NAME="destroy()"><H3>DESTROY()</H3></A><PRE>
@@ -16437,7 +21759,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @destroy, wipe(), create()
   
 </PRE>
-<A HREF="#delextract()">[PREV]</A>
+<A HREF="#descformat">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#destroy_ok">[NEXT]</A>
 <BR>
@@ -16470,15 +21792,15 @@ Generated: Wed Jan 13 04:15:48 2016
      1 - Display all the rolls of the dice.
      2 - Display the totals, then display all the roles of the dice.
      3 - Display the totals, then all normal rolls of dice, then display 
-         failures/criticals after with the default '|' seperator.
+         failures/criticals after with the default '|' separator.
      4 - Display all the normal rolls of the dice, then display the
-         failures, then the criticals seperated by the default '|' character.
+         failures, then the criticals separated by the default '|' character.
      5 - Display just the totals, then failures/criticals after with
-         the default '|' seperator.
+         the default '|' separator.
 
   &lt;botval&gt; specifies low ceiling masks for the dice.  You may specify an 
-  optional output seperator for the numbers.  If the seperator you specify
-  is the '|' character, the seperator used for failure/criticals becomes ':'.
+  optional output separator for the numbers.  If the separator you specify
+  is the '|' character, the separator used for failure/criticals becomes ':'.
   
   You may specify offset values to the 'fail'ure or for 'crit'ical success.
   The offset increases the range of failure or success.
@@ -16492,7 +21814,7 @@ Generated: Wed Jan 13 04:15:48 2016
       You say &quot;1 2&quot;
     &gt; say dice(2,4,2,3)    [give me just the dice rolls with MIN value of 3]
       You say &quot;3 3&quot;
-    &gt; say dice(2,4,2,,@)   [give me just the dice rolls with a seperator '@']
+    &gt; say dice(2,4,2,,@)   [give me just the dice rolls with a separator '@']
       You say &quot;1@2&quot;
    
   See Also: rand()
@@ -16513,15 +21835,15 @@ Generated: Wed Jan 13 04:15:48 2016
      1 - Display all the rolls of the dice.
      2 - Display the totals, then display all the roles of the dice.
      3 - Display the totals, then all normal rolls of dice, then display 
-         failures/criticals after with the default '|' seperator.
+         failures/criticals after with the default '|' separator.
      4 - Display all the normal rolls of the dice, then display the
-         failures, then the criticals seperated by the default '|' character.
+         failures, then the criticals separated by the default '|' character.
      5 - Display just the totals, then failures/criticals after with
-         the default '|' seperator.
+         the default '|' separator.
 
   &lt;botval&gt; specifies low ceiling masks for the dice.  You may specify an 
-  optional output seperator for the numbers.  If the seperator you specify
-  is the '|' character, the seperator used for failure/criticals becomes ':'.
+  optional output separator for the numbers.  If the separator you specify
+  is the '|' character, the separator used for failure/criticals becomes ':'.
   
   You may specify offset values to the 'fail'ure or for 'crit'ical success.
   The offset increases the range of failure or success.
@@ -16535,7 +21857,7 @@ Generated: Wed Jan 13 04:15:48 2016
       You say &quot;1 2&quot;
     &gt; say dice(2,4,2,3)    [give me just the dice rolls with MIN value of 3]
       You say &quot;3 3&quot;
-    &gt; say dice(2,4,2,,@)   [give me just the dice rolls with a seperator '@']
+    &gt; say dice(2,4,2,,@)   [give me just the dice rolls with a separator '@']
       You say &quot;1@2&quot;
    
   See Also: rand()
@@ -16546,6 +21868,10 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#differences">[NEXT]</A>
 <BR>
 <HR><A NAME="differences"><H3>DIFFERENCES</H3></A><PRE>
+  Topic: DIFFERENCES
+  
+  If you are coming from a MUD/LP, type 'help muddiff' for those.
+  
   First we'll touch on the TinyMUX differences.
   1) Paging.
      In mux, you can type: page &lt;player-list&gt;=topic, but you need to 
@@ -16583,6 +21909,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#differences2">[NEXT]</A>
 <BR>
 <HR><A NAME="differences2"><H3>DIFFERENCES2</H3></A><PRE>
+  Topic: DIFFERENCES
+  
   Welp, there's not many differences to be honest.  However, as most TinyMUSH's
   use the brandy mailer, you may use the mail method above to make a syntax
   that you'd be compatible with.
@@ -17213,6 +22541,10 @@ Generated: Wed Jan 13 04:15:48 2016
     F - anything NOT set flash.
     N - anything NOT using ansi colors.
   
+  The following ansi special matches are allowed for search.
+    d - any foreground color.
+    D - any background color.
+  
   If these are specified in replace, it will strip those specified ansi
   special encodings. 
     
@@ -17224,7 +22556,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say editansi([ansi(hb,abc,hg,xyz,n,def)],hb,y,hg,b)
     You say &quot;abcxyzdef&quot; (abc is yellow, xyz is blue, def is non-ansi)
   
-  See Also: accents(), edit(), regedit(), pemit(), @edit
+  See Also: ansipos(), accents(), edit(), regedit(), pemit(), @edit
 
 </PRE>
 <A HREF="#edit()">[PREV]</A>
@@ -17278,12 +22610,15 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="elements()"><H3>elements()</H3></A><PRE>
   Function: elements(&lt;list of words&gt;,&lt;list of numbers&gt;[[,&lt;delim&gt;][,&lt;sep&gt;]])
- 
+   
   This function returns the words in &lt;list of words&gt; that are in the
   positions specified by &lt;list of numbers&gt;. Optionally, a list delimiter
   other than a space can be separated.  This function does not assume a null
   to be a valid argument.  For that, use elementsmux().
- 
+  
+  If you specify &lt;list of numbers&gt; as negative, it takes from the end starting
+  at -1.
+   
   Examples:
     &gt; say elements(Foo Ack Beep Moo Zot,2 4)
     You say &quot;Ack Moo&quot;
@@ -17295,7 +22630,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;is@test@is@is@is@is&quot;
     &gt; say elements(this@is@a@test,2 4 2 2 2 2,@,)
     You say &quot;is test is is is is&quot;
- 
+   
   See Also: extract(), extractword(), elementsmux(), elementpos()
   
 </PRE>
@@ -17305,12 +22640,15 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="elementsmux()"><H3>elementsmux()</H3></A><PRE>
   Function: elementsmux(&lt;list of words&gt;,&lt;list of numbers&gt;[[,&lt;delim&gt;][,&lt;sep&gt;]])
- 
+   
   This function returns the words in &lt;list of words&gt; that are in the
   positions specified by &lt;list of numbers&gt;. Optionally, a list delimiter
   other than a space can be separated.  This function assumes 'null' arguments
   are valid arguments while elements() does not.
- 
+  
+  If you specify &lt;list of numbers&gt; as negative, it takes from the end starting
+  at -1.
+   
   Examples:
     &gt; say elementsmux(Foo Ack Beep Moo Zot,2 4)
     You say &quot;Ack Moo&quot;
@@ -17322,7 +22660,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;is@test@is@is@is@is&quot;
     &gt; say elementsmux(this@is@a@test,2 4 2 2 2 2,@,)
     You say &quot;is test is is is is&quot;
- 
+   
   See Also: extract(), extractword(), elements(), elementpos()
   
   
@@ -17336,9 +22674,9 @@ Generated: Wed Jan 13 04:15:48 2016
   
   The elist function is used to return a list of words into an english
   recognizable format.  You may specify an output delimiter to use if
-  you wish but it makes the format rather unique.  You may specify a seperate
+  you wish but it makes the format rather unique.  You may specify a separate
   punctuation instead of the default comma (,).  The punctuation may be
-  more than one character.  You may specify the seperator if not a space as 
+  more than one character.  You may specify the separator if not a space as 
   well.
   
   You can also supply a munging function to apply for each argument passed to
@@ -17362,7 +22700,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say elist(one/two/three,what a life,/,/)
     You say &quot;one,/two,/what a life/three&quot;
   
-  See Also: iter(), citer(), nsiter(), list()
+  See Also: iter(), citer(), nsiter(), list(), inf()
   
 </PRE>
 <A HREF="#elementsmux()">[PREV]</A>
@@ -17370,9 +22708,18 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#elock()">[NEXT]</A>
 <BR>
 <HR><A NAME="elock()"><H3>elock()</H3></A><PRE>
-  Function: elock(&lt;object&gt;[/&lt;whichlock&gt;],&lt;victim&gt;)
+  Function: elock(&lt;object&gt;[/&lt;whichlock&gt;], &lt;victim&gt; [,&lt;type&gt; [,&lt;default&gt;]])
+  
   Checks if &lt;victim&gt; would pass the named lock on &lt;object&gt;.  Only the object's
   owner may test locks other than the default lock.
+  
+  Optional values are as follows:
+    &lt;type&gt;    -- The argument (0-2) that you wish to pass as '%0' for 
+                 customizable UseLock lock checks.  '0' is default, 1 is 
+                 $commands only, 2 is ^listens only.  Valid values 0, 1, or 2.
+                 This is only meaningful for UseLocks.
+    &lt;default&gt; -- specify the default value if no lock found.  Defaults to '1'.
+                 Valid values 0 or 1.
   
   Example:
     &gt; @lock me/page=!*Twinklock
@@ -17383,8 +22730,14 @@ Generated: Wed Jan 13 04:15:48 2016
       Set.
     &gt; say elock(me/pagelock,*twink)
       You say &quot;1&quot;
+    &gt; @unlock me/twink
+      Set.
+    &gt; say elock(me/pagelock,*twink)
+      You say &quot;1&quot;
+    &gt; say elock(me/pagelock,*twink,,0)
+      You say &quot;0&quot;
   
-  See Also: @lock, lock(), lockencode(), lockdecode(), lockcheck()
+  See Also: @lock, lock(), lockencode(), lockdecode(), lockcheck(), testlock()
   
 </PRE>
 <A HREF="#elist()">[PREV]</A>
@@ -17549,12 +22902,15 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#eq()">[NEXT]</A>
 <BR>
 <HR><A NAME="eq()"><H3>eq()</H3></A><PRE>
-  Function: eq(&lt;integer1&gt;,&lt;integer2&gt;)
+  Function: eq(&lt;integer1&gt;, &lt;integer2&gt; [,&lt;integer3&gt;,...])
  
-  Takes two integers, and returns 1 if they are equal and 0 if they are not.
+  Takes two (or more) integers, and returns 1 if all the values
+  are equal, otherwise it returns a 0.  This function handles floating 
+  point numbers as well.
+  
   Warning: passing anything but integers will produce unexpected results,
   as non-numeric strings usually are treated as numeric 0.
- 
+   
   Example:
     &gt; say eq(1,-1)
     You say &quot;0&quot;
@@ -17562,6 +22918,10 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;1&quot;
     &gt; say eq(foo, bar)
     You say &quot;1&quot;
+    &gt; say eq(5,5,5,5,5,5)
+    You say &quot;1&quot;
+    &gt; say eq(5,5,5,3,5,5)
+    You say &quot;0&quot;
   
   See Also: lt(), lte(), gte(), gt(), neq()
   
@@ -17600,7 +22960,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Function: escape(&lt;string&gt;)
  
   Returns &lt;string&gt; after adding an escape character (\) at the start of the
-  string and also before each of the characters %;[]{}\ that appear in the
+  string and also before each of the characters [](){};%\,^ that appear in the
   string.  This prevents strings entered by players from causing undesired
   side effects when used, such as making your object perform unintended
   commands or give out information to which you have access.  Note that this
@@ -17654,6 +23014,10 @@ Generated: Wed Jan 13 04:15:48 2016
   that you specified.  This is intended to be used with weird escape 
   situations like calling external sources.
   
+  To escape out the '|' character, have it as the last character.  Ergo,
+  something like: esclist(abcd||mystring).  This says escape out the '|'
+  then break the list on the next '|'.
+    
   Examples:
     &gt; @va me=Test: 'A string' and &quot;anoter string&quot;, I say.
     Set.
@@ -17686,7 +23050,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say eval(me,va)
     You say &quot;1+1=2&quot;
   
-  See Also: s(), get_eval(), get(), u(), u2(), zfun()
+  See Also: s(), get_eval(), get(), u(), u2(), zfun(), subeval(), sandbox()
   
 </PRE>
 <A HREF="#esclist()">[PREV]</A>
@@ -17695,6 +23059,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="examine"><H3>examine</H3></A><PRE>
   Command: examine[/&lt;switches&gt;] &lt;object&gt;[/&lt;wild-attrib&gt;]
+  
+  Available switches are on: help examine4
   
   Displays all available information about &lt;object&gt;.  &lt;object&gt; may be an
   object, 'me' or 'here'. You must control the object to examine it, or it
@@ -17708,7 +23074,9 @@ Generated: Wed Jan 13 04:15:48 2016
   to indicate the status of the attribute.  The list of flag letters that
   show up is shown in 'help examine2'
   
-{ 'help examine2' for more }
+{ 'help examine2' for what the flag letters mean }
+{ 'help examine3' for what the global flag letters mean }
+{ 'help examine4' for what the switches are and examples }
   
 </PRE>
 <A HREF="#eval()">[PREV]</A>
@@ -17716,6 +23084,9 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#examine2">[NEXT]</A>
 <BR>
 <HR><A NAME="examine2"><H3>examine2</H3></A><PRE>
+  (CONTINUED)
+  Command: examine[/&lt;switches&gt;] &lt;object&gt;[/&lt;wild-attrib&gt;]
+  
   The following flag letters show up with attributes when examined:
     + - The attribute is locked, it does not change ownership when the
         object is @chowned and may not be modified.
@@ -17738,7 +23109,8 @@ Generated: Wed Jan 13 04:15:48 2016
     B - The attribute is modifiable by Architect or higher only.
     g - The attribute is modifiable by Guildmaster or higher only.
   
-{ 'help examine3' for more }
+{ 'help examine3' for what the global flag letters mean }
+{ 'help examine4' for what the switches are and examples }
   
 </PRE>
 <A HREF="#examine">[PREV]</A>
@@ -17746,6 +23118,9 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#examine3">[NEXT]</A>
 <BR>
 <HR><A NAME="examine3"><H3>examine3</H3></A><PRE>
+  (CONTINUED)
+  Command: examine[/&lt;switches&gt;] &lt;object&gt;[/&lt;wild-attrib&gt;]
+  
   If expanded looks are enabled (@list options to verify), you may also
   see global attributes on attributes.  These are surrounded by []'s.
   The following global attributes can exist:
@@ -17770,32 +23145,45 @@ Generated: Wed Jan 13 04:15:48 2016
     B - The attribute is modifiable by Architect or higher only.
     g - The attribute is modifiable by Guildmaster or higher only.
   
-{ 'help examine4' for more }
+{ 'help examine4' for what the switches are and examples }
+
 </PRE>
 <A HREF="#examine2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#examine4">[NEXT]</A>
 <BR>
 <HR><A NAME="examine4"><H3>examine4</H3></A><PRE>
+  (CONTINUED)
+  Command: examine[/&lt;switches&gt;] &lt;object&gt;[/&lt;wild-attrib&gt;]
+  
   If you specify a wildcarded attribute name, then only those attributes
   that match are shown.  So, 'exam me/v?' will show all your attributes that
   start with v and are two characters long.
  
   The following switches are available:
-     /brief  - Show everything but the attributes.
-     /quick  - When examining an object you don't control, show only the
-               owner's name. 
-     /full   - When examining an object you don't control, show any public
-               attributes set on the object in addition to the owner's name.
-     /parent - Includes attributes that are not present on the object itself
-               but which are inherited from the object's parent.  This only
-               works if you have permission to see it.
-     /tree   - Examine per Penn-Tree output separating trees with '`'.
-               Only useful with using #obj/attr format.
-     /regexp - Use regular expression for wildcard matches.
+     /brief   - Show everything but the attributes.
+     /quick   - When examining an object you don't control, show only the
+                owner's name. 
+     /full    - When examining an object you don't control, show any public
+                attributes set on the object in addition to the owner's name.
+     /parent  - Includes attributes that are not present on the object itself
+                but which are inherited from the object's parent.  This only
+                works if you have permission to see it.
+     /tree    - Examine per Penn-Tree output separating trees with '`'.
+                Only useful with using #obj/attr format.
+     /regexp  - Use regular expression for wildcard matches.
+     /cluster - Examines the specified cluster (and all members).
+     /display - Ansify matching parenthesis, braces,and brackets.
+  
+  
+  Example:
+    &gt; examine me
+      -- Output of examine of yourself
+    &gt; examine me/*foo*
+      -- Output of just all attribs matching *foo*
   
   See Also: look, @decompile, VISUAL, ATTRIBUTE OWNERSHIP, FLAG LIST,
-            ATTRIBUTE FLAGs
+            ATTRIBUTE FLAGS, lattr(), cluster_lattr()
   
   
 </PRE>
@@ -17835,7 +23223,10 @@ Generated: Wed Jan 13 04:15:48 2016
   If an exit is set DARK it will not show up in the list of obvious exits in
   a room.
   
-  See Also: @link, @open
+  You may use loc() to find the destination of an exit, and home() to find
+  the source (location) of the exit. 
+  
+  See Also: @link, @open, loc(), home()
   
 </PRE>
 <A HREF="#exit()">[PREV]</A>
@@ -17909,15 +23300,30 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#extractword()">[NEXT]</A>
 <BR>
 <HR><A NAME="extractword()"><H3>EXTRACTWORD()</H3></A><PRE>
-  Function: extractword(&lt;string&gt;, &lt;first&gt;, &lt;length&gt;[, &lt;delim&gt;], &lt;sep&gt;] ,&lt;del&gt;])
+  Function: extractword(&lt;strng&gt;[,&lt;first&gt;,&lt;len&gt;[,&lt;dlim&gt;],&lt;sep&gt;],&lt;del&gt;],&lt;mod&gt;]]])
   
-  Extractword returns a string of length words, starting with the first
+  Extractword returns a string of &lt;len&gt; length words, starting with the first
   word.  This works effectively like extract(), however, the deliminiter 
-  &lt;delim&gt; and seperator &lt;sep&gt; can be multi-character.  In addition, the
-  seperator may also contain ansi or special characters.
+  &lt;dlim&gt; and separator &lt;sep&gt; can be multi-character.  In addition, the
+  separator may also contain ansi or special characters.
+  
+  If you specify only &lt;strng&gt; and no other arguments, it returns the first
+  word of the string as if the first() function.
+  
+  If you specify a negative number to &lt;first&gt;, it counts backwards from the end
+  of the string.  So -1 is the last argument, -2 is previous to last, and so
+  forth.
+  
+  If you specify a negative number to &lt;len&gt;, it will return up to the total
+  words minus the length.  So -1 will return all words from start to the
+  last element, -2 to the previous to last element, and so forth.
   
   If you specify the &lt;del&gt; toggle to '1' it assumes delextract() compatibility
   where the words choosen are all the words EXCEPT the range specified.
+  
+  If you specify the &lt;mod&gt; toggle to '1' it will apply a modulo to the &lt;first&gt;
+  argument against the total words in &lt;strng&gt; and wrap-around the value
+  automatically.
    
   Unlike extract(), extractword() is also ansi-aware.
   
@@ -17931,6 +23337,10 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;multi@@@char&quot;
     &gt; say extractword(a@@@multi@@@char@@@delimiter, 2, 2, @@@,%b)
     You say &quot;multi char&quot;
+    &gt; say extractword(Skip the first and last elements, 2, -2)
+    You say &quot;the first and last&quot;
+    &gt; say extractword((Get just the last three elements,-3, 3)
+    You say &quot;last three elements&quot;
   
   See Also: extract(), extractword(), index(), insert(), ldelete(), replace(),
             randextract() 
@@ -17948,7 +23358,7 @@ Generated: Wed Jan 13 04:15:48 2016
   (because it is unlinked or locked). You fail to use a room when you fail
   to look around (because it's locked).
   
-  See Also: get, look, @afail, @fail, @lock, @ofail
+  See Also: get, look, @afail, @fail, @lock, @ofail, SHOWFAILCMD
   
 </PRE>
 <A HREF="#extractword()">[PREV]</A>
@@ -18036,7 +23446,7 @@ Generated: Wed Jan 13 04:15:48 2016
   This function evaluates the contents of &lt;attr&gt; for each element of &lt;list&gt;,
   passing it in as %0.  A &lt;delimiter&gt;-separated list is returned of those
   elements for which the evaluation returns the value 1.  You may specify an
-  optional output seperator.
+  optional output separator.
   
   &lt;delim&gt; may be used to specify a delimiter other than space.
   
@@ -18052,7 +23462,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say filter(object/is_odd,1@2@3@4@5,@,|)
     You say &quot;1|3|5&quot;
   
-  See Also: u(), map(), fold(), citer(), nsiter(), munge(), list(), sortlist()
+  See Also: u(), map(), fold(), citer(), nsiter(), munge(), list(), 
+            sortlist(), inf()
   
 </PRE>
 <A HREF="#fdiv()">[PREV]</A>
@@ -18106,10 +23517,10 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="firstof()"><H3>FIRSTOF()</H3></A><PRE>
   Function: ofparse(&lt;type&gt;, [&lt;eval1&gt; [,&lt;eval2&gt; ... &lt;evalN or delim&gt;]])
 
-  Type 1&amp;3: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 2&amp;4: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
-  Type 5&amp;7: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 6&amp;8: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
+  Type 1&amp;3: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 2&amp;4: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
+  Type 5&amp;7: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 6&amp;8: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
   
   This function will take each &lt;eval&gt; and returns it based on the &lt;type&gt;.
   
@@ -18167,23 +23578,23 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="flag list"><H3>FLAG LIST</H3></A><PRE>
   Topic: FLAG LIST
  
-  Flag  Title        Flag  Title           Flag  Title        Flag  Title
+  Flag  Title        Flag  Title           Flag  Title      Flag  Title
   -------------------------------------------------------------------------
-    A - ABODE          L - LINK_OK           X - FREE           m - MYOPIC
-    B - ARCHITECT      M - MONITOR           Y - PARENT_OK      n - AUDIBLE
-    C - CHOWN_OK       N - NO_SPOOF          a - COUNCILOR      o - NO_TEL
-    D - DARK           O - OPAQUE            b - CLOAK          p - PUPPET
-    E - EXIT           P - PLAYER            c - CONNECTED      r - ROBOT
-    F - FLOATING       Q - QUIET             d - DESTROY_OK     s - SAFE 
-    G - GOING          R - ROOM              e - ENTER_OK       t - TERSE      
-    H - HAVEN          S - STICKY            f - FUBAR          v - VERBOSE
-    I - INHERIT        T - TRACE/TRANSPARENT g - GUILDMASTER    w - NO_WALLS
-    J - JUMP_OK        U - UNFINDABLE        h - HALTED         x - SLAVE   
-    K - KEY            V - VISUAL            i - IMMORTAL       y - NO_YELL    
-    ~ - INDESTRUCTIBLE W - ROYALTY           l - LIGHT          z - CONTROL_OK
-    = - BYEROOM        &lt; - ANSI              &gt; - ANSICOLOR      
+    A - ABODE          L - LINK_OK           X - FREE         m - MYOPIC
+    B - ARCHITECT      M - MONITOR           Y - PARENT_OK    n - AUDIBLE
+    C - CHOWN_OK       N - NO_SPOOF          a - COUNCILOR    o - NO_TEL
+    D - DARK           O - OPAQUE            b - CLOAK        p - PUPPET
+    E - EXIT           P - PLAYER            c - CONNECTED    q - REQUIRE_TREES
+    F - FLOATING       Q - QUIET             d - DESTROY_OK   r - ROBOT
+    G - GOING          R - ROOM              e - ENTER_OK     s - SAFE 
+    H - HAVEN          S - STICKY            f - FUBAR        t - TERSE      
+    I - INHERIT        T - TRACE/TRANSPARENT g - GUILDMASTER  v - VERBOSE
+    J - JUMP_OK        U - UNFINDABLE        h - HALTED       w - NO_WALLS
+    K - KEY            V - VISUAL            i - IMMORTAL     x - SLAVE   
+    ~ - INDESTRUCTIBLE W - ROYALTY           l - LIGHT        y - NO_YELL    
+    = - BYEROOM        &lt; - ANSI              &gt; - ANSICOLOR    z - CONTROL_OK
     - - NO_FLASH
-  
+ 
   See Also: flag list2, attribute flags
   
   For information on a particular flag, type 'help &lt;flagname&gt;'.
@@ -18263,7 +23674,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say flags(me/asdfadsfasdfaf)
     You say &quot;&quot;
   
-  See Also: lflags(), hasflag()
+  See Also: lflags(), hasflag(), ltoggles(), ltotems(), totems()
   
 </PRE>
 <A HREF="#flags">[PREV]</A>
@@ -18414,7 +23825,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say fold(object/add_nums,1 2 3 4 5)
     You say &quot;15&quot;
   
-  See Also: u(), iter(), map(), filter(), citer(), nsiter(), list()
+  See Also: u(), iter(), map(), filter(), citer(), nsiter(), list(), inf()
   
 </PRE>
 <A HREF="#fmod()">[PREV]</A>
@@ -18536,6 +23947,7 @@ Generated: Wed Jan 13 04:15:48 2016
    
   Example:
     &gt; folder/delete love-letters
+ 
 </PRE>
 <A HREF="#folder current">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -18580,6 +23992,31 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#folder list">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#folder quicklist">[NEXT]</A>
+<BR>
+<HR><A NAME="folder quicklist"><H3>folder quicklist</H3></A><PRE>
+  Topic: folder quick-reference help
+  
+  folder/change [&lt;folder&gt;]          - Either resets your folder (if 
+                                      nothing specified) or will change to
+                                      the specified folder.
+  folder/cshare                     - Will display current folders shared.
+  folder/current                    - Will display your current folder.
+  folder/create [&lt;folder&gt;]          - Will create a user-named folder.  The
+                                      folder name has to be alphanumeric.
+  folder/delete [&lt;folder&gt;]          - Will delete the given folder.
+  folder/list                       - Will list all of your current folders.
+  folder/move &lt;arg&gt;=&lt;from&gt;,&lt;to&gt;     - Will move the specified mail into the
+                                      target folder from the specified folder.
+  folder/rename &lt;folder&gt;=&lt;newname&gt;  - Will rename the folder to the new name.
+  folder/share [&lt;folder&gt;]           - Will share a given folder to the people
+                                      matched in your mail/share.
+  
+  See Also: folder
+  
+</PRE>
+<A HREF="#folder move">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#folder rename">[NEXT]</A>
 <BR>
 <HR><A NAME="folder rename"><H3>folder rename</H3></A><PRE>
@@ -18593,7 +24030,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: folder list
   
 </PRE>
-<A HREF="#folder move">[PREV]</A>
+<A HREF="#folder quicklist">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#folder share">[NEXT]</A>
 <BR>
@@ -18617,6 +24054,156 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#folder rename">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#folder/change">[NEXT]</A>
+<BR>
+<HR><A NAME="folder/change"><H3>folder/change</H3></A><PRE>
+  Command: folder/change [&lt;folder&gt;]
+  
+  Change the current folder to &lt;folder&gt;.  If no folder is specified, your
+  current folder is reset to nothing.
+ 
+  Examples:
+    &gt; folder/change urgent
+    &gt; folder/change
+  
+  See Also: folder list
+  
+</PRE>
+<A HREF="#folder share">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#folder/create">[NEXT]</A>
+<BR>
+<HR><A NAME="folder/create"><H3>folder/create</H3></A><PRE>
+  Command: folder/create &lt;folder name&gt;
+  
+  Create a folder with &lt;folder name&gt; as the name.  Folder names may be up
+  to 20 characters and may not have spaces in them.  Folder names must
+  be alphanumeric.
+   
+  Example:
+    &gt; folder/create loveletters
+  
+  See Also: folder list, folder share
+  
+</PRE>
+<A HREF="#folder/change">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#folder/cshare">[NEXT]</A>
+<BR>
+<HR><A NAME="folder/cshare"><H3>folder/cshare</H3></A><PRE>
+  Command: folder/cshare
+  
+  This command will check your share folder(s).  Any folders you have marked
+  for sharing will be displayed.
+ 
+  See Also: folder share
+  
+</PRE>
+<A HREF="#folder/create">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#folder/current">[NEXT]</A>
+<BR>
+<HR><A NAME="folder/current"><H3>folder/current</H3></A><PRE>
+  Command: folder/current
+  
+  This command reports your current folder.
+  
+  See Also: folder list, folder cshare
+  
+</PRE>
+<A HREF="#folder/cshare">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#folder/delete">[NEXT]</A>
+<BR>
+<HR><A NAME="folder/delete"><H3>folder/delete</H3></A><PRE>
+  Command: folder/delete &lt;folder name&gt;
+  
+  This will delete &lt;folder name&gt;.  You may only delete empty folders.
+   
+  Example:
+    &gt; folder/delete love-letters
+ 
+</PRE>
+<A HREF="#folder/current">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#folder/list">[NEXT]</A>
+<BR>
+<HR><A NAME="folder/list"><H3>folder/list</H3></A><PRE>
+  Command: folder/list
+  
+  List all your folders.
+  
+  See Also: folder share, folder cshare
+  
+</PRE>
+<A HREF="#folder/delete">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#folder/move">[NEXT]</A>
+<BR>
+<HR><A NAME="folder/move"><H3>folder/move</H3></A><PRE>
+  Command: folder/move all=&lt;from&gt;,&lt;to&gt;
+           folder/move &lt;# list&gt;=&lt;from&gt;,&lt;to&gt;
+           folder/move &lt;dbref#&gt;=&lt;from&gt;,&lt;to&gt;
+           folder/move &lt;player&gt;=&lt;from&gt;,&lt;to&gt;
+   
+  You may move all or specified messages from one folder to another. 'all'
+  indicates to move all messages. &lt;# list&gt; refers to a list of message numbers
+  separated by spaces (or just one message number). &lt;player&gt; refers to 
+  the player name of someone who sent you mail. &lt;dbref#&gt; refers to the dbref #
+  of someone who sent you mail. &lt;from&gt; indicates the source folder name, while
+  &lt;to&gt; indicates the destination folder name.  Only message numbers may be
+  listed (not players, etc.), and you may not combine the different types
+  (e.g. message numbers and a player).
+   
+  Examples:
+    &gt; folder/move all=tinypal,allfriends
+    &gt; folder/move 5=incoming,important
+    &gt; folder/move wizard=incoming,urgent
+    &gt; folder/move 2 4=urgent,completed
+    &gt; folder/move #12345=mystery,solved
+  
+  See Also: folder share, mail mark, mail save, folder list
+  
+</PRE>
+<A HREF="#folder/list">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#folder/rename">[NEXT]</A>
+<BR>
+<HR><A NAME="folder/rename"><H3>folder/rename</H3></A><PRE>
+  Command: folder/rename &lt;original name&gt;=&lt;new name&gt;
+  
+  Rename a folder from &lt;original name&gt; to &lt;new name&gt;.
+   
+  Example:
+    &gt; folder/rename love-letters=personal
+  
+  See Also: folder list
+  
+</PRE>
+<A HREF="#folder/move">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#folder/share">[NEXT]</A>
+<BR>
+<HR><A NAME="folder/share"><H3>folder/share</H3></A><PRE>
+  Command: folder/share [&lt;folder&gt;]
+  
+  This command is only of use in conjunction with the mail/share command. If
+  you have enabled others to check your mail with the mail/share command, those
+  people who pass the share lock can only check the folder specified in the
+  folder/share command.  If you have mail/share set, but no share folder
+  set, anyone passing the mail/share can do a mail/number or mail/check on
+  any of your folders.  If you do not specify a folder on the folder/share
+  command, the share folder will be reset.
+   
+  Examples:
+    &gt; folder/share jokes
+    &gt; folder/share
+  
+  See Also: mail share, mail number, mail check, folder list
+ 
+</PRE>
+<A HREF="#folder/rename">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#foldercurrent()">[NEXT]</A>
 <BR>
 <HR><A NAME="foldercurrent()"><H3>FOLDERCURRENT()</H3></A><PRE>
@@ -18630,7 +24217,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: folder, folderlist()
 
 </PRE>
-<A HREF="#folder share">[PREV]</A>
+<A HREF="#folder/share">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#folderlist()">[NEXT]</A>
 <BR>
@@ -18648,7 +24235,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#foreach()">[NEXT]</A>
 <BR>
 <HR><A NAME="foreach()"><H3>FOREACH()</H3></A><PRE>
-  Function: foreach([&lt;object&gt;/]&lt;attribute&gt;,&lt;string&gt;[,&lt;begin&gt;, &lt;end&gt;])
+  Function: foreach([&lt;object&gt;/]&lt;attribute&gt;,&lt;string&gt;[,&lt;begin&gt;, &lt;end&gt; [,&lt;ansi&gt;]])
    
   Each character in &lt;string&gt; has the user-defined function of the first
   argument performed on it; the character is passed to the function as
@@ -18657,9 +24244,16 @@ Generated: Wed Jan 13 04:15:48 2016
   between &lt;begin&gt; and &lt;end&gt; are parsed, other characters are concatenated 
   as they are. This allows a rudimentary form of tokens and speeds up 
   the evaluation greatly if tokenizing is your purpose.
+  
+  If you specify &lt;ansi&gt; as '1', then specify &lt;begin&gt; and &lt;end&gt; as the special 
+  string '@@' to specify to ignore the &lt;begin&gt; and &lt;end&gt; values.  Just putting
+  nulls (empty values) there will assume null begin and end values and may
+  not return the result you are wishing for.  Due to the higher than normal
+  overhead, ansi-awareness in this function is not the default.
    
   Examples:
     &gt; &amp;add_one me=[add(%0,1)]
+    &gt; &amp;ansi me=-%0-
     Set.
     &gt; say [foreach(add_one, 54321)]
     You say, &quot;65432&quot;
@@ -18667,11 +24261,58 @@ Generated: Wed Jan 13 04:15:48 2016
     Set.
     &gt; say [foreach(add_one, This adds #0# to numbers in this string,#,#)]
     You say, &quot;This adds 1 to numbers in this string.&quot;
+    &gt; say [foreach(ansi,ansi(hr,r,hb,b,hc,c,hg,g),@@,@@,1)]
+    You say &quot;-r--b--c--g-&quot;  (r is red, b is blue, c is cyan, g is green)
     
-  See Also: @dolist, iter(), map(), citer(), nsiter(), list()
+  See Also: @dolist, iter(), map(), citer(), nsiter(), list(), inf()
   
 </PRE>
 <A HREF="#folderlist()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#formatdesc">[NEXT]</A>
+<BR>
+<HR><A NAME="formatdesc"><H3>formatdesc</H3></A><PRE>
+  All NON-ACTION attributes allowed formatting are in: help attributes
+  
+  Attribute formatting can be accomplished multiple ways.  First, there is
+  a generic local 'format' for most @-attributes.  To process this format,
+  you need to set an attribute of the name 'format&lt;attr&gt;' on the target
+  (or parent, global parent, zone of the target. Use &lt;attr&gt;format if the
+  config parameter format_compatibility is enabled). If this attribute is
+  not found, it will then look at the global default parents for matching
+  attribute inheritance.  Any attribute that you wish to inherit default
+  pattern formatting must be set DEFAULT (attribute flag).  The desc is
+  passed into the formatting as '%0'.  Local formatting has priority
+  over global formatting.
+  
+  The DEFAULT attribute flag can be set in two ways.
+    1.  Individually on the attribute: @set #dbref/attribute=default
+    2.  Set it globally through two methods:
+        A.  Internal (built-in): @admin attr_access=attribute default  
+        B.  User defined:        @attribute/access attribute=default
+  
+  Option #1 will be cleared if or when the attribute is cleared.
+  Option #2-A can be done through the netrhost.conf file for permanence.
+  Option #2-B is always permanent and doesn't have to be re-issued.
+  
+  Note: Most RhostMUSHes will be configured to use &amp;FORMAT&lt;attr&gt;.
+        See '@list options system' to discover which method is in use.
+  
+  Examples:
+    &gt; @desc me=This is a test
+    &gt; @admin player_attr_default=123
+    &gt; @desc #123=-&lt; %0 &gt;-
+    &gt; lo me
+      -&lt; This is a test &gt;-
+    &gt; &amp;formatdesc me===&lt;%0&gt;==
+    &gt; lo me
+      ===&lt;This is a test&gt;===
+
+  See Also: ATTRIBUTES, ATTRIBUTE FLAG DEFAULT, @conformat, 
+            @exitformat, @nameformat, invformat
+
+</PRE>
+<A HREF="#foreach()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#free">[NEXT]</A>
 <BR>
@@ -18691,7 +24332,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: GUILDMASTER, ARCHITECT, COUNCILOR, ROYALTY, IMMORTAL 
   
 </PRE>
-<A HREF="#foreach()">[PREV]</A>
+<A HREF="#formatdesc">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#fubar">[NEXT]</A>
 <BR>
@@ -18745,13 +24386,12 @@ Generated: Wed Jan 13 04:15:48 2016
  FLIP() ----&gt; reverse()  DIE() -------&gt; dice()      IF() ---------&gt; ifelse()
  MATCHALL() &gt; totmatch() LPARENT() ---&gt; parents()   NONZERO() ----&gt; ifelse()
  STRTRUNC() &gt; left()     SOUNDSLIKE() &gt; soundlike() FILTERBOOL() -&gt; filter()
- SUBEVAL() -&gt; eval()     GREPI() -----&gt; grep()      LANDBOOL() ---&gt; land()
+ LMATH()   -&gt; strfunc()  GREPI() -----&gt; grep()      LANDBOOL() ---&gt; land()
  ZONE() ----&gt; lzone()    ELEMENT() ---&gt; elements()  LORBOOL() ----&gt; lor()
  LNORBOOL() &gt; lnor()     ANDBOOL() ---&gt; and()       ORBOOL() -----&gt; or()
  NOTBOOL() -&gt; not()      XORBOOL() ---&gt; xor()       LOOP() -------&gt; parse()
  MEAN()    -&gt; avg()      ENUMERATE() -&gt; elist()     MOD() --------&gt; remainder()
- LMATH()   -&gt; strfunc()
-  
+    
   To see the help on the aliased function, please check the help of the 
   function that it aliases.
    
@@ -18765,27 +24405,28 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="function classes"><H3>FUNCTION CLASSES</H3></A><PRE>
   Topic: FUNCTION CLASSES
    
-  Ansi:                 ANSI() STRIPANSI() COLORS()
+  Ansi:                 ANSI() ANSIPOS() EDITANSI() STRIPANSI() COLORS() 
               See Also: help ansi functions
   
   Arithmetic:           ABS() ADD() AVG() BETWEEN() BOUND() DEC() DICE()
                         DIV() EE() FBETWEEN() FBOUND() FDIV() FLOORDIV() INC()
-                        MOD() MODULO() MUL() NCOMP() RAND() REMAINDER() 
+                        MASK() MOD() MODULO() MUL() NCOMP() RAND() REMAINDER() 
                         SIGN() STRMATH() SUB() XDEC() XINC() 
               See Also: help arithmetic functions
   
   Database Information: CON() CREATETIME() ENTRANCES() EXIT() FOLDERCURRENT()
                         FOLDERLIST() GLOBALROOM() LOC() LOCATE() LROOMS() 
-                        MAILQUICK() MODIFYTIME() NEARBY() NEXT() NUM() OWNER()
-                        RLOC() ROOM() SEARCH() SEARCHNG() SEES() STATS() 
-                        WHERE() LISTCOMMANDS() LISTFLAGS() LISTFUNCTIONS() 
-                        LISTNEWSGROUPS() LISTTOGGLES() PMATCH() RNUM() VALID()
+                        MAILQUICK() MODIFYTIME() NEARBY() NEXT() NUM() OBJID()
+                        OWNER() RLOC() ROOM() SEARCH() SEARCHOBJID() SEARCHNG()
+                        SEARCHNGOBJID()  SEES() STATS() WHERE() LISTCOMMANDS()
+                        LISTFLAGS() LISTFUNCTIONS() LISTNEWSGROUPS() 
+                        LISTTOGGLES() LISTTOTEMS() PMATCH() RNUM() VALID() 
                         XCON()
               See Also: help database information functions
   
-  Numerical Conversion: CEIL() CRC32() DIGEST() FLOOR() PACK() ROMAN() ROUND()
-                        SPELLNUM() TOBIN() TODEC() TOHEX() TOOCT() TRUNC() 
-                        UNPACK()
+  Numerical Conversion: CEIL() CRC32() DIGEST() FLOOR() MASK() PACK() 
+                        PACKMATH() ROMAN() ROUND() SPELLNUM() TOBIN() TODEC() 
+                        TOHEX() TOOCT() TRUNC() UNPACK()
               See Also: help numerical conversion functions
   
   { 'help function classes2' for more }    
@@ -18802,21 +24443,22 @@ Generated: Wed Jan 13 04:15:48 2016
                       STARTSECS() STARTTIME() VERSION()
             See Also: help game information functions
   
-  Lists:              AINDEX() AIINDEX() ANDFLAG() ANDFLAGS() CITER() 
-                      DELEXTRACT() ELEMENTS() ELEMENTSMUX() ELIST() EXTRACT()
-                      EXTRACTWORD() FILTER() FIRST() FLAGS() FOLD() FOREACH()
-                      IBREAK() IINDEX() ILEV() INDEX() INSERT() INUM() ITER()
-                      ITEXT() KEEPFLAGS() KEEPTYPE() LADD() LAND() LAST() 
-                      LAVG() LDELETE() LDIV() LISTDIFF() LISTINTER() 
-                      LISTMATCH() LISTUNION() LMAX() LMIN() LMUL() LNOR()
-                      LNUM() LNUM2() LOR() LRAND() LREPLACE() LSUB() LXNOR() 
-                      LXOR() MAP() MATCH() MEMBER() MIX() MUNGE() NSITER() 
-                      NUMMATCH() NUMMEMBER() NUMWILDMATCH() PARSE() RANDMATCH()
-                      RANDEXTRACT() REMFLAGS() REMOVE() REMTYPE() REST() 
-                      REVERSE() REVWORDS() RINDEX() SAFEBUFF() SETDIFF() 
-                      SETINTER() SETUNION() SORT() SORTBY() SORTLIST() STEP() 
-                      STRFUNC() STRMATH() TOTMATCH() TOTMEMBER() TOTWILDMATCH()
-                      WHILE() WILDMATCH()
+  Lists:              AINDEX() AIINDEX() ANDFLAG() ANDFLAGS() ANDTOTEM()
+                      ANDTOTEMS() ARRAY() CITER() DELEXTRACT() ELEMENTS() 
+                      ELEMENTSMUX() ELIST() EXTRACT() EXTRACTWORD() FILTER() 
+                      FIRST() FLAGS() FOLD() FOREACH() IBREAK() IINDEX() ILEV()
+                      INDEX() INF() INSERT() INUM() ITER() ITEXT() KEEPFLAGS()
+                      KEEPTYPE() LADD() LAND() LAST() LAVG() LDELETE() LDIV() 
+                      LISTDIFF() LISTINTER() LISTMATCH() LISTUNION() LMAX() 
+                      LMIN() LMUL() LNOR() LNUM() LNUM2() LOR() LRAND() 
+                      LREPLACE() LSUB() LXNOR() LXOR() MAP() MATCH() MEMBER() 
+                      MIX() MUNGE() NSITER() NUMMATCH() NUMMEMBER() 
+                      NUMWILDMATCH() PARSE() RANDMATCH() RANDEXTRACT() 
+                      REMFLAGS() REMOVE() REMTYPE() REST() REVERSE() REVWORDS()
+                      RINDEX() SAFEBUFF() SETDIFF() SETINTER() SETUNION() 
+                      SORT() SORTBY() SORTLIST() STEP() STRFUNC() STRMATH() 
+                      TOTEMS() TOTMATCH() TOTMEMBER() TOTWILDMATCH() 
+                      TRREVERSE() WHILE() WILDMATCH()
             See Also: help list functions
   
   Logarithms:         E() EXP() LN() LOG() PI() POWER() POWER10() SHL() SHR()
@@ -18836,23 +24478,24 @@ Generated: Wed Jan 13 04:15:48 2016
   Logical:            AND() MASK() NAND() NOR() OR() XOR() XNOR() CAND() COR()
             See Also: help logical functions
   
-  Miscellaneous:      ASC() CHR() CNAME() ERROR() LOCKCHECK() LOCKDECODE()
-                      LOCKENCODE() LOCALIZE() MOON() NAMEQ() NULL() 
-                      PARENMATCH() PID() PRIVATIZE() PUSHREGS() R() 
-                      SETQ() SETQ_OLD() SETQMATCH() SETR() SETR_OLD() 
-                      SOUNDEX() SOUNDLIKE() TRACE()
+  Miscellaneous:      ASC() CHR() CNAME() ERROR() LISTTAGS() LOCKCHECK()
+                      LOCKDECODE() LOCKENCODE() LOCALIZE() MOON() NAMEQ()
+                      NULL() PARENMATCH() PID() PRIVATIZE() PUSHREGS() R() 
+                      SANDBOX() SETQ() SETQ_OLD() SETQMATCH() SETR() SETR_OLD()
+                      SOUNDEX() SOUNDLIKE() STDERR() TAG() TAGMATCH() TRACE()
             See Also: help miscellaneous functions
   
   Object Information: APOSS() ART() ATTRCNT() CNAME() CONTROLS() DEFAULT() 
                       EDEFAULT() ELOCK() FULLNAME() GET() GET_EVAL() 
                       GRAB() GRABALL() GREP() GUILD() HASATTR() HASATTRP() 
-                      HASFLAG() HASTOGGLE() HASTYPE() HOME() LASTCREATE() 
-                      LATTR() LCMDS() LCON() LEXITS() LFLAGS() LOCK() 
-                      LTOGGLES() LZONE() NAME() OBJ() OBJEVAL() ORFLAG() 
-                      ORFLAGS() PARENT() PGREP() POSS() RACE() SHIFT() SUBJ() 
-                      TYPE() U() U2() UDEFAULT() UDEFAULT2() UEVAL() 
-                      ULDEFAULT() U2LDEFAULT() ULOCAL() ULOCAL2() V() 
-                      VATTRCNT() VISIBLE() VISIBLEMUX() WRITABLE() XGET()
+                      HASFLAG() HASTOGGLE() HASTOTEM() HASTYPE() HOME() 
+                      LASTCREATE() LATTR() LCMDS() LCON() LEXITS() LFLAGS()
+                      LOCK() LTOGGLES() LTOTEMS() LZONE() NAME() OBJ() 
+                      OBJEVAL() ORFLAG() ORFLAGS() ORTOTEM() ORTOTEMS() 
+                      PARENT() PGREP() POSS() RACE() SHIFT() SUBJ() TYPE() U()
+                      U2() UDEFAULT() UDEFAULT2() UEVAL() ULDEFAULT() 
+                      U2LDEFAULT() ULOCAL() ULOCAL2() V() VATTRCNT() VISIBLE()
+                      VISIBLEMUX() WRITABLE() XGET()
             See Also: help object information functions
   
   { 'help function classes4' for more }
@@ -18901,21 +24544,22 @@ Generated: Wed Jan 13 04:15:48 2016
                        COMP() CREPLACE() DECODE64() DECRYPT() DELETE() EDIT() 
                        EDITANSI() ELEMENTPOS() ENCODE64() ENCRYPT() ESCAPE() 
                        ESCAPEX() ESCLIST() EVAL() GARBLE() IFELSE() ISALNUM() 
-                       ISALPHA() ISDBREF() ISDIGIT() ISNUM() ISPUNCT() 
-                       ISSPACE() ISWORD() ISXDIGIT() LCSTR() LEFT() LIT() LJC()
-                       LJUST() MERGE() MID() NOSTR() NOTCHR() NUMPOS() ORCHR() 
-                       PARSESTR() PEDIT() POS() PRINTF() RANDPOS() REPEAT() 
-                       REPLACE() RIGHT() RJC() RJUST() ROTL() ROTR() S() 
-                       SCRAMBLE() SECURE() SECUREX() SHL() SHR() SHUFFLE() 
-                       SPACE() SPLICE() SQUISH() STR() STRDISTANCE() STREQ() 
-                       STREVAL() STRIP() STRIPACCENTS() STRLEN() STRMATCH() 
-                       SUBNETMATCH() SWITCH() SWITCHALL() T() TOTPOS() TR() 
-                       TRANSLATE() TRIM() UCSTR() UNESCLIST() WORDPOS() 
-                       WORDS() WRAP() WRAPCOLUMNS() XORCHR()
+                       ISALPHA() ISDBREF() ISDIGIT() ISNUM() ISOBJID() 
+                       ISPUNCT() ISSPACE() ISTAG() ISWORD() ISXDIGIT() LCSTR() 
+                       LEFT() LIT() LJC() LJUST() MERGE() MID() NOSTR() 
+                       NOTCHR() NUMPOS() ORCHR() PARSESTR() PEDIT() POS() 
+                       PRINTF() RANDPOS() REPEAT() REPLACE() RIGHT() RJC() 
+                       RJUST() ROTL() ROTR() S() SCRAMBLE() SECURE() SECUREX()
+                       SHL() SHR() SHUFFLE() SPACE() SPLICE() SQUISH() STR() 
+                       STRDISTANCE() STREQ() STREVAL() STRIP() STRIPACCENTS() 
+                       STRLEN() STRMATCH() SUBEVAL() SUBNETMATCH() SWITCH() 
+                       SWITCHALL() T() TEMPLATE() TOTPOS() TR() TRANSLATE() 
+                       TRIM() UCSTR() UNESCLIST() WORDPOS() WORDS() WRAP() 
+                       WRAPCOLUMNS() XORCHR()
              See Also: help string functions
   
-  Time:                CONVSECS() CONVTIME() PTIMEFMT() SECS() SINGLETIME()
-                       TIME() TIMEFMT()
+  Time:                CONVSECS() CONVTIME() MSECS() PTIMEFMT() SECS() 
+                       SINGLETIME() TIME() TIMEFMT()
              See Also: help time functions  
   
   { 'help function classes6' for more }
@@ -18939,9 +24583,9 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Side-Effects:        CLONE() CREATE() DESTROY() DIG() EMIT() LEMIT() LINK() 
                        LIST() LOCK() NAME() NAMEQ() NPEMIT() OEMIT() OPEN() 
-                       PARENT() PEMIT() R() REMIT() RSET() RXLEVEL() SET() 
-                       SETQ() SETQ_OLD() SETR() SETR_OLD() TEL() TOGGLE() 
-                       TXLEVEL() WIPE() ZEMIT()
+                       PARENT() PEMIT() R() REMIT() RSET() RULER() RXLEVEL() 
+                       SET() SETQ() SETQ_OLD() SETR() SETR_OLD() TEL() 
+                       TOGGLE() TOTEMSET() TXLEVEL() WIPE() ZEMIT()
              See Also: help side effect functions  
   
   Dbase Side-Effects:  SQLITE_QUERY()
@@ -18959,7 +24603,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Zone Functions:     INZONE() ZFUN() ZFUN2() ZFUNDEFAULT() ZFUN2DEFAULT() 
                       ZFUNEVAL() ZFUNLDEFAULT() ZFUNL2DEFAULT() ZFUNLOCAL() 
-                      ZFUN2LOCAL() ZWHO()
+                      ZFUN2LOCAL() ZONECMD() ZWHO()
             See Also: help zone functions
   
   Cluster Functions:  CLUSTER_ADD() CLUSTER_ATTRCNT() CLUSTER_DEFAULT() 
@@ -18989,23 +24633,24 @@ Generated: Wed Jan 13 04:15:48 2016
  @@()               ABS()               ACCENT()             ACOS()        
  ADD()              AFTER()             AINDEX()             AIINDEX()         
  ALPHAMAX()         ALPHAMIN()          AND()                ANDCHR()        
- ANDFLAG()          ANDFLAGS()          ANSI()               APOSS()     
- ARRAY()            ART()               ASC()                ASIN()           
- ATAN()             ATAN2()             ATTRCNT()            AVG()            
- BEFORE()           BETWEEN()           BITTYPE()            BOUND()          
- BRACKETS()         CAND()              CAPSTR()             CASE()           
- CASEALL()          CAT()               CEIL()               CENTER()         
- CHARIN()           CHAROUT()           CHKREALITY()         CHKTRACE()       
- CHOMP()            CHR()               CITER()              CLONE()          
+ ANDFLAG()          ANDFLAGS()          ANDTOTEM()           ANDTOTEMS()
+ ANSI()             ANSIPOS()           APOSS()              ARRAY()          
+ ART()              ASC()               ASIN()               ATAN()           
+ ATAN2()            ATTRCNT()           ATTRPASS()           AVG()             
+ BEFORE()           BETWEEN()           BITTYPE()            BOUND()           
+ BRACKETS()         CAND()              CAPSTR()             CASE()            
+ CASEALL()          CAT()               CEIL()               CENTER()          
+ CHARIN()           CHAROUT()           CHKREALITY()         CHKTRACE()        
+ CHOMP()            CHR()               CITER()              CLONE()           
  CLUSTER_ADD()      CLUSTER_ATTRCNT()   CLUSTER_DEFAULT()    CLUSTER_EDEFAULT()
- CLUSTER_FLAGS()    CLUSTER_GET()       CLUSTER_GET_EVAL()   CLUSTER_GREP()   
- CLUSTER_HASATTR()  CLUSTER_HASFLAG()   CLUSTER_LATTR()      CLUSTER_REGREP() 
- CLUSTER_REGREPI()  CLUSTER_SET()       CLUSTER_STATS()      CLUSTER_U()      
- CLUSTER_U2()       CLUSTER_U2DEFAULT() CLUSTER_U2LDEFAULT() CLUSTER_U2LOCAL()
- CLUSTER_UDEFAULT() CLUSTER_UEVAL()     CLUSTER_ULDEFAULT()  CLUSTER_ULOCAL() 
- CLUSTER_VATTRCNT() CLUSTER_WIPE()      CLUSTER_XGET()       CMDS()           
- CNAME()            COLORS()            COLUMNS()            COMP()           
- CON()              CONFIG()            CONN()               CONTROLS()       
+ CLUSTER_FLAGS()    CLUSTER_GET()       CLUSTER_GET_EVAL()   CLUSTER_GREP()    
+ CLUSTER_HASATTR()  CLUSTER_HASFLAG()   CLUSTER_LATTR()      CLUSTER_REGREP()  
+ CLUSTER_REGREPI()  CLUSTER_SET()       CLUSTER_STATS()      CLUSTER_U()       
+ CLUSTER_U2()       CLUSTER_U2DEFAULT() CLUSTER_U2LDEFAULT() CLUSTER_U2LOCAL() 
+ CLUSTER_UDEFAULT() CLUSTER_UEVAL()     CLUSTER_ULDEFAULT()  CLUSTER_ULOCAL()  
+ CLUSTER_VATTRCNT() CLUSTER_WIPE()      CLUSTER_XGET()       CMDS()            
+ CNAME()            COLORS()            COLUMNS()            COMP()            
+ CON()              CONFIG()            CONN()               CONTROLS()        
  CONVSECS()    
   
 { 'help function list2' for more }
@@ -19017,31 +24662,32 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="function list2"><H3>FUNCTION LIST2</H3></A><PRE>
 
-  CONVTIME()      COR()          COS()         CRC32()         CREATE() 
-  CREATETIME()    CREPLACE()     CTU()         DEC()           DECODE64()
-  DECRYPT()       DEFAULT()      DELETE()      DELEXTRACT()    DESTROY()     
-  DICE()          DIG()          DIGEST()      DIST2D()        DIST3D()      
-  DIV()           E()            EDEFAULT()    EDIT()          EDITANSI() 
-  EE()            ELIST()        ELEMENTPOS()  ELEMENTS()      ELEMENTSMUX()
-  ELOCK()         EMIT()         ENCODE64()    ENCRYPT()       ENTRANCES() 
-  EQ()            ERROR()        ESCAPE()      ESCAPEX()       ESCLIST()   
-  EVAL()          EXIT()         EXP()         EXTRACT()       EXTRACTWORD()
-  FBETWEEN()      FBOUND()       FDIV()        FILTER()        FINDABLE()  
-  FIRST()         FLAGS()        FLOOR()       FLOORDIV()      FOLD()      
-  FOLDERCURRENT() FOLDERLIST()   FOREACH()     FULLNAME()      GARBLE()    
-  GET()           GET_EVAL()     GLOBALROOM()  GRAB()          GRABALL()   
-  GREP()          GT()           GTE()         GUILD()         HASATTR()   
-  HASATTRP()      HASFLAG()      HASTOGGLE()   HASTYPE()       HASQUOTA()  
-  HASRXLEVEL()    HASTXLEVEL()   HOME()        IBREAK()        IDLE()      
-  IFELSE()        IINDEX()       ILEV()        INC()           INDEX()     
-  INPROGRAM()     INSERT()       INUM()        INZONE()        ISALNUM()   
-  ISALPHA()       ISCLUSTER()    ISDBREF()     ISDIGIT()       ISHIDDEN()  
-  ISNUM()         ISPUNCT()      ISSPACE()     ISWORD()        ISXDIGIT()  
-  ITER()          ITEXT()        KEEPFLAGS()   KEEPTYPE()      LADD()      
-  LAND()          LAST()         LASTCREATE()  LATTR()         LAVG()      
-  LCMDS()         LCON()         LCSTR()       LDELETE()       LDIV()      
-  LEMIT()         LEFT()         LEXITS()      LFLAGS()        LINK()      
-  LIST()          LISTCOMMANDS() LISTDIFF()    LISTFUNCTIONS() 
+  CONVTIME()      COR()           COS()          CRC32()       CREATE() 
+  CREATETIME()    CREPLACE()      CTU()          DEC()         DECODE64()
+  DECRYPT()       DEFAULT()       DELETE()       DELEXTRACT()  DESTROY()     
+  DICE()          DIG()           DIGEST()       DIST2D()      DIST3D()      
+  DIV()           E()             EDEFAULT()     EDIT()        EDITANSI() 
+  EE()            ELIST()         ELEMENTPOS()   ELEMENTS()    ELEMENTSMUX()
+  ELOCK()         EMIT()          ENCODE64()     ENCRYPT()     ENTRANCES() 
+  EQ()            ERROR()         ESCAPE()       ESCAPEX()     ESCLIST()   
+  EVAL()          EXIT()          EXP()          EXTRACT()     EXTRACTWORD()
+  FBETWEEN()      FBOUND()        FDIV()         FILTER()      FINDABLE()  
+  FIRST()         FLAGS()         FLOOR()        FLOORDIV()    FOLD()      
+  FOLDERCURRENT() FOLDERLIST()    FOREACH()      FULLNAME()    GARBLE()    
+  GET()           GET_EVAL()      GLOBALROOM()   GRAB()        GRABALL()   
+  GREP()          GT()            GTE()          GUILD()       HASATTR()   
+  HASATTRP()      HASFLAG()       HASTOGGLE()    HASTOTEM()    HASTYPE()   
+  HASQUOTA()      HASRXLEVEL()    HASTXLEVEL()   HOME()        IBREAK()    
+  IDLE()          IFELSE()        IINDEX()       ILEV()        INC()       
+  INDEX()         INF()           INPROGRAM()    INSERT()      INUM()      
+  INZONE()        ISALNUM()       ISALPHA()      ISCLUSTER()   ISDBREF()   
+  ISDIGIT()       ISHIDDEN()      ISNUM()        ISOBJID()     ISPUNCT()   
+  ISSPACE()       ISTAG()         ISWORD()       ISXDIGIT()    ITER()      
+  ITEXT()         KEEPFLAGS()     KEEPTYPE()     LADD()        LAND()      
+  LAST()          LASTCREATE()    LATTR()        LAVG()        LCMDS()     
+  LCON()          LCSTR()         LDELETE()      LDIV()        LEMIT()     
+  LEFT()          LEXITS()        LFLAGS()       LINK()        LIST()      
+  LISTCOMMANDS()  LISTDIFF()      LISTFUNCTIONS()
   
 { 'help function list3' for more }
   
@@ -19052,30 +24698,32 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="function list3"><H3>FUNCTION LIST3</H3></A><PRE>
     
-  LISTFLAGS()   LISTINTER()    LISTMATCH()    LISTNEWSGROUPS() LISTPROTECTION()
-  LISTRLEVELS() LISTTOGGLES()  LISTUNION()    LIT()            LJC()          
-  LJUST()       LLOC()         LMAX()         LMIN()           LMUL()         
-  LN()          LNOR()         LNUM()         LNUM2()          LOC()          
-  LOCALFUNC()   LOCALIZE()     LOCATE()       LOCK()           LOCKCHECK()
-  LOCKDECODE()  LOCKENCODE()   LOG()          LOR()            LRAND()       
-  LREPLACE()    LROOMS()       LSUB()         LT()             LTE()         
-  LTOGGLES()    LWHO()         LXNOR()        LXOR()           LZONE()       
-  MAILQUICK()   MAP()          MATCH()        MASK()           MAX()         
-  MEMBER()      MERGE()        MID()          MIN()            MIX()         
-  MOD()         MODULO()       MODIFYTIME()   MONEY()          MONEYNAME()   
-  MOON()        MUDNAME()      MUL()          MUNGE()          MWORDS()
-  NAME()        NAMEQ()        NAND()         NCOMP()          NEARBY()       
-  NEQ()         NEXT()         NOR()          NOSTR()          NOT()          
-  NOTCHR()      NPEMIT()       NSITER()       NUM()            NUMMATCH()     
-  NULL()        NUMMEMBER()    NUMPOS()       NUMWILDMATCH()   OBJ()          
-  OBJEVAL()     OEMIT()        OPEN()         OR()             ORCHR()        
-  ORFLAG()      ORFLAGS()      OWNER()        PACK()           PARENMATCH()   
-  PARENT()      PARSE()        PARSESTR()     PEDIT()          PEMIT()        
-  PFIND()       PGREP()        PI()           PID()            PMATCH()       
-  PORT()        POS()          POSS()         POWER()          POWER10()      
-  PRINTF()      PRIVATIZE()    PROGRAMMER()   PTIMEFMT()       PUSHREGS()     
-  QUOTA()       R()            RACE()         RAND()           RANDPOS()      
-  RANDMATCH()   RANDEXTRACT() 
+  LISTFLAGS()    LISTINTER()   LISTMATCH()    LISTNEWSGROUPS() LISTPROTECTION()
+  LISTRLEVELS()  LISTTAGS()    LISTTOGGLES()  LISTTOTEMS()     LISTUNION()    
+  LIT()          LJC()         LJUST()        LLOC()           LMAX()         
+  LMIN()         LMUL()        LN()           LNOR()           LNUM()         
+  LNUM2()        LOC()         LOCALFUNC()    LOCALIZE()       LOCATE()       
+  LOCK()         LOCKCHECK()   LOCKDECODE()   LOCKENCODE()     LOG()          
+  LOR()          LRAND()       LREPLACE()     LROOMS()         LSET()         
+  LSUB()         LT()          LTE()          LTOGGLES()       LTOTEMS()      
+  LWHO()         LXNOR()       LXOR()         LZONE()          MAILQUICK()    
+  MAP()          MATCH()       MASK()         MAX()            MEMBER()       
+  MERGE()        MID()         MIN()          MIX()            MOD()          
+  MODULO()       MODIFYTIME()  MONEY()        MONEYNAME()      MOON()         
+  MSECS()        MUDNAME()     MUL()          MUNGE()          MWORDS()       
+  NAME()         NAMEQ()       NAND()         NCOMP()          NEARBY()       
+  NEQ()          NEXT()        NOR()          NOSTR()          NOT()          
+  NOTCHR()       NPEMIT()      NSITER()       NUM()            NUMMATCH()     
+  NULL()         NUMMEMBER()   NUMPOS()       NUMWILDMATCH()   OBJ()          
+  OBJEVAL()      OBJID()       OEMIT()        OPEN()           OR()           
+  ORCHR()        ORFLAG()      ORFLAGS()      ORTOTEM()        ORTOTEMS()     
+  OWNER()        PACK()        PACKMATH()     PARENMATCH()     PARENT()       
+  PARSE()        PARSESTR()    PEDIT()        PEMIT()          PFIND()        
+  PGREP()        PI()          PID()          PMATCH()         PORT()         
+  POS()          POSS()        POWER()        POWER10()        PRINTF()       
+  PRIVATIZE()    PROGRAMMER()  PTIMEFMT()     PUSHREGS()       QUOTA()        
+  R()            RACE()        RAND()         RANDPOS()        RANDMATCH()    
+  RANDEXTRACT() 
     
 { 'help function list4' for more }
  
@@ -19094,24 +24742,27 @@ Generated: Wed Jan 13 04:15:48 2016
   REPEAT()        REPLACE()       REST()         REVERSE()      REVWORDS()    
   RIGHT()         RINDEX()        RJC()          RJUST()        RLOC()        
   RNUM()          ROMAN()         ROOM()         ROTL()         ROTR()        
-  ROUND()         RSET()          RXLEVEL()      S()            SAFEBUFF()    
-  SCRAMBLE()      SEARCH()        SEARCHNG()     SECS()         SECURE()      
-  SECUREX()       SEES()          SET()          SETDIFF()      SETINTER()     
-  SETQ()          SETQ_OLD()      SETQMATCH()    SETR()         SETR_OLD()    
-  SETUNION()      SHIFT()         SHL()          SHR()          SHUFFLE()     
-  SIGN()          SIN()           SINGLETIME()   SORT()         SORTBY()      
-  SORTLIST()      SOUNDEX()       SOUNDLIKE()    SOUNDSLIKE()   SPACE()      
-  SPELLNUM()      SPLICE()        SQL()          SQLESCAPE()    SQLOFF()
-  SQLON()         SQLPING()       SQLITE_QUERY() SQRT()         SQUISH()     
-  STARTTIME()     STARTSECS()     STATS()        STEP()         STR()        
+  ROUND()         RSET()          RULER()        RXLEVEL()      S()          
+  SAFEBUFF()      SANDBOX()       SCRAMBLE()     SEARCH()       SEARCHOBJID()
+  SEARCHNG()      SEARCHNGOBJID() SECS()         SECURE()       SECUREX()    
+  SEES()          SET()           SETDIFF()      SETINTER()     SETQ()       
+  SETQ_OLD()      SETQMATCH()     SETR()         SETR_OLD()     SETUNION()   
+  SHIFT()         SHL()           SHR()          SHUFFLE()      SIGN()       
+  SIN()           SINGLETIME()    SORT()         SORTBY()       SORTLIST()   
+  SOUNDEX()       SOUNDLIKE()     SOUNDSLIKE()   SPACE()        SPELLNUM()   
+  SPLICE()        SQL()           SQLESCAPE()    SQLOFF()       SQLON()      
+  SQLPING()       SQLITE_QUERY()  SQRT()         SQUISH()       STARTTIME()  
+  STARTSECS()     STATS()         STDERR()       STEP()         STR()        
   STRCAT()        STRDISTANCE()   STREQ()        STREVAL()      STRFUNC()    
   STRIP()         STRIPACCENTS()  STRIPANSI()    STRLEN()       STRMATCH()   
-  STRMATH()       SUB()           SUBJ()         SUBNETMATCH()  SWITCH()     
-  SWITCHALL()     T()             TAN()          TEL()          TIME()       
-  TIMEFMT()       TOBIN()         TODEC()        TOGGLE()       TOHEX()      
-  TOOCT()         TOTCMDS()       TOTMATCH()     TOTMEMBER()    TOTPOS()     
-  TOTWILDMATCH()  TR()            TRACE()        TRANSLATE() 
-
+  STRMATH()       SUB()           SUBEVAL()      SUBJ()         SUBNETMATCH()
+  SWITCH()        SWITCHALL()     T()            TAG()          TAGMATCH()
+  TAN()           TEL()           TEMPLATE()     TIME()         TIMEFMT()
+  TOBIN()         TODEC()         TOGGLE()       TOHEX()        TOOCT()
+  TOTCMDS()       TOTEMS()        TOTEMSET()     TOTMATCH()     TOTMEMBER()  
+  TOTPOS()        TOTWILDMATCH()  TR()           TRACE()        TRANSLATE()  
+  TRIM()
+  
 { 'help function list5' for more }
 
 </PRE>
@@ -19121,7 +24772,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="function list5"><H3>FUNCTION LIST5</H3></A><PRE>
   
-  TRIM()         TRUNC()       TXLEVEL()       TYPE()          U() 
+  TRREVERSE()    TRUNC()       TXLEVEL()       TYPE()          U() 
   U2()           UCSTR()       UDEFAULT()      UDEFAULT2()     UEVAL()
   ULDEFAULT()    U2LDEFAULT()  ULOCAL()        ULOCAL2()       UNESCLIST()
   UNPACK()       V()           VADD()          VALID()         VATTRCNT()   
@@ -19132,7 +24783,7 @@ Generated: Wed Jan 13 04:15:48 2016
   XDEC()         XINC()        XGET()          XNOR()          XOR()        
   XORCHR()       ZEMIT()       ZFUN()          ZFUN2()         ZFUNDEFAULT()
   ZFUN2DEFAULT() ZFUNEVAL()    ZFUNLDEFAULT()  ZFUNL2DEFAULT() ZFUNLOCAL()  
-  ZFUN2LOCAL()   ZWHO() 
+  ZFUN2LOCAL()   ZONECMD()     ZWHO() 
   
 { 'help function aliases' for aliases on existing functions }
   
@@ -19219,7 +24870,7 @@ Generated: Wed Jan 13 04:15:48 2016
   This function garbles the input from &lt;str&gt; and returns it garbled.  Each word
   has a 1 in &lt;value&gt; chance of being garbled.  Normal garbled strings have a 
   random character assigned unless you specify the filler character.  You may 
-  specify a seperator other than space.  If you specify the &lt;type&gt; of '1', it 
+  specify a separator other than space.  If you specify the &lt;type&gt; of '1', it 
   assumes the value is a percentile instead of fractional.  A &lt;value&gt; '0' with
   &lt;type&gt; '0' (1/0) returns nothing while &lt;type&gt; '1' (0%) returns the string.
   The key field allows the following bitwise values:
@@ -19244,7 +24895,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say garble(this is a test!?,50,,-,1,1) (50 percent, no garble punct.)
     You say &quot;---- is a ----!?&quot;
   
-  See Also: strip(), edit(), editansi(), mask(), regedit()
+  See Also: strip(), edit(), editansi(), regedit()
   
 </PRE>
 <A HREF="#game information functions">[PREV]</A>
@@ -19383,6 +25034,53 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#give">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#globbing">[NEXT]</A>
+<BR>
+<HR><A NAME="globbing"><H3>GLOBBING</H3></A><PRE>
+  Topic:  WILDCARDS [* and ?]  (also referred to as GLOBBING)
+  
+  Note: RhostMUSH also supports regular expressions.  Please refer to 
+        'help REGEXPS'
+  
+  Wildcards are the standard globbing mechanism for the mush engine.  With the
+  wildcards, the '*' character is considered 0 or more characters and the '?'
+  character is considered a single character.  These are used primarilly in
+  commands and functions that allow mulit-matching based on wild card support.
+  
+  Example:
+    &gt; say match(this is a test,?es*)
+    You say &quot;4&quot;
+  
+  Wildcards, however, are most useful for $command substitution matching.
+  When you create your own softcoded command, any argument you want
+  substituted you would place a '*' or a '?' for that argument.  Each argument
+  is then matched up with a numerical argument for each wildcard used.  The
+  first argument being %0, second being %1, and so forth.
+  
+  Example:
+    &gt; &amp;TEST1 me=$test1*:@emit Your First Test:%0
+    &gt; &amp;TEST2 me=$test2?:@emit Your Second Test:%0
+    &gt; &amp;TEST3 me=$test3 *:@emit Your Third Test:%0
+    &gt; test1
+    Your First Test:
+    &gt; test1 abc
+    Your First Test: abc  [notice the space between ':' and 'a']
+    &gt; test2
+    Huh? (Type 'help' for help)  [Because ? requires 1 character exactly]
+    &gt; test2X
+    Your Second Test:X
+    &gt; test2abc
+    Huh? (Type 'help' for help)  [Because ? required 1 character exactly]
+    &gt; test3
+    Huh? (Type 'help' for help)  [because you have a space in the command]
+    &gt; test3 abc
+    Your Third Test:abc  [notice no space between ':' and 'a']
+    
+  { See 'help wildcards2' for clarification and extended explainations }
+ 
+</PRE>
+<A HREF="#globalroom()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#goals">[NEXT]</A>
 <BR>
 <HR><A NAME="goals"><H3>GOALS</H3></A><PRE>
@@ -19393,7 +25091,7 @@ Generated: Wed Jan 13 04:15:48 2016
   to meet. There are no winners or losers, only fellow players.  Enjoy.
   
 </PRE>
-<A HREF="#globalroom()">[PREV]</A>
+<A HREF="#globbing">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#going">[NEXT]</A>
 <BR>
@@ -19480,14 +25178,14 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#graball()">[NEXT]</A>
 <BR>
 <HR><A NAME="graball()"><H3>GRABALL()</H3></A><PRE>
-  Function: graball(&lt;string&gt;, &lt;pattern&gt;[, &lt;delimeter&gt;[, &lt;seperator&gt;]])
+  Function: graball(&lt;string&gt;, &lt;pattern&gt;[, &lt;delimeter&gt;[, &lt;separator&gt;]])
    
   This function matches &lt;pattern&gt; against each word of &lt;string&gt;, returning
   the all the words it matches.  If no words are found to match the pattern,
   then an empty string is returned.  &lt;pattern&gt; may consist of wildcards.
   Wildcards being the use of '*' for any number of characters or '?' for
   a single character.  An optional delimiter may be used as well as an
-  optional output seperator. 
+  optional output separator. 
   
   Examples:
     &gt; graball(This is a test,*es*)
@@ -19710,6 +25408,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="hasflag()"><H3>hasflag()</H3></A><PRE>
   Function: hasflag(&lt;object&gt;[/&lt;attribute&gt;],&lt;flag&gt;)
+  
   Returns true if object &lt;object&gt; has the flag named &lt;flag&gt; set on it.
   You may not be able to retrieve information for objects that you do not
   own.  You may also check if the given flag exists on the ATTRIBUTE.
@@ -19726,7 +25425,7 @@ Generated: Wed Jan 13 04:15:48 2016
   NOPROG is how the MUSH internally recognizes the NO_COMMAND flag.
   Confusing, I know.  See 'help ATTRIBUTE FLAGS' on all of these flags.
   
-  See Also: LIST FLAGS, ATTRIBUTE FLAGS, hastype()
+  See Also: LIST FLAGS, ATTRIBUTE FLAGS, hastype(), hastoggle(), hastotem()
   
 </PRE>
 <A HREF="#hasattrp()">[PREV]</A>
@@ -19771,7 +25470,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say hasrxlevel(me,real)
     You say '1'.
   
-  See Also: hastxlevel(), rxlevel(), txlevel(), listrlevels(), chkreality()
+  See Also: hastxlevel(), rxlevel(), txlevel(), listrlevels(), chkreality(),
+            rxdesc()
   
 </PRE>
 <A HREF="#hasquota()">[PREV]</A>
@@ -19781,14 +25481,36 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="hastoggle()"><H3>HASTOGGLE()</H3></A><PRE>
   Function: hastoggle(&lt;player&gt;,&lt;toggle&gt;)
   
+  This function will return '1' if &lt;player&gt; has the specified toggle, '0' if
+  not. If you do not have permission to pull the information, a '#-1' may
+  be returned.
+  
   Example:
     &gt; say hastoggle(player, brandy_mail)
     You say &quot;1&quot;
    
-  See Also: hasflag()
+  See Also: hasflag(), hastotem()
   
 </PRE>
 <A HREF="#hasrxlevel()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#hastotem()">[NEXT]</A>
+<BR>
+<HR><A NAME="hastotem()"><H3>HASTOTEM()</H3></A><PRE>
+  Function: hastotem(&lt;player&gt;, &lt;totem&gt;)
+  
+  This function will return '1' if &lt;player&gt; has the specified totem, '0' if
+  not.  If you do not have permission to pull the information, a '#-1' may
+  be returned.
+  
+  Example:
+    &gt; say hastotem(player, totem1)
+    You say &quot;1&quot;
+   
+  See Also: hasflag(), hastoggle()
+  
+</PRE>
+<A HREF="#hastoggle()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#hastxlevel()">[NEXT]</A>
 <BR>
@@ -19803,10 +25525,11 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say hastxlevel(me,real)
     You say '1'.
   
-  See Also: hasrxlevel(), rxlevel(), txlevel(), listrlevels(), chkreality()
+  See Also: hasrxlevel(), rxlevel(), txlevel(), listrlevels(), chkreality(),
+            rxdesc()
   
 </PRE>
-<A HREF="#hastoggle()">[PREV]</A>
+<A HREF="#hastotem()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#hastype()">[NEXT]</A>
 <BR>
@@ -19851,6 +25574,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Notes on help descriptions: 
         [text] - Text enclosed in []'s is optional.  The []'s are never typed
                  in as part of the command.
+  
         &lt;parameter&gt; - Information parameter for a command.  The &lt;&gt;'s are
                       never typed in as part of the command.
  
@@ -19864,6 +25588,8 @@ Generated: Wed Jan 13 04:15:48 2016
   You may use '*' or '?' for wildcard searches on topics.
   
   You may use the /search switch for content searching.  Eg: help/search *mail*
+  
+  You may use the /query switch for detailed searching.  Eg: help/query *mail*
   
   Command syntax help is available by issuing /syntax. Eg: @emit/syntax
   
@@ -19889,13 +25615,45 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#help">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#historical">[NEXT]</A>
+<BR>
+<HR><A NAME="historical"><H3>historical</H3></A><PRE>
+  For a list of actual changes, see 'help revis'.
+  
+  RhostMUSH, first originating in 1989/1990, was founded as a TinyMUD.
+  Though the current code runs a MUSH compatible kernal, we still use
+  the exact same database from that period.  You will find RhostMUSH
+  is nothing like a MUD, MUSH or a MUSE.  It is a hybrid of many systems.
+  The coders for RhostMUSH have put a lot of effort into adding changes 
+  and modifying the server.  You will find that pretty much any code 
+  will work properly here on RhostMUSH.  Another major change is error 
+  messages are randomized.  So if you see something strange, you're 
+  not being spoofed.  Also, if you notice a strange response, don't 
+  think it's a problem.  Talk to a staff person as the option you 
+  may be trying may be disabled.
+  
+  The list of changes done to this server goes beyond any document
+  can describe.  The only resemblance this has to TinyMUSH or any
+  other variety of server is in its backward compatibility with
+  how it parses and functionality returns.
+   
+  For help on these people, look at CREDITS
+  
+  See Also: CREDITS
+  
+</PRE>
+<A HREF="#here">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#home()">[NEXT]</A>
 <BR>
 <HR><A NAME="home()"><H3>HOME()</H3></A><PRE>
   home(&lt;object&gt;)
  
   Returns the object's home.
- 
+  
+  If used on an exit, it will return the exit's *location*.  Exits do
+  not have a 'home' other than their location.
+   
   Example:
     &gt; exam me
     Mortal(#226Pc)
@@ -19908,10 +25666,10 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say home(me)
     You say &quot;#367&quot;
   
-  See Also: loc(), room(), @link
+  See Also: loc(), room(), rloc(), @link, EXITS
   
 </PRE>
-<A HREF="#here">[PREV]</A>
+<A HREF="#historical">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#homes">[NEXT]</A>
 <BR>
@@ -19961,7 +25719,7 @@ Generated: Wed Jan 13 04:15:48 2016
   &gt; say [iter(red blue green,iter(fish shoe, [inum(1)]:[itext(1)][ibreak(0)]))]
   You say, &quot;1:red 2:blue 3:green&quot;
   
-  See Also: iter(), itext(), ilev(), inum(), list()
+  See Also: iter(), itext(), ilev(), inum(), list(), inf(), %i, %d
 
   
 </PRE>
@@ -19975,10 +25733,10 @@ Generated: Wed Jan 13 04:15:48 2016
   (*note this flag is meaningless on RhostMUSH*)
   When set on a player or object, denotes that they are In-Character and 
   therefore subject to inclusion in tinyplots, etc, and whatever they
-  say or do will be interpreted as if their character was doing or saying it.
+  say or do will be interpreted as if their player was doing or saying it.
   If this flag is not set, whatever the they say or do is to be interpreted
   as if it is either the real life person talking, or some mixture of the
-  character and the real life person that is not 100% In-Character and should
+  player and the real life person that is not 100% In-Character and should
   not be taken as being in character.
  
   When set on a room it denotes that the room is fair ground for roleplaying.
@@ -20084,18 +25842,22 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#idle">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
-<A HREF="#ifelse()">[NEXT]</A>
+<A HREF="#if()">[NEXT]</A>
 <BR>
-<HR><A NAME="ifelse()"><H3>ifelse()</H3></A><PRE>
+<HR><A NAME="if()"><H3>if()</H3></A><PRE>
   Function: ifelse(&lt;expression&gt;,&lt;true string&gt;[,&lt;false string&gt;])
  
   This function returns &lt;true string&gt; if &lt;expression&gt; is true (not 0), 
   &lt;false string&gt; otherwise. Much more efficient than an equivalent
   switch(). To check if a string contains text or not, use strlen() within
-  the test case.  The false string is optional and if nothing is specified, 
-  it will return an empty string if a false match is met.  This will 
-  effectively mimic the if() function found on other servers.
+  the test case.  
   
+  The false string is optional and if nothing is specified, it will return 
+  an empty string if a false match is met.  This will effectively mimic 
+  the if() function found on other servers.
+  
+  This function is aliased to if().
+   
   Example:
     &gt; say ifelse(v(test),Test exists!,Test doesn't exist.)
     You say &quot;Test doesn't exist.&quot;
@@ -20110,6 +25872,37 @@ Generated: Wed Jan 13 04:15:48 2016
  
 </PRE>
 <A HREF="#idle()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ifelse()">[NEXT]</A>
+<BR>
+<HR><A NAME="ifelse()"><H3>ifelse()</H3></A><PRE>
+  Function: ifelse(&lt;expression&gt;,&lt;true string&gt;[,&lt;false string&gt;])
+ 
+  This function returns &lt;true string&gt; if &lt;expression&gt; is true (not 0), 
+  &lt;false string&gt; otherwise. Much more efficient than an equivalent
+  switch(). To check if a string contains text or not, use strlen() within
+  the test case.  
+  
+  The false string is optional and if nothing is specified, it will return 
+  an empty string if a false match is met.  This will effectively mimic 
+  the if() function found on other servers.
+  
+  This function is aliased to if().
+   
+  Example:
+    &gt; say ifelse(v(test),Test exists!,Test doesn't exist.)
+    You say &quot;Test doesn't exist.&quot;
+    &gt; say ifelse(strlen(v(test)),Test exits!,Test doesn't exist.)
+    You say &quot;Test exists!&quot;
+    &gt; say ifelse(gt(1,0),This is true!)
+    You say &quot;This is true!&quot;
+    &gt; say ifelse(gt(0,1),This is true!)
+    You say &quot;&quot;
+  
+  See Also: switch(), case(), @switch
+ 
+</PRE>
+<A HREF="#if()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#iindex()">[NEXT]</A>
 <BR>
@@ -20152,7 +25945,7 @@ Generated: Wed Jan 13 04:15:48 2016
   This example shows that the ilev() is in the 3rd (starting at 0)
   level of iter.
   
-  See Also: inum(), itext(), iter(), ibreak(), list()
+  See Also: inum(), itext(), iter(), ibreak(), list(), inf()
   
 </PRE>
 <A HREF="#iindex()">[PREV]</A>
@@ -20177,9 +25970,13 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="inc()"><H3>INC()</H3></A><PRE>
   Function: inc(&lt;number&gt;)
   
+  INC() and XINC() may be reversed.  to check if they are, Please reference:  
+                           @list options system  
+  
   The inc() function is used to increment numerical values in local registers.
-  The valid registers are 0 through 9.  If the value in the register is a 
-  string, it will return the string without any changes.
+  The valid registers are 0-9, and a-z.  You may also use setq labels.
+  If the value in the register is a string, it will return the string without
+  any changes.
   
   Example:
     &gt; say [setq(0,10)] 1: [r(0)] [inc(0)] 2: [r(0)]
@@ -20231,6 +26028,54 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#indestructible">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#inf()">[NEXT]</A>
+<BR>
+<HR><A NAME="inf()"><H3>INF()</H3></A><PRE>
+  Function: iter(&lt;list&gt;, &lt;eval&gt;[, &lt;delim&gt; [, &lt;output separator&gt;]])
+             inf(&lt;list&gt;, &lt;eval&gt;[, &lt;delim&gt; [, &lt;output separator&gt;]])
+ 
+  &lt;list&gt; is a &lt;delimiter&gt;-separated list of strings, which can be object
+  numbers, attributes, or arbitrary words.  &lt;eval&gt; is a string that is to be
+  evaluated once for each item in &lt;list&gt;, replacing the special symbol ## with
+  the corresponding item from &lt;list&gt;.  A space-separated list of the results
+  of these evaluations is returned to the caller.  The effect is very similar
+  to @dolist, except that the results are made into a list and returned, not
+  executed.  The special symbol #@ can be used to return the positional match
+  of the current item of the list.  You may specify a filler for the string.
+  
+  You may use %i0-%i9 for itext(0) to itext(9).  
+  You may use %il for the outermost layer, equiv to itext(ilev())
+  
+  The inf() function is special in that it allows &lt;list&gt; to be passed a 
+  special handler of :&lt;value&gt;:&lt;key&gt;: where &lt;value&gt; is a positive or negative 
+  number, and &lt;key&gt; is &gt; or &lt;.  Such as ':50:&gt;:'   
+  
+  You may not mix the special handler and other values.
+  
+  Examples:
+    &gt; say iter(This is a test,-## #@-)
+    You say &quot;-This 1- -is 2- -a 3- -test 4-&quot;
+    &gt; say iter(This is a test,strlen(##))
+    You say &quot;4 2 1 4&quot;
+    &gt; say iter(lnum(10),mul(mul(##,##),10))
+    You say &quot;0 10 40 90 160 250 360 490 640 810&quot;
+    &gt; say iter(Was it a cat I saw,words(##),s)
+    You say &quot;1 4 1&quot;
+    &gt; say iter(This is a test,##,,***)
+    You say &quot;This***is***a***test&quot;
+    &gt; say iter(This is a test,%i0,,***)
+    You say &quot;This***is***a***test&quot;
+    &gt; say iter(:1000:&gt;:,%i0)
+    You say &quot;:1000:&gt;:&quot;         (iter does not allow the special &lt;list&gt;)
+    &gt; say inf(:1000:&gt;:,%i0)
+    You say &quot;1000 1001 ...&quot;    (it'll print values from 1000 to the LBUF size)
+  
+  See Also: nsiter(), citer(), @dolist, parse(), list(), list(), itext(), 
+            inum(), ilev(), ibreak(), %i, %d
+ 
+</PRE>
+<A HREF="#index()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#info">[NEXT]</A>
 <BR>
 <HR><A NAME="info"><H3>INFO</H3></A><PRE>
@@ -20240,7 +26085,7 @@ Generated: Wed Jan 13 04:15:48 2016
   the mush like players connected, uptime, version, and so forth.
   
 </PRE>
-<A HREF="#index()">[PREV]</A>
+<A HREF="#inf()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#inherit">[NEXT]</A>
 <BR>
@@ -20291,7 +26136,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#insert()">[NEXT]</A>
 <BR>
 <HR><A NAME="insert()"><H3>INSERT()</H3></A><PRE>
-  Function: insert(&lt;list&gt;, &lt;pos&gt; [&lt;pos2&gt;...&lt;posN&gt;], &lt;word&gt;[, &lt;sep&gt;])
+  Function: insert(&lt;list&gt;, &lt;pos&gt; [..&lt;posN&gt;], &lt;word&gt;[[,&lt;sep&gt;] [,&lt;osep&gt;]], &lt;key&gt;)
    
   This function inserts a word into &lt;list&gt; so that the word becomes the
   &lt;pos&gt;'th element of the list, and all subsequent list elements are moved
@@ -20303,18 +26148,57 @@ Generated: Wed Jan 13 04:15:48 2016
   
   The &lt;pos&gt; fields may be negative to take the argument from the right
   instead of the left.
-   
+  
+  You may specify a separate &lt;sep&gt; seperator or it assumes space if not
+  provided.  
+  
+  The &lt;osep&gt; output delimiter may be more than one character, and if 
+  enabled, '@@' can be used as another method for a null.  You may specify 
+  an empty &lt;osep&gt; as well.
+  
+  The following &lt;key&gt;s exist for insert:
+    0 - (default) do normal insert
+    1 - Append the text to the position(s)
+    2 - Prepend the text to the position(s)
+    3 - Box in the position(s) with the text (prepend and append)
+    4 - Transpose box in the position(s) with the text (prepend and append)
+  
+{ see 'help insert2' for examples } 
+
+</PRE>
+<A HREF="#inprogram()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#insert2 ">[NEXT]</A>
+<BR>
+<HR><A NAME="insert2 "><H3>INSERT2 </H3></A><PRE>
+ (CONTINUED)
+  Function: insert(&lt;list&gt;,&lt;pos&gt; [..&lt;posN&gt;],&lt;word&gt;[[,&lt;sep&gt;][,&lt;osep&gt;][,&lt;key&gt;]])
+  
+  Note: if you leave the &lt;osep&gt; output seperator null when using &lt;key&gt;, it 
+        assumes you want an empty (null) output seperator.  To have it use 
+        the same seperator explicitly specify the &lt;osep&gt; if you plan to 
+        use &lt;key&gt;.  You only need to explicitly set &lt;osep&gt; if you use &lt;key&gt;
+        or if you plan to use a different output seperator.
+  
   Examples:
     &gt; say insert(This is a test, 4, new)
     You say &quot;This is a new test&quot;
     &gt; say insert(Yet@Another@List, 3, Funky, @)
     You say &quot;Yet@Another@Funky@List&quot;
+    &gt; say insert(1|2|3,2,&gt;&gt;,|,|,1)
+    You say &quot;1|2&gt;&gt;|3&quot;
+    &gt; say insert(1|2|3,2,&gt;&gt;,|,|,2)
+    You say &quot;1|&gt;&gt;2|3&quot;
+    &gt; say insert(1|2|3,2,&gt;&gt;,|,|,3)
+    You say &quot;1|&gt;&gt;2&gt;&gt;|3&quot;
+    &gt; say insert(1|2|3,2,&gt;&gt;,|,|,4)          (this transposes the &gt; character)
+    You say &quot;1|&gt;&gt;2&lt;&lt;|3&quot;
   
   See Also: extract(), extractword(), ldelete(), replace(), iindex(), aindex(),
             rindex()
   
 </PRE>
-<A HREF="#inprogram()">[PREV]</A>
+<A HREF="#insert()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#internal_doors">[NEXT]</A>
 <BR>
@@ -20339,7 +26223,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @door
   
 </PRE>
-<A HREF="#insert()">[PREV]</A>
+<A HREF="#insert2 ">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#inum()">[NEXT]</A>
 <BR>
@@ -20349,6 +26233,8 @@ Generated: Wed Jan 13 04:15:48 2016
             ibreak(&lt;n&gt;)
             ilev()
    
+  You may specify %i_N instead of inum(N) for iter or list.
+  
   These functions, when called within an iter(), return the equivalent
   of ## (itext) or #@ (inum), with reference to the nth more outermost
   iter(), where n=0 refers to the current iter(), n=1 to an iter()
@@ -20368,10 +26254,13 @@ Generated: Wed Jan 13 04:15:48 2016
   &gt; say [iter(red blue green,iter(fish shoe, [inum(0)]:[itext(0)]))]
   You say, &quot;1:fish 2:shoe 1:fish 2:shoe 1:fish 2:shoe&quot;
    
+  &gt; say [iter(red blue green,iter(fish shoe, %i_0:%i0))]
+  You say, &quot;1:fish 2:shoe 1:fish 2:shoe 1:fish 2:shoe&quot;
+   
   &gt; say [iter(red blue green,iter(fish shoe, [itext(1)]:[itext(0)]))]
   You say, &quot;red:fish red:shoe blue:fish blue:shoe green:fish green:shoe&quot;
   
-  See Also: iter(), itext(), ilev(), ibreak(), list()
+  See Also: iter(), itext(), ilev(), ibreak(), list(), inf(), %i, %d
 
 </PRE>
 <A HREF="#internal_doors">[PREV]</A>
@@ -20380,23 +26269,60 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="inventory"><H3>inventory</H3></A><PRE>
   Command: inventory
+  
   Lists what you are carrying and how much money you have.  If alternate 
   inventories are in effect, anything wielded or worn may not be shown up
   by this inventory.  To see these inventories, use the 'wielded' and
   'worn' commands respectively.
   
-  See Also: score, worn, wielded
+  See Also: score, worn, wielded, invformat
   
 </PRE>
 <A HREF="#inum()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#invformat">[NEXT]</A>
+<BR>
+<HR><A NAME="invformat"><H3>invformat</H3></A><PRE>
+  Attribute: INVFORMAT
+  
+  This attribute is set via &amp;INVFORMAT.  There is no '@invformat'.
+  
+  This attribute when set will format the enctor's inventory.  If the enactor
+  is @powered FORMATTING (either directly or through a parent/zone chain),
+  then you may also use %0-%6 for arguments.  They are:
+    %0 - The space separated list of dbref#'s that would normally show 
+         up in inventory.
+    %1 - The '|' delimited list of names that would normally show up in
+         inventory.
+    %2 - The space separated list of exit dbref#'s that would normally 
+         show up in inventory.
+    %3 - The '|' delimited list of exit names that would normally show 
+         up in inventory.
+    %4 - The space separated list of dbref#'s that are toggled WIELDED
+    %5 - The space separated list of dbref#'s that are toggled WORN
+    %6 - The backpack name that is globally set. (@admin inventory_name)
+  
+  If the target is not @powered FORMATTING, then none of the % registers
+  will return a result.
+  
+  See Also: @conformat, @exitformat, @nameformat, attribute formatting
+
+</PRE>
+<A HREF="#inventory">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#inzone()">[NEXT]</A>
 <BR>
 <HR><A NAME="inzone()"><H3>INZONE()</H3></A><PRE>
-  Function: inzone(&lt;zone&gt;)
-  Returns the rooms in the specified zonemaster.  If the target is not a
-  zonemaster, or if the object is not a valid zone, it returns an empty
-  list.  This is _not_ database intensive.
+  Function: inzone(&lt;zonemaster&gt;)
+            inzone(&lt;zonemaster&gt;, &lt;zonemember&gt;)
+  
+  The first option returns the rooms in the specified &lt;zonemaster&gt;.  If the 
+  target is not a zonemaster, or if the object is not a valid zone, it 
+  returns an empty list.  This is _not_ database intensive.
+  
+  The second option returns '1' if the target &lt;zonemember&gt; belongs to the
+  specified &lt;zonemaster&gt;.  The &lt;zonemember&gt; may be any data type.  This is
+  _not_ database intensive.
   
   Example:
     &gt; @set here=zonemaster
@@ -20407,11 +26333,15 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;#0 #534 #987&quot;
     &gt; say inzone(here)
     You say &quot;#0 #534&quot;
+    &gt; say inzone(here,#987)
+    You say &quot;1&quot;
+    &gt; say inzone(here,#123)
+    You say &quot;0&quot;
   
-  See Also: @zone, ZONES, lzone(), zwho()
+  See Also: @zone, ZONES, lzone(), zwho(), zonecmd()
   
 </PRE>
-<A HREF="#inventory">[PREV]</A>
+<A HREF="#invformat">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#isalnum()">[NEXT]</A>
 <BR>
@@ -20429,7 +26359,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;1&quot;
   
   See Also: isdbref(), isalpha(), ispunct(), isxdigit(), isdigit(), isspace(),
-            isword()
+            istag(), isword(), isobjid()
   
 </PRE>
 <A HREF="#inzone()">[PREV]</A>
@@ -20450,7 +26380,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;0&quot;
  
   See Also: isdbref(), isalnum(), ispunct(), isxdigit(), isdigit(), isspace(),
-            isword()
+            istag(), isword(), isobjid()
   
 </PRE>
 <A HREF="#isalnum()">[PREV]</A>
@@ -20487,8 +26417,8 @@ Generated: Wed Jan 13 04:15:48 2016
      You say &quot;0&quot;
   
   See Also: isspace(), isalpha(), isalnum(), isdigit(), isxdigit(), ispunct(),
-            isword()
-  
+            istag(), isword(), isobjid()
+
 </PRE>
 <A HREF="#iscluster()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -20508,7 +26438,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;1&quot;
   
   See Also: isdbref(), isalpha(), isalnum(), isxdigit(), ispunct(), isspace(),
-            isword(), isint()
+            istag(), isword(), isint(), isobjid()
   
 </PRE>
 <A HREF="#isdbref()">[PREV]</A>
@@ -20519,6 +26449,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Function: ishidden(&lt;player&gt;)
   
   This function currently is not available to non-bitted players.
+  This returns TRUE if the playere is set hidden.
   
   Example:
     &gt; say ishidden(#1)
@@ -20549,7 +26480,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;0&quot;
   
   See Also: isdbref(), isalpha(), isalnum(), isxdigit(), ispunct(), isspace(),
-            isword(), isdigit()
+            istag(), isword(), isdigit(), isobjid()
 
 </PRE>
 <A HREF="#ishidden()">[PREV]</A>
@@ -20589,6 +26520,36 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#islower()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#isobjid()">[NEXT]</A>
+<BR>
+<HR><A NAME="isobjid()"><H3>ISOBJID()</H3></A><PRE>
+  Function: isobjid(&lt;string&gt;)
+  
+  This function will return 1 if the string passed to it is a valid objid.
+  To be a valid objid the string must begin with '#' and be followed by an
+  integer, contain a ':' and have a valid timestamp.  Ergo, it must be a
+  valid objid.  Also, the objid must exist in the current database as a valid
+  object.  If the object fails either of these criteria, then a 0 is
+  returned.
+ 
+  Example:
+     &gt; say objid(#1)
+     You say &quot;#1:841303473&quot;
+     &gt; say isobjid(#-1)
+     You say &quot;0&quot;
+     &gt; say isobjid(#1)
+     You say &quot;0&quot;
+     &gt; say isobjid(#1:841303473)
+     You say &quot;1&quot;
+     &gt; say isobjid(#1:841303472)
+     You say &quot;0&quot;
+  
+  See Also: isspace(), isalpha(), isalnum(), isdigit(), isxdigit(), ispunct(),
+            istag(), isword(), isdbref()
+  
+</PRE>
+<A HREF="#isnum()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#ispunct()">[NEXT]</A>
 <BR>
 <HR><A NAME="ispunct()"><H3>ISPUNCT()</H3></A><PRE>
@@ -20605,10 +26566,10 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;1&quot;
    
   See Also: isdbref(), isalpha(), isalnum(), isxdigit(), isdigit(), isspace(),
-            isword()
+            istag(), isword(), isobjid()
   
 </PRE>
-<A HREF="#isnum()">[PREV]</A>
+<A HREF="#isobjid()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#isspace()">[NEXT]</A>
 <BR>
@@ -20628,10 +26589,33 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;0&quot;
  
   See Also: isdbref(), isalpha(), isalnum(), isdigit(), isxdigit(), ispunct(),
-            isword()
+            istag(), isword(), isobjid()
   
 </PRE>
 <A HREF="#ispunct()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#istag()">[NEXT]</A>
+<BR>
+<HR><A NAME="istag()"><H3>ISTAG()</H3></A><PRE>
+  Function: istag(&lt;string&gt;)
+  
+  This function will return 1 if the string passed to it is a valid tag.
+  To be a valid tag it must be defined in the @tag subsystem and must begin
+  with a '#'.  If the object fails these conditions, then a 0 is returned.
+  
+  Example:
+     &gt; say istag(#-1)
+     You say &quot;0&quot;
+     &gt; say isdtag(#sirlancelot)
+     You say &quot;1&quot;
+     &gt; say isdbref(#sirnotappearinginthismovie)
+     You say &quot;0&quot;
+  
+  See Also: @ltag, isspace(), isalpha(), isalnum(), isdigit(), isxdigit(), 
+            ispunct(), isdbref(), isword(), isobjid()
+
+</PRE>
+<A HREF="#isspace()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#isupper()">[NEXT]</A>
 <BR>
@@ -20643,7 +26627,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: islower()
 
 </PRE>
-<A HREF="#isspace()">[PREV]</A>
+<A HREF="#istag()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#isword()">[NEXT]</A>
 <BR>
@@ -20682,7 +26666,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;0&quot;
  
   See Also: isdbref(), isalpha(), isalnum(), isdigit(), ispunct(), isspace(),
-            isword()
+            istag(), isword(), isobjid()
   
 </PRE>
 <A HREF="#isword()">[PREV]</A>
@@ -20690,7 +26674,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#iter()">[NEXT]</A>
 <BR>
 <HR><A NAME="iter()"><H3>ITER()</H3></A><PRE>
-  Function: iter(&lt;list&gt;, &lt;eval&gt;[, &lt;delim&gt; [, &lt;output seperator&gt;]])
+  Function: iter(&lt;list&gt;, &lt;eval&gt;[, &lt;delim&gt; [, &lt;output separator&gt;]])
+             inf(&lt;list&gt;, &lt;eval&gt;[, &lt;delim&gt; [, &lt;output separator&gt;]])
  
   &lt;list&gt; is a &lt;delimiter&gt;-separated list of strings, which can be object
   numbers, attributes, or arbitrary words.  &lt;eval&gt; is a string that is to be
@@ -20703,7 +26688,13 @@ Generated: Wed Jan 13 04:15:48 2016
   
   You may use %i0-%i9 for itext(0) to itext(9).  
   You may use %il for the outermost layer, equiv to itext(ilev())
-   
+  
+  The inf() function is special in that it allows &lt;list&gt; to be passed a 
+  special handler of :&lt;value&gt;:&lt;key&gt;: where &lt;value&gt; is a positive or negative 
+  number, and &lt;key&gt; is &gt; or &lt;.  Such as ':50:&gt;:'   
+  
+  You may not mix the special handler and other values.
+  
   Examples:
     &gt; say iter(This is a test,-## #@-)
     You say &quot;-This 1- -is 2- -a 3- -test 4-&quot;
@@ -20717,9 +26708,13 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;This***is***a***test&quot;
     &gt; say iter(This is a test,%i0,,***)
     You say &quot;This***is***a***test&quot;
+    &gt; say iter(:1000:&gt;:,%i0)
+    You say &quot;:1000:&gt;:&quot;         (iter does not allow the special &lt;list&gt;)
+    &gt; say inf(:1000:&gt;:,%i0)
+    You say &quot;1000 1001 ...&quot;    (it'll print values from 1000 to the LBUF size)
   
   See Also: nsiter(), citer(), @dolist, parse(), list(), list(), itext(), 
-            inum(), ilev(), ibreak()
+            inum(), ilev(), ibreak(), %i, %d
  
 </PRE>
 <A HREF="#isxdigit()">[PREV]</A>
@@ -20732,6 +26727,8 @@ Generated: Wed Jan 13 04:15:48 2016
             ibreak(&lt;n&gt;)
             ilev()
    
+  You may use %iN instead of itext(N) with iter/list.
+  
   These functions, when called within an iter(), return the equivalent
   of ## (itext) or #@ (inum), with reference to the nth more outermost
   iter(), where n=0 refers to the current iter(), n=1 to an iter()
@@ -20750,11 +26747,14 @@ Generated: Wed Jan 13 04:15:48 2016
    
   &gt; say [iter(red blue green,iter(fish shoe, [inum(0)]:[itext(0)]))]
   You say, &quot;1:fish 2:shoe 1:fish 2:shoe 1:fish 2:shoe&quot;
+  
+  &gt; say [iter(red blue green,iter(fish shoe, %i_0:%i0))]
+  You say, &quot;1:fish 2:shoe 1:fish 2:shoe 1:fish 2:shoe&quot;
    
   &gt; say [iter(red blue green,iter(fish shoe, [itext(1)]:[itext(0)]))]
   You say, &quot;red:fish red:shoe blue:fish blue:shoe green:fish green:shoe&quot;
   
-  See Also: iter(), inum(), ilev(), ibreak(), list()
+  See Also: iter(), inum(), ilev(), ibreak(), list(), %i, %d
   
 </PRE>
 <A HREF="#iter()">[PREV]</A>
@@ -20807,7 +26807,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#keepflags()">[NEXT]</A>
 <BR>
 <HR><A NAME="keepflags()"><H3>KEEPFLAGS()</H3></A><PRE>
-  Function: keepflags(&lt;list&gt;, [&amp;|]&lt;flag(s)&gt; [,&lt;delim&gt;[,&lt;output delim&gt;]])
+  Function: keepflags(&lt;list&gt;,[&amp;|]&lt;flag(s)&gt;[,&lt;delim&gt;[,&lt;output delim&gt;][,&lt;type&gt;]])
   
   The keepflags function keeps all dbref#'s in the given list that contains
   the flags specified.  You must use one of the operators for flag checks:
@@ -20816,6 +26816,8 @@ Generated: Wed Jan 13 04:15:48 2016
   
   This function returns the list of dbref#'s that correctly match up the
   flags you specified.
+  
+  You may specify a &lt;type&gt; of 1 to return values as objid's.
   
   Examples: (#1 is a wizard, nothing else is)
     &gt; say keepflags(#1 #2 #3 #4,&amp;W)
@@ -20836,7 +26838,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#keeptype()">[NEXT]</A>
 <BR>
 <HR><A NAME="keeptype()"><H3>KEEPTYPE()</H3></A><PRE>
-  Function: keeptype(&lt;string&gt;,&lt;type(s)&gt;[,&lt;delim&gt;[,&lt;output delim&gt;]])
+  Function: keeptype(&lt;string&gt;,&lt;type(s)&gt;[,&lt;delim&gt;[,&lt;output delim&gt;][,&lt;type&gt;]])
  
   The keeptype function KEEPS all types of 'type' from the string 'string'.
   The different types are standard MUSH object types:
@@ -20846,9 +26848,14 @@ Generated: Wed Jan 13 04:15:48 2016
       EXIT   - specifying exits
       OTHER  - specifying anything not fitting a MUSH 'type'.
   
-  You may specify optional seperators and output seperators.   You may specify
+  You may specify optional separators and output separators.   You may specify
   more than one type at once.
   
+  If you specify &lt;type&gt; as 1, the results are always returned as dbref#'s, 
+  otherwise the values are returned as the element in &lt;string&gt;.
+  
+  If you specify &lt;type&gt; as 2, the results are returned as objid's.
+    
   Examples: (#0 is a room, #1 #55 and #584 are players, #-1 is invalid (other))
     &gt; say keeptype(#0 #1 #55 #584 #-1,player)
     You say &quot;#1 #55 #584&quot;
@@ -20940,7 +26947,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Function: last(&lt;list&gt; [,&lt;delim&gt; [,&lt;key&gt;]])
   
   This function returns the last element in the list.  You may specify an 
-  optional seperator (delim), otherwise a default of a space is used.
+  optional separator (delim), otherwise a default of a space is used.
   
   &lt;delim&gt; may be used to specify a word delimiter other than a space.
   
@@ -21037,7 +27044,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say lattr(me/^..$,,,1)
     You say &quot;VA VB VC VE VV XX&quot;
  
-  See Also: @dolist, attrcnt(), vattrcnt(), cluster_lattr()
+  See Also: @dolist, attrcnt(), vattrcnt(), cluster_lattr(), lcmds()
   
 </PRE>
 <A HREF="#lattr()">[PREV]</A>
@@ -21068,7 +27075,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   This function returns the name of any command that exits on the
   object.  You may specify $-commands or ^-listens to search for.
-  The output seperator defaults at a space, but you may wish to
+  The output separator defaults at a space, but you may wish to
   specify a delimiter as commands may contain spaces.
   The following types exist:
     $ - list all commands on the target object.
@@ -21095,24 +27102,33 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#lcon()">[NEXT]</A>
 <BR>
 <HR><A NAME="lcon()"><H3>LCON()</H3></A><PRE>
-  Function: lcon(&lt;object&gt;[/switch] [,&lt;switch&gt;][,&lt;output seperator&gt;][,0|1)])
+  Function: lcon(&lt;obj&gt;[/swi] [[,&lt;swi&gt; [,&lt;sep&gt; [,&lt;name&gt; [,&lt;objid&gt; [,&lt;count&gt;]])
  
+  If you specify &lt;count&gt; with any argument, it returns the total number of
+  items instead of the list of items.  This option will work with all other
+  options.
+  
   Returns a space-separated list of the contents of &lt;object&gt;.
   It takes specific switches as an option:
-      /PLAYER  -- lists all TYPE players in the contents.
-      /OBJECT  -- lists all TYPE objects in the contents.
-      /CONNECT -- lists all connected players in the contents.
-      /PUPPET  -- lists all flag type 'PUPPET' in the contents.
-      /LISTEN  -- lists all listening things in the contents.
+      /PLAYER    -- lists all TYPE players in the contents.
+      /OBJECT    -- lists all TYPE objects in the contents.
+      /CONNECT   -- lists all connected players in the contents.
+      /PUPPET    -- lists all flag type 'PUPPET' in the contents.
+      /LISTEN    -- lists all listening things in the contents.
+      /CMDLISTEN -- lists all listening/command things in the contents.
+      /VISIBLE   -- lists only things visible (not-dark) as if looking.
   
   You may optionally specify the switch as the second argument, without 
   the '/' before it, to do the same thing.  This will cause any /switch
   you have in the first argument to assume it's part of the object name.
-  The function takes an output seperator as an optional third argument.
+  The function takes an output separator as an optional third argument.
 
-  If the optional last argument is set to 1, lcon will display the object
-  names instead of the #dbrefs.
-
+  If the optional &lt;name&gt; argument is set to '1', lcon will display the object
+  names instead of the #dbrefs.  This is not compatible with objid.
+  
+  If the optional &lt;objid&gt; argument is set to '1', lcon will display the
+  objid's in the list.
+  
   By default, Rhost returns '#-1' if lcon() returns no objects. If the
   config option mux_lcon_compat is set to '1', lcon() will return an empty
   string instead, for MUX compatibility.
@@ -21127,6 +27143,8 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;#223&quot;
     &gt; say lcon(me,puppet)
     You say &quot;#223&quot;
+    &gt; say lcon(me,puppet,,,1)
+    You say &quot;#223:8281828210&quot;
   
   See Also: lexits(), @dolist
   
@@ -21152,7 +27170,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#ldelete()">[NEXT]</A>
 <BR>
 <HR><A NAME="ldelete()"><H3>LDELETE()</H3></A><PRE>
-  Function: ldelete(&lt;list&gt;, &lt;pos&gt; [&lt;pos2&gt;...&lt;posN&gt;] [, &lt;sep&gt;])
+  Function: ldelete(&lt;list&gt;, &lt;pos&gt; [&lt;pos2&gt;..&lt;posN&gt;] [[,&lt;sep&gt;] [,&lt;osep&gt;]])
  
   This function removes a word from &lt;list&gt; by position.
   
@@ -21160,6 +27178,13 @@ Generated: Wed Jan 13 04:15:48 2016
   
   The &lt;pos&gt; fields may be negative to take the argument from the right
   instead of the left.
+  
+  You may specify a separate &lt;sep&gt; seperator or it assumes space if not
+  provided.  
+  
+  The &lt;osep&gt; output delimiter may be more than one character, and if 
+  enabled, '@@' can be used as another method for a null.  You may specify 
+  an empty &lt;osep&gt; as well.
    
   Examples:
     &gt; say ldelete(This is not a test, 3)
@@ -21216,12 +27241,19 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#left()">[NEXT]</A>
 <BR>
 <HR><A NAME="left()"><H3>LEFT()</H3></A><PRE>
-  Function: left(&lt;string&gt;, &lt;position&gt;)
-   (Alias): strtrunc(&lt;string&gt;,&lt;position&gt;)
+  Function: left(&lt;string&gt;, &lt;position&gt; [,&lt;key&gt;])
+   (Alias): strtrunc(&lt;string&gt;,&lt;position&gt; [,&lt;key&gt;])
   
   Left will take a string and return the left-most position of characters
   from the string.
   
+  You may specify a &lt;key&gt; of 1 to tell left() to take the string raw and
+  not do ansi-aware processing.  This will speed up the function.
+  The default is '0' which does ansi processing.
+  
+  Note: the config param 'ansi_default' handles if the ansi handling is 
+        configured default or not.  In which case the 'key' is reversed.
+   
   Example:
     &gt; say left(this is a test,5)
     You say &quot;this &quot;
@@ -21259,15 +27291,18 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#lexits()">[NEXT]</A>
 <BR>
 <HR><A NAME="lexits()"><H3>LEXITS()</H3></A><PRE>
-  Function: lexits(&lt;loc&gt;[,&lt;output seperator&gt;][,0|1)][&lt;key&gt;])
+  Function: lexits(&lt;loc&gt; [,&lt;output separator&gt;] [,&lt;name&gt;] [,&lt;key&gt;] [,&lt;objid&gt;])
  
   Returns a space-separated list of the exits in &lt;loc&gt; and its parents.
   Dark exits are not returned unless you own the location.
   Parented exits that are set PRIVATE will not be displayed.
-  The function takes an output seperator as an optional second argument.
+  The function takes an output separator as an optional second argument.
  
-  If the last optional argument is 1, lexits will display object names
-  instead of #dbrefs.
+  If the optional &lt;name&gt; argument is '1', lexits will display object names
+  instead of #dbrefs.  This is not compatible with &lt;objid&gt;.
+  
+  If the optional &lt;objid&gt; argument is '1', then lexits will display the
+  objid's instead of the dbref#'s.
   
   The following optional keys are available:
     0 - list all children of the target (default)
@@ -21281,9 +27316,11 @@ Generated: Wed Jan 13 04:15:48 2016
     The Town Square
     You are in the town square.  All around you .....
     Obvious exits:
-    foo  up  southeast  sw  north  
+    foo  up  southeast south
     &gt; say lexits(here)
-    You say &quot;#302 #10 #9 #8 #6&quot;
+    You say &quot;#302 #10 #9 #8&quot;
+    &gt; say lexits(here,,,,1)
+    You say &quot;#302:8185018282 #10:8919291929 #9:8959295828 #8:8582828281&quot;
   
   See Also: lcon(), @dolist, PARENT OBJECTS
   
@@ -21311,7 +27348,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say flags(me/desc)
     You say &quot;p&quot;
   
-  See Also: flags(), hasflag()
+  See Also: @set, @toggle, @totem, flags(), hasflag(), ltoggles(), ltotems()
   
 </PRE>
 <A HREF="#lexits()">[PREV]</A>
@@ -21387,7 +27424,11 @@ Generated: Wed Jan 13 04:15:48 2016
   
   aindex()      - Appends a string at a position in another string.
   aiindex()     - Similar to aindex(), but allows adding to an empty string.
+  andflag()     - Checks if a target has all the indicated flag letters.
   andflags()    - Checks if a target has all the indicated flags.
+  andtotem()    - Checks if a target has all the indicated totem letters.
+  andtotems()   - Checks if a target has all the indicated totems.
+  array()       - Break up a string into an array list of registers
   caplist()     - Performs a capstr() on a list of words.
   citer()       - Similar to iter(), but by character instead of word.
   delextract()  - Returns words specified that are not present in a list.
@@ -21405,6 +27446,7 @@ Generated: Wed Jan 13 04:15:48 2016
   iindex()      - Similar to index, but inserts &lt;string&gt; at &lt;position&gt;.
   ilev()        - Returns the level of recursion you are at in iter().
   index()       - Like extract(), but supports items being more than one word.
+  inf()         - Like iter() but allows special list args for Infinite vals.
   insert()      - Inserts a word into a list.
   inum()        - The equivalant of #@ inside an iter()
   iter()        - Iterates over a list, and processes code for each member.
@@ -21492,9 +27534,11 @@ Generated: Wed Jan 13 04:15:48 2016
   step()        - Steps through a list X elements at a time. 
   strfunc()     - Transforms a string of arguments to proper arguments.
   strmath()     - Applies math to a string.
+  totems()      - List totem letters on target.
   totmatch()    - Returns all matches of a pattern against a string.
   totmember()   - Returns all matches of a pattern against a list.
   totwildmatch()- Like wildmatch(), but returns every match.
+  trreverse()   - Like reverse() but transposes characters.
   while()       - Evaluates a list until a condition is reached.
   wildmatch()   - Matches a pattern against a string.
   
@@ -21506,7 +27550,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="list()"><H3>LIST()</H3></A><PRE>
   Function: list(&lt;list&gt;, &lt;eval&gt;[, &lt;delim&gt; ][, &lt;header&gt;][, &lt;target&gt;])
  
-  This function works just like iter() but returns each result on a seperate
+  This function works just like iter() but returns each result on a separate
   line thereby bypassing the buffer limit that RhostMUSH contains.  Each line
   will be a new line and will not be space delimited and will be displayed
   PRIOR to the output of the command calling it.
@@ -21555,7 +27599,7 @@ Generated: Wed Jan 13 04:15:48 2016
     2
     BB
     
-  See Also: nsiter(), citer(), @dolist, parse(), list()
+  See Also: nsiter(), citer(), @dolist, parse(), list(), inf()
   
 </PRE>
 <A HREF="#list()">[PREV]</A>
@@ -21563,15 +27607,20 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#listcommands()">[NEXT]</A>
 <BR>
 <HR><A NAME="listcommands()"><H3>LISTCOMMANDS()</H3></A><PRE>
-  Function: listcommands()
+  Function: listcommands([&lt;key&gt;])
   
   This function will return all the commands that you have access to.
+  
+  The available keys are:
+    0 - list all the main commands you have access to (default)
+    1 - list all the VATTR based commands you have access to
+    2 - list all VATTR based and main commands you have access to
   
   Example:
     &gt; say listcommands()
     You say &quot;@@ @alias ... &quot;
   
-  See Also: listfunctions(), listtoggles()
+  See Also: listfunctions(), listtoggles(), listflags(), listtotems()
   
 </PRE>
 <A HREF="#list2">[PREV]</A>
@@ -21660,7 +27709,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say listflags()
     You say &quot;ABODE(A) ARCHITECT(B) ... &quot; 
   
-  See Also: listcommands(), listfunctions()
+  See Also: listcommands(), listfunctions(), listtoggles(), listtotems()
   
 </PRE>
 <A HREF="#listening">[PREV]</A>
@@ -21671,16 +27720,20 @@ Generated: Wed Jan 13 04:15:48 2016
   Function: listfunctions([keyval])
   
   This function will return all the functions that you have access to.
-  Valid keyvalues are:
-    0 - List all functions (built-in and user-defined)  This is the default.
+  Valid keyvalues masks are:
+    0 - List all functions (built-in, user-defined, and local) this is default.
     1 - List only the built-in functions.
     2 - List only the user-defined functions.
+    4 - List only the local user-defined functions.
+  
+  These are bitwise masks.  So if you selected '3' it would do built-in and
+  user-defined.  '6' would do user-defined and local user-defined.
   
   Example:
     &gt; say listfunctions()
     You say &quot;@@ ABS ... &quot;
    
-  See Also: listcommands(), listtoggles()
+  See Also: listcommands(), listtoggles(), listflags(), listtotems()
   
 </PRE>
 <A HREF="#listflags()">[PREV]</A>
@@ -21714,13 +27767,16 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#listmatch()">[NEXT]</A>
 <BR>
 <HR><A NAME="listmatch()"><H3>LISTMATCH()</H3></A><PRE>
-  Function: listmatch(&lt;string&gt;, &lt;pattern&gt;[, &lt;delimiter&gt;])
+  Function: listmatch(&lt;string&gt;, &lt;pattern&gt;[, &lt;delimiter&gt; [,&lt;args&gt;]])
  
   The listmatch() function tries to match &lt;pattern&gt; against &lt;string&gt;. If it
   succeeds, it returns a list of the text that matched each wildcard (up to
   ten) in &lt;pattern&gt;. Normally, the list is space-separated, but if
   &lt;delimiter&gt; is specified, the list will be separated by that instead.
- 
+  
+  You may specify the optional &lt;args&gt; that you want to display in a space
+  delimited list.
+   
   If it fails, or &lt;pattern&gt; contains no wildcards, it returns an empty
   string.
  
@@ -21729,6 +27785,12 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;This is a &quot;
     &gt; say listmatch(hit the troll with the sword, hit * with *, /)
     You say &quot;the troll/the sword&quot;
+    &gt; say listmatch(hit the troll with the sword, hit * with *, /, 0 1)
+    You say &quot;the troll/the sword&quot;
+    &gt; say listmatch(hit the troll with the sword, hit * with *, /, 1)
+    You say &quot;the sword&quot;
+    &gt; say listmatch(hit the troll with the sword, hit * with *, /, 0)
+    You say &quot;the troll&quot;
     &gt; say listmatch(kow, wok)
     You say &quot;&quot;
   
@@ -21771,9 +27833,12 @@ Generated: Wed Jan 13 04:15:48 2016
     0 - list all protected names of the target player (default)
     1 - list only the protected names that are marked as aliases.
     2 - list only the protected names that are not marked as aliases.
+    3 - list protect names that are marked as aliases and the @alias.
+    4 - list only the @alias
   
   If the player is invalid, it returns an error, otherwise it returns an
-  empty string if nothing is found for that criteria.
+  empty string if nothing is found for that criteria.  If the key is outside
+  of the range, it uses the default.
   
   The default deliminator is a colon (:).
   
@@ -21791,14 +27856,14 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="listrlevels()"><H3>LISTRLEVELS()</H3></A><PRE>
   Function: listrlevels()
   
-  Returns all available levels in a space seperated list.  This function
+  Returns all available levels in a space separated list.  This function
   takes no arguments.
   
   Example:
     &gt; say listrlevels()
     You say &quot;Real Shadow Auf Umbra&quot;
   
-  See Also: txlevel(), rxlevel(), chkreality()
+  See Also: txlevel(), rxlevel(), chkreality(), rxdesc()
 
 </PRE>
 <A HREF="#listprotection()">[PREV]</A>
@@ -21830,10 +27895,39 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say listtoggles()
     You say &quot;VANILLA_ERRORS(V) ... &quot;
     
-  See Also: listcommands(), listfunctions()
+  See Also: listcommands(), listfunctions(), listtotems(), listflags()
   
 </PRE>
 <A HREF="#lists">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#listtotems()">[NEXT]</A>
+<BR>
+<HR><A NAME="listtotems()"><H3>LISTTOTEMS()</H3></A><PRE>
+  Function: listtotems([&lt;slot&gt;])
+  
+  This function will return all the totems that you have access to.  You may
+  specify an optional slot position for all totems assigned to that slot.
+  This is useful as there could potentially be tens of thousands of totems
+  defined.   By default there are 10 slots, but there could potentially be
+  hundreds.  Totem slots start at '0'.
+  
+  In the following example, we'll assume one and two are slot 0, and three is
+  assigned to slot 2.  In the example, no totems are assigned to slot 1.
+   
+  Examples:
+    &gt; say listtotems()
+    You say &quot;ONE(1) TWO([2]) THREE(3)&quot;
+    &gt; say listtotems(0) 
+    You say &quot;ONE(1) TWO([2])&quot;
+    &gt; say listtotems(2)
+    You say &quot;THREE(3)&quot;
+    &gt; say listtotems(1)
+    You say &quot;&quot;
+  
+  See Also: listcommands(), listfunctions(), listtoggles(), listflags()
+  
+</PRE>
+<A HREF="#listtoggles()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#listunion()">[NEXT]</A>
 <BR>
@@ -21858,7 +27952,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: listinter(), listdiff(), setunion()
 
 </PRE>
-<A HREF="#listtoggles()">[PREV]</A>
+<A HREF="#listtotems()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#lit()">[NEXT]</A>
 <BR>
@@ -21903,7 +27997,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say =[printf($:.:-5s,bar)]=      (the '-' specifies left justifies)
     You say &quot;=bar..=&quot;
   
-  See Also: ljc(), rjust(), rjc(), strlen(), printf(), wrap()
+  See Also: ljc(), rjust(), rjc(), strlen(), printf(), wrap(), template()
   
 </PRE>
 <A HREF="#lit()">[PREV]</A>
@@ -21926,7 +28020,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say -[ljc(this is foo,6)]-
     You say &quot;-this i-&quot;
    
-  See Also: ljust(), rjc(), rjust(), printf(), wrap()
+  See Also: ljust(), rjc(), rjust(), printf(), wrap(), template()
  
 </PRE>
 <A HREF="#lj()">[PREV]</A>
@@ -21958,7 +28052,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say =[printf($:.:-5s,bar)]=      (the '-' specifies left justifies)
     You say &quot;=bar..=&quot;
   
-  See Also: ljc(), rjust(), rjc(), strlen(), printf(), wrap()
+  See Also: ljc(), rjust(), rjc(), strlen(), printf(), wrap(), template()
   
 </PRE>
 <A HREF="#ljc()">[PREV]</A>
@@ -22107,7 +28201,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#lnum()">[NEXT]</A>
 <BR>
 <HR><A NAME="lnum()"><H3>LNUM()</H3></A><PRE>
-  Function: lnum(&lt;number&gt;[,&lt;number&gt;,&lt;seperator&gt;,&lt;stepping&gt;])
+  Function: lnum(&lt;number&gt;[,&lt;number&gt;,&lt;separator&gt;,&lt;stepping&gt;])
  
   Returns a list of numbers from 0 to &lt;number&gt;-1.
   If a second number is specified it tells to use
@@ -22166,10 +28260,12 @@ Generated: Wed Jan 13 04:15:48 2016
   Function: loc(&lt;object&gt;)
  
   Returns the number of the location where &lt;object&gt; is.  You must either
-  control the object or be nearby for it to work.  When used on an exit it
-  returns the destination of the exit.  You can also use loc() to find the
-  location of players that are not set UNFINDABLE.
- 
+  control the object or be nearby for it to work.  You can also use loc() 
+  to find the location of players that are not set UNFINDABLE (or DARK).
+  
+  When used on an exit it returns the *destination* of the exit, not the
+  location. Use the home() function on exits to find their location.
+  
   Example:
     &gt; look
     Mortal's Room(#367R)
@@ -22187,7 +28283,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say loc(here)
     You say &quot;#367&quot;
   
-  See Also: rloc(), room(), where()
+  See Also: rloc(), room(), where(), home(), EXITS
   
 </PRE>
 <A HREF="#lnum2()">[PREV]</A>
@@ -22241,7 +28337,8 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Note: In the last example, we allowed '12345' to be localized, but not '0'.
   
-  See Also: pushregs(), ulocal(), zfunlocal(), eval(), privatize(), @lfunction
+  See Also: pushregs(), ulocal(), zfunlocal(), eval(), privatize(), 
+            sandbox(), subeval(), @lfunction
   
 </PRE>
 <A HREF="#localfunc()">[PREV]</A>
@@ -22266,6 +28363,7 @@ Generated: Wed Jan 13 04:15:48 2016
     *    - Look for everything in the above list.
   
 { 'help locate2' for more }
+
 </PRE>
 <A HREF="#localize()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -22294,6 +28392,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You have 42463 clams.
   
 { 'help locate3' for more }
+
 </PRE>
 <A HREF="#locate()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -22320,7 +28419,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say locate(me,here,*)
     You say &quot;#250&quot;
   
-  See Also: num(), PARENT OBJECTS
+  See Also: num(), PARENT OBJECTS, objid()
   
 </PRE>
 <A HREF="#locate2">[PREV]</A>
@@ -22353,7 +28452,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say lock(me,yes,va)
     You say &quot;Attribute locked.&quot;
   
-  See Also: @lock, elock(), lockencode(), lockdecode(), lockcheck()
+  See Also: @lock, elock(), lockencode(), lockdecode(), lockcheck(),
+            testlock()
   
 </PRE>
 <A HREF="#locate3">[PREV]</A>
@@ -22363,13 +28463,21 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="lockcheck()"><H3>lockcheck()</H3></A><PRE>
   Function: lockencode(&lt;string&gt;)
             lockdecode(&lt;string&gt;)
-            lockcheck(&lt;string&gt;,&lt;target&gt;)
+            lockcheck(&lt;string&gt;, &lt;target&gt; [&lt;type&gt;])
   
   lockencode() returns an encoded string of a boolean lock evaluation.
    
   lockdecode() returns the decoded string of the encoded boolean.
   
   lockcheck() returns boolean true(1)/false(0) based on the encoded boolean.
+  
+  The optional &lt;type&gt; to lockcheck() is used for specialist lock values like
+  USELOCK where based on how the eval lock works it will pass.  You do not
+  have to specify a type, but locks that check for it should be used.
+  Types allowed are as follows:
+    0 - default lock.  Neither a $command nor a ^listen
+    1 - $command lock
+    2 - ^listen lock
   
   This is the same value (though encoded) that would be set when you issue
   a @Lock on something.  This is useful if you wish to enbed lock values
@@ -22389,7 +28497,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say lockcheck(KCMxMjM0KSYoIzkwMSk=,*Guest)
     You say &quot;0&quot;
   
-  See Also: lockdecode(), lockdecode(), lockcheck(), lock(), elock(), @lock
+  See Also: testlock(), lockdecode(), lockdecode(), lockcheck(), lock(), 
+            elock(), @lock
 
 </PRE>
 <A HREF="#lock()">[PREV]</A>
@@ -22399,13 +28508,21 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="lockdecode()"><H3>lockdecode()</H3></A><PRE>
   Function: lockencode(&lt;string&gt;)
             lockdecode(&lt;string&gt;)
-            lockcheck(&lt;string&gt;,&lt;target&gt;)
+            lockcheck(&lt;string&gt;, &lt;target&gt; [&lt;type&gt;])
   
   lockencode() returns an encoded string of a boolean lock evaluation.
    
   lockdecode() returns the decoded string of the encoded boolean.
   
   lockcheck() returns boolean true(1)/false(0) based on the encoded boolean.
+  
+  The optional &lt;type&gt; to lockcheck() is used for specialist lock values like
+  USELOCK where based on how the eval lock works it will pass.  You do not
+  have to specify a type, but locks that check for it should be used.
+  Types allowed are as follows:
+    0 - default lock.  Neither a $command nor a ^listen
+    1 - $command lock
+    2 - ^listen lock
   
   This is the same value (though encoded) that would be set when you issue
   a @Lock on something.  This is useful if you wish to enbed lock values
@@ -22425,7 +28542,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say lockcheck(KCMxMjM0KSYoIzkwMSk=,*Guest)
     You say &quot;0&quot;
   
-  See Also: lockdecode(), lockdecode(), lockcheck(), lock(), elock(), @lock
+  See Also: testlock(), lockdecode(), lockdecode(), lockcheck(), lock(), 
+            elock(), @lock
 
 </PRE>
 <A HREF="#lockcheck()">[PREV]</A>
@@ -22435,13 +28553,21 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="lockencode()"><H3>lockencode()</H3></A><PRE>
   Function: lockencode(&lt;string&gt;)
             lockdecode(&lt;string&gt;)
-            lockcheck(&lt;string&gt;,&lt;target&gt;)
+            lockcheck(&lt;string&gt;, &lt;target&gt; [&lt;type&gt;])
   
   lockencode() returns an encoded string of a boolean lock evaluation.
    
   lockdecode() returns the decoded string of the encoded boolean.
   
   lockcheck() returns boolean true(1)/false(0) based on the encoded boolean.
+  
+  The optional &lt;type&gt; to lockcheck() is used for specialist lock values like
+  USELOCK where based on how the eval lock works it will pass.  You do not
+  have to specify a type, but locks that check for it should be used.
+  Types allowed are as follows:
+    0 - default lock.  Neither a $command nor a ^listen
+    1 - $command lock
+    2 - ^listen lock
   
   This is the same value (though encoded) that would be set when you issue
   a @Lock on something.  This is useful if you wish to enbed lock values
@@ -22461,10 +28587,47 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say lockcheck(KCMxMjM0KSYoIzkwMSk=,*Guest)
     You say &quot;0&quot;
   
-  See Also: lockdecode(), lockdecode(), lockcheck(), lock(), elock(), @lock
+  See Also: testlock(), lockdecode(), lockdecode(), lockcheck(), lock(), 
+            elock(), @lock
 
 </PRE>
 <A HREF="#lockdecode()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#locks">[NEXT]</A>
+<BR>
+<HR><A NAME="locks"><H3>locks</H3></A><PRE>
+  Command: @lock[/&lt;whichlock&gt;] &lt;object&gt;=&lt;key&gt;
+           @lock &lt;object&gt;/&lt;attrib&gt;
+   
+  The first form locks &lt;object&gt; to a specific key(s).  Type 'help @lock keys'
+  for a list of the keys you may use.
+   
+  &lt;whichlock&gt; indicates which lock you want to set on the object.  If you
+  don't specify one, you set the Default lock. Type 'help @lock locks' for
+  a list of the locks you may set and what they are used for.
+   
+  The second form locks the indicated attribute of the named object, so that
+  when the object is @chowned, the attribute will remain owned by you.
+  It may also be used when you own an attribute on an object that you do not
+  own, in this case it prevents the object's owner from @chowning the
+  attribute to himself, and prevents anyone from modifying or removing the
+  attribute.  The following sub-topics exist:
+   
+         help mail lock   - help on how to set a mail lock.
+         help @lock keys  - list of valid keys you can use in @locking.
+         help @lock locks - list of available locks you can @lock.
+         help @lock type &lt;lock&gt; - give detailed help on the specific lock.
+         help userlocks   - a special way to define user-defined locking.
+  
+  Note: For evaluation locks, %0 is passed as a boolean (0/1) on if the lock
+        is a $command match or a ^listen match.  %1 will be passed as the
+        *unevaluated* conditional that the eval lock is matching against.
+  
+  See Also: @unlock, @lset, @chown, lock(), elock(), testlock(), 
+            lockencode(), lockdecode(), lockcheck()
+  
+</PRE>
+<A HREF="#lockencode()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#log()">[NEXT]</A>
 <BR>
@@ -22490,7 +28653,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: e(), exp(), ln(), power(), power10()
   
 </PRE>
-<A HREF="#lockencode()">[PREV]</A>
+<A HREF="#locks">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#logarithmic functions">[NEXT]</A>
 <BR>
@@ -22630,20 +28793,33 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#lparent()">[NEXT]</A>
 <BR>
 <HR><A NAME="lparent()"><H3>LPARENT()</H3></A><PRE>
-  Function: lparent(&lt;obj&gt;)
+  Function: parents(&lt;obj&gt; [,&lt;objid&gt;])
   
   Returns all the parents of &lt;obj&gt;.  Returns #-1 if &lt;obj&gt; cannot be found
   or has no parent or if you do not own and/or control &lt;obj&gt;
   
+  If the optional &lt;objid&gt; is specified as '1', then it returns the objid's 
+  instead of the dbref#'s.
+  
+  By default, if you can not examine any of the parents in the chain, then
+  it will not show you the parent of that chain. 
+ 
+  If the @admin parameter 'parent_follow' is enabled, which is the default,
+  then if you control the &lt;obj&gt; you will see the entire parent chain,
+  regardless of your control or examine permissions of those parents in 
+  the chain.  We felt this should be the proper default behavior.
+  
   Example:
-    &gt; say lparent(me)
+    &gt; say parents(me)
     You say &quot;#-1&quot;
     &gt; @parent #4=#5
     Parent set.
     &gt; @parent #5=#6
     Parent set.
-    &gt; say lparent(#4)
+    &gt; say parents(#4)
     You say &quot;#5 #6&quot;
+    &gt; say parents(#4,1)
+    You say &quot;#5:8185828582 #6:8281859282&quot;
   
   See Also: parent(), children()
   
@@ -22657,7 +28833,7 @@ Generated: Wed Jan 13 04:15:48 2016
    
   This function returns a total of '&lt;count&gt;' elements between the
   numbers '&lt;lower&gt;' and '&lt;upper&gt;'.  It may also choose the lower and
-  upper numbers for the list it generates.  If no output seperator
+  upper numbers for the list it generates.  If no output separator
   (output delim) is specified, a space is used by default.
    
   Example:
@@ -22697,7 +28873,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#lrooms()">[NEXT]</A>
 <BR>
 <HR><A NAME="lrooms()"><H3>lrooms()</H3></A><PRE>
-  Function: lrooms(&lt;loc&gt; [,&lt;iteration&gt; [,&lt;type&gt;]])
+  Function: lrooms(&lt;loc&gt; [,&lt;iteration&gt; [,&lt;type&gt;] [,&lt;objid&gt;]])
   
   This function returns from 1 to MAXIMUM level of iterations of rooms
   connected to the target &lt;loc&gt; room.  The MAXIMUM level is hypothetically
@@ -22714,6 +28890,9 @@ Generated: Wed Jan 13 04:15:48 2016
   that type '0' is not always guaranteed to be absolutely accurate as rooms 
   could be linked differently based on the order it's checked.
   
+  If you specify &lt;objid&gt; as '1', then it returns the objid's instead of
+  the dbref#'s.
+   
   Examples:
     &gt; say lrooms(here,1)
     You say &quot;#191 #101&quot;
@@ -22723,11 +28902,55 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;#191 #101 #19 #0 #1012 #10102&quot;
     &gt; say lrooms(here,2,0)
     You say &quot;#19 #0 #1012 #10102&quot;
+    &gt; say lrooms(here,,,1)
+    You say &quot;#191:8182858282 #101:8285928582&quot;
   
   See Also: room(), lexits()
   
 </PRE>
 <A HREF="#lreplace()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#lset()">[NEXT]</A>
+<BR>
+<HR><A NAME="lset()"><H3>LSET()</H3></A><PRE>
+  Function: lset(&lt;object&gt;[/&lt;lock&gt;] [,[!]&lt;flag&gt;])
+            lset(&lt;object&gt;[/&lt;lock&gt;])
+  
+  The lset() function is used to set specialized permissions on locks.  If you
+  do not specify a lock, it will default to 'DefaultLock' which is aliased to 
+  'BasicLock' for backward compatibility with other codebases.  If you do not
+  specify a lock, it will display the current flags on the specified target
+  lock.
+  
+  You may specify the '!' option to remove a specialist lock.
+  
+  Please see help on '@lset' for what specialized locks that you may set.
+  You can only set the flags which you have permission to.
+  
+  This function returns an empty value and notifies the player as if they 
+  ran the @lset command.
+  
+  Examples:
+    &gt; say lset(me,no_inherit)
+    @lset: [DefaultLock] set NO_INHERIT on Ashen-Shugar(#1234)
+    You say &quot;&quot;
+    &gt; say lset(me)
+    @lset: [DefaultLock] on Player(#123): no_inherit
+    You say &quot;&quot;
+    &gt; say lset(me/basic)
+    @lset: [DefaultLock] on Player(#123): no_inherit
+    You say &quot;&quot;
+    &gt; say lset(me/default)
+    @lset: [DefaultLock] on Player(#123): no_inherit
+    You say &quot;&quot;
+    &gt; say lset(me/fubar)
+    #-1 LOCK NOT FOUND
+    You say &quot;&quot;
+  
+  See Also: @lset, @set, set()
+
+</PRE>
+<A HREF="#lrooms()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#lsub()">[NEXT]</A>
 <BR>
@@ -22746,18 +28969,20 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: lavg(), ldiv(), lmul(), lmax(), lmin(), ladd()
   
 </PRE>
-<A HREF="#lrooms()">[PREV]</A>
+<A HREF="#lset()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#lt()">[NEXT]</A>
 <BR>
 <HR><A NAME="lt()"><H3>lt()</H3></A><PRE>
-  Function: lt(&lt;integer1&gt;,&lt;integer2&gt;)
- 
-  Takes two integers, and returns 1 if and only if &lt;integer1&gt; is less than
-  &lt;integer2&gt;, and 0 otherwise.  Warning: passing anything but integers will
-  produce unexpected results, as non-numeric strings usually are treated
-  as numeric 0.
- 
+  Function: lt(&lt;integer1&gt;, &lt;integer2&gt; [,&lt;integer3&gt;,...])
+   
+  Takes two (or more) integers, and returns 1 if and only if &lt;integer1&gt; is 
+  less than &lt;integer2&gt; (which is less than &lt;integer3&gt; and so forth), and 0 
+  otherwise.  This function handles floating point numbers as well.
+  
+  Warning: passing anything but integers will produce unexpected results, 
+  as non-numeric strings usually are treated as numeric 0.  
+   
   Example:
     &gt; say lt(4,5)
     You say &quot;1&quot;
@@ -22766,6 +28991,10 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say lt(6,5)
     You say &quot;0&quot;
     &gt; say lt(foo, bar)
+    You say &quot;0&quot;
+   &gt; say lt(1,2,3,4,5)
+    You say &quot;1&quot;
+   &gt; say lt(1,2,3,4,5,3)
     You say &quot;0&quot;
   
   See Also: lte(), gte(), gt(), eq(), neq()
@@ -22776,13 +29005,16 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#lte()">[NEXT]</A>
 <BR>
 <HR><A NAME="lte()"><H3>lte()</H3></A><PRE>
-  Function: lte(&lt;integer1&gt;,&lt;integer2&gt;)
- 
-  Takes two integers, and returns 1 if and only if &lt;integer1&gt; is less than 
-  or equal to &lt;integer2&gt;, and 0 otherwise.  Warning: passing anything but 
-  integers will produce unexpected results, as non-numeric strings usually 
-  are treated as numeric 0.
- 
+  Function: lte(&lt;integer1&gt;, &lt;integer2&gt; [,&lt;integer3&gt;,...])
+   
+  Takes two (or more) integers, and returns 1 if and only if &lt;integer1&gt; is 
+  less than or equal to &lt;integer2&gt; (which is less than or equal &lt;integer3&gt;
+  and so forth), and 0 otherwise.  This function handles floating point
+  numbers as well.
+  
+  Warning: passing anything but integers will produce unexpected results, 
+  as non-numeric strings usually are treated as numeric 0.
+   
   Example:
     &gt; say lte(4,5)
     You say &quot;1&quot;
@@ -22792,6 +29024,10 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;0&quot;
     &gt; say lte(foo, bar)
     You say &quot;1&quot;
+   &gt; say lte(1,2,3,4,5)
+    You say &quot;1&quot;
+   &gt; say lte(1,2,3,4,5,3)
+    You say &quot;0&quot;
   
   See Also: lt(), gte(), gt(), eq(), neq()
   
@@ -22812,19 +29048,43 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say ltoggles(#1)
     You say &quot;#-1&quot;
   
-  See Also: @toggle
+  See Also: @toggle, @set, @totem, lflags(), ltotems()
   
 </PRE>
 <A HREF="#lte()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#ltotems()">[NEXT]</A>
+<BR>
+<HR><A NAME="ltotems()"><H3>LTOTEMS()</H3></A><PRE>
+  Function: ltotems(&lt;player&gt;)
+  
+  Returns all the totems that the target player has.  This will only list
+  totems that you have access to be able to see.
+  
+  Examples:
+    &gt; say ltotems(me)
+    You say &quot;TOTEM1 TOTEM2 TOTEM3&quot;
+    &gt; say ltotems(#-1)
+    You say &quot;#-1&quot;
+  
+  See Also: @set, @toggle, lflags(), ltoggles()
+
+</PRE>
+<A HREF="#ltoggles()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#lwho()">[NEXT]</A>
 <BR>
 <HR><A NAME="lwho()"><H3>LWHO()</H3></A><PRE>
-  Function: lwho([[&lt;value&gt;], [&lt;target&gt;]])
+  Function: lwho([[&lt;value&gt;], [&lt;target&gt;], [&lt;isobjid&gt;]])
   Returns a list of the db numbers of connected players.  This returns what
   a 'WHO' or 'DOING' would return.  This takes an optional type value.
   '0' is the default, and '1' returns the player list in the form dbref:port.
-  '2' will return just the ports.
+  '2' will return just the ports.  
+  
+  You may specify &lt;isobjid&gt; as '1' if you wish to have the arguments returned
+  as object-id's.  Note, that since objid's return break values with a ':',
+  if you specify the port &lt;value&gt; it uses '|' instead to separate the argument
+  from the port.
   
   Note: You can only see your own port(s) unless you're a wizard.  Any other
         port will return '-1'.
@@ -22845,11 +29105,15 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;#226 #271 #1&quot;
     &gt; say lwho(1)
     You say &quot;#226:20 #271:5 #1:6&quot;
+    &gt; say lwho(,,1)
+    You say &quot;#226:662752801 #271:662992921 #1:662728521&quot;
+    &gt; say lwho(1,,1)
+    You say &quot;#226:662752801|20 #271:662992921|5 #1:662728521|6&quot;
   
   See Also: WHO, DOING, conn(), idle()
  
 </PRE>
-<A HREF="#ltoggles()">[PREV]</A>
+<A HREF="#ltotems()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#lxnor()">[NEXT]</A>
 <BR>
@@ -22894,13 +29158,17 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#lzone()">[NEXT]</A>
 <BR>
 <HR><A NAME="lzone()"><H3>LZONE()</H3></A><PRE>
-  Function: lzone(&lt;object&gt; [,&lt;key&gt;])
+  Function: lzone(&lt;object&gt; [,&lt;key&gt;] [,&lt;objid&gt;])
+  
   Returns the zone list for an object. If the object is a zonemaster,
   the list contains the objects within the zone controlled by the 
   zonemaster. If the object is not a zonemaster, the list contains
   all of the zonemasters that the object belongs to.  This is _not_
   database intensive.
   
+  You may optionally specify &lt;objid&gt; as '1' to return the objid's 
+  of the target instead of the dbref#'s.
+   
   The following optional keys are available:
     0 - list all zones (or zonemasters) of the target (default)
     n - List 'n'th 400 zones (or zonesmasters) of the target. 
@@ -22915,10 +29183,12 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; @zone here=#534
     &gt; say lzone(here)         
     You say &quot;#0 #534&quot;
+    &gt; say lzone(here,,1)         
+    You say &quot;#0:8185828502 #534:8258128282&quot;
     &gt; say lzone(here,l)
     You say &quot;1 2&quot;
  
-  See Also: @zone, ZONES, inzone(), zwho()
+  See Also: @zone, ZONES, inzone(), zwho(), zonecmd()
  
 </PRE>
 <A HREF="#lxor()">[PREV]</A>
@@ -22929,9 +29199,22 @@ Generated: Wed Jan 13 04:15:48 2016
   Command: mail [@]&lt;player-list&gt;=&lt;subject&gt; (with BRANDY_MAIL toggle)
            mail [@]&lt;player-list&gt;=[&lt;subj&gt;/]&lt;body&gt; (with PENN_MAIL toggle)
            mail [@]&lt;player-list&gt;=[&lt;subj&gt;//]&lt;body&gt; (with no toggle)
-           mail [&lt;mesg#&gt;|new|unread|nall|uall|ball]
+           mail [&lt;mesg#&gt;|new|unread|nall|uall|ball|1-N]
   
-  'HELP MAIL MAIN' for main index.    'HELP MAIL TOPICS' for topical help.
+   ---- For the main mail help file please see:  HELP MAIL MAIN ----
+  
+   Note: For folder help please type 'help folder'
+  
+   Important topics:
+      'HELP MAIL MAIN' for main index.    -- this is very helpful
+      'HELP MAIL TOPICS' for topical help.
+  
+   Important initial help entries:
+      'HELP MAIL CMDLIST' for the mail command listing and descriptions
+      'HELP FOLDER CMDLIST' for the folder command listing and descriptions
+      'HELP MAIL DTUTOR' for a quick tutorial on how to use mail
+      'HELP MAIL BTUTOR' for a quick tutorial on the mail editor (optional)
+      'HELP MAIL PTUTOR' for a quick tutorial on Penn @mail syntax (optional)
   
   If you are used to the MUX standard of @mail or the softcoded BrandyMail
   you will want to use the BRANDY_MAIL toggle.  
@@ -22940,7 +29223,7 @@ Generated: Wed Jan 13 04:15:48 2016
   the PENN_MAIL toggle.  The BRANDY_MAIL toggle will take presidence.
   
   For using the line editor, you may use the MAIL_STRIPRETURN toggle.  This
-  will convert the carrage return between lines to a space when combining.
+  will convert the carriage return between lines to a space when combining.
    
   To set a toggle, you would type: @toggle me=&lt;toggle&gt;.  An example would be:
                         @toggle me=BRANDY_MAIL
@@ -22951,10 +29234,26 @@ Generated: Wed Jan 13 04:15:48 2016
     Mail: Message sent to -&gt; &lt;your name&gt;
     Mail: Done
   
-  See Also: mail main, mail topics
+  See Also: mail main, mail topics, folder
   
 </PRE>
 <A HREF="#lzone()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail PLUSall">[NEXT]</A>
+<BR>
+<HR><A NAME="mail PLUSall"><H3>mail +all</H3></A><PRE>
+  This is a sub-option to 'mail/read' (short for just 'mail').  If you
+  specify '+all' at the end, it will read every message that you have
+  in your mailbox.  Warning:  This can be spammy.
+  
+  Example:
+    &gt; mail/read +all
+    &gt; mail +all
+  
+  See Also: mail uall, mail nall, mail new, mail unread, mail ball
+  
+</PRE>
+<A HREF="#mail">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mail alias">[NEXT]</A>
 <BR>
@@ -22971,7 +29270,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Wizards: wizhelp wmail alias
   
 </PRE>
-<A HREF="#mail">[PREV]</A>
+<A HREF="#mail PLUSall">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mail anonymous">[NEXT]</A>
 <BR>
@@ -22998,6 +29297,33 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#mail alias">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#mail attributes">[NEXT]</A>
+<BR>
+<HR><A NAME="mail attributes"><H3>mail attributes</H3></A><PRE>
+  Topic: MAIL ATTRIBUTES
+  
+  The following attributes have special meaning in the mail system.
+    @mailsig     -- The signature that is assigned to any mail sent.
+    &amp;mailfilter  -- This is evaluated to auto-filter what folder mail goes to.
+    &amp;mailnotify  -- This is evaluated to auto-send notification to senders.
+    @mailtime    -- (Wizard only) Sets the auto-delete time on a player.
+    @mailsmax    -- (Wizard only) Sets the maximum saved messages on a player.
+    MailLock     -- (Internal) This is the lock mail/lock sets
+  
+  The following wildcard patterns are used for mail:
+    mail &amp;foo=text    -- This will check your personal FOO attribute for
+                         the player list you want to send to.
+                         This is non-evaluated.
+    mail ~foo=text    -- This will check your personal FOO attribute for
+                         the player list you want to send to.
+                         This is evaluated.
+  
+  See Also: @mailsig, &amp;mailfilter, &amp;mailnotify, mail lock, mail setup_aliases
+  For wizards, wizhelp: @mailsmax, @mailtime
+
+</PRE>
+<A HREF="#mail anonymous">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#mail autofor">[NEXT]</A>
 <BR>
 <HR><A NAME="mail autofor"><H3>mail autofor</H3></A><PRE>
@@ -23005,9 +29331,9 @@ Generated: Wed Jan 13 04:15:48 2016
            mail/autofor +off
   
   Autoforwarding is used to autoforward mail that you would normally get
-  to another player character.  This is handy in the event that you have
-  multiple characters and wish to have mail all catagorized to a central
-  character.  All forwarded mail is sent as from the original sender, 
+  to another player.  This is handy in the event that you have
+  multiple players and wish to have mail all catagorized to a central
+  player.  All forwarded mail is sent as from the original sender, 
   not from the player it was forwarded from.
   
   Autoforwarding can only be forwarded on a one-time basis.  It is not
@@ -23022,7 +29348,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: mail lock, mail share
   
 </PRE>
-<A HREF="#mail anonymous">[PREV]</A>
+<A HREF="#mail attributes">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mail autopurges">[NEXT]</A>
 <BR>
@@ -23152,6 +29478,10 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="mail btutor"><H3>mail btutor</H3></A><PRE>
   Topic: mail btutor (Enhanced Line Editor (Brandy) Interface)
   
+  Note: Some RhostMUSH's will have a bunch of @mail aliases to mimic
+        the MUX/TM3 (and in some cases the +mail) interfaces.  If
+        so please refer to these help files.
+  
   Welcome to the mail system tutorial (brandy interface).  This will
   not cover all the commands, but will give you a good heads up on
   how to use the mail interface if you come from a MUX background
@@ -23248,7 +29578,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#mail cmdlist">[NEXT]</A>
 <BR>
 <HR><A NAME="mail cmdlist"><H3>mail cmdlist</H3></A><PRE>
-  Topic: mail command list of commands (in alphabetical order)
+  Topic: mail command list of commands (in alphabetical order) [1/3]
   
   mail                       - This is short for 'mail/quick'
   mail/alias                 - This lists all global mail aliases.
@@ -23276,7 +29606,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#mail cmdlist2">[NEXT]</A>
 <BR>
 <HR><A NAME="mail cmdlist2"><H3>mail cmdlist2</H3></A><PRE>
-  Topic: mail quicklist of commands (CONTINUED)
+  Topic: mail quicklist of commands (CONTINUED) [2/3]
   
   mail/number &lt;target&gt;[=&lt;arg&gt;] - This displays the target player's mail.  You
                                must pass that person's sharelock before you
@@ -23305,7 +29635,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#mail cmdlist3">[NEXT]</A>
 <BR>
 <HR><A NAME="mail cmdlist3"><H3>mail cmdlist3</H3></A><PRE>
-  Topic: mail quicklist of commands (CONTINUED)
+  Topic: mail quicklist of commands (CONTINUED) [3/3]
   
   mail[/send] [&lt;arg&gt;]&lt;player-list&gt;=[&lt;subject&gt;//]&lt;body&gt; - This sends mail to
                                the targeted player(s).  The /send switch is
@@ -23611,7 +29941,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="mail dtutor6"><H3>mail dtutor6</H3></A><PRE>
   Topic: Mail Default Tutor (Page 6)
   
-  Ok, let's say you just wanted to send the player a message seperate from
+  Ok, let's say you just wanted to send the player a message separate from
   a reply.  You may send mail one of two ways.  You can send it the quick
   and easy method (which will be shown here), or you may use the built-in
   line editor (which is full of features).  If you prefer to use the
@@ -23873,7 +30203,7 @@ Generated: Wed Jan 13 04:15:48 2016
       mail massmail          mail credits            mail send examples
       mail line examples     mail write examples     mail signature
       mail cmdlist           mail technical          mail tutorial
-      mail quicklist         mail setup_aliases
+      mail quicklist         mail setup_aliases      mail attributes
   
   help on options can be seen by using the help command with any topic.
   
@@ -23926,7 +30256,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Topic: mail mass mailing
   
   Massmailing is done by using the optional /SEND feature of the mail
-  system.  The syntax is as follows:
+  system.  You may use commas as the delimiter.  The syntax is as follows:
   
   mail[/send] usr1 usr2 .. +&lt;gls&gt; $&lt;gev&gt; &amp;&lt;pls&gt; ~&lt;eval&gt; = [subject//]message
   
@@ -24099,21 +30429,50 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#mail password">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#mail ptutor">[NEXT]</A>
+<BR>
+<HR><A NAME="mail ptutor"><H3>mail ptutor</H3></A><PRE>
+  Topic: mail ptutor (Penn format handler)
+  
+  Honestly, there's little that this interface changes from the
+  default mail handler.  The important things are as follows:
+  
+  - This requires the PENN_MAIL @toggle to be set on the player
+    (@set me=penn_mail)
+  - This will change the format of sending mail from the default
+    of:
+                 mail player(s)=subject//body
+    to:
+                 mail player(s)=subject/body
+  
+    Yes, it only removes the extra / in sending.
+  
+  For all the other Penn-mail syntax, please check your RhostMUSH for
+  a @mail compatible wrapper package (available with all RhostMUSHs)
+  
+  See Also: penn_mail
+  
+</PRE>
+<A HREF="#mail previous">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#mail quick">[NEXT]</A>
 <BR>
 <HR><A NAME="mail quick"><H3>mail quick</H3></A><PRE>
-  Command: mail/quick
+  Command: mail/quick [&lt;folder&gt;]
  
   Get a quick summary of how many new, unread, old, and marked messages
   in the current folder.  Also reports the current folder.
   
+  You may specify an optional folder to get quick a quick summary of that
+  particular mail folder.
+  
   The /quick switch is optional for this command and you can just type 'mail'
-  standalone.
+  standalone.  The /quick switch is required if you specify a folder.
   
   See Also: mail status, mail
   
 </PRE>
-<A HREF="#mail previous">[PREV]</A>
+<A HREF="#mail ptutor">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mail quicklist">[NEXT]</A>
 <BR>
@@ -24166,17 +30525,29 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#mail read">[NEXT]</A>
 <BR>
 <HR><A NAME="mail read"><H3>mail read</H3></A><PRE>
-  Command: mail[/read] &lt;msg #|new|unread&gt;
+  Command: mail[/read] &lt;msg #|new|unread|nall|uall|ball|1-N&gt;
+           mail/read/save &lt;msg #|new|unread|nall|uall|ball|1-N&gt;
   
   Read a mail message.  You can specify the message number, or to read the 
   first new or unread mail message.  Check help on the status sub-command 
   (wizhelp mail status)for information on how to see mail headers.  The /READ
-  switch is optional.  Optional arguments to 'mail/read' is as follows:
+  switch is optional.  
+  
+  The optional /save switch when used in junction with the /read switch will
+  output the mail in a standard EMail format (MBOX) which you can then save to 
+  file and load in your favorite email program (mutt, pine, elm, outlook,
+  thunderbird, and so forth).  You would just import the file as an MBOX
+  formatted file.  Please refer to your mail program on how to read in this
+  mail format.
+  
+  Optional arguments to 'mail/read[/save]' is as follows:
+      mail[/read] +all   - read ALL your messages (spammy)
       mail[/read] new    - read first new message
       mail[/read] nall   - read ALL new messages
       mail[/read] unread - read first unread message
       mail[/read] uall   - read ALL unread messages
       mail[/read] ball   - read ALL new AND unread messages
+      mail[/read] X-Y    - read messages starting at 'X' and until 'Y'
       mail[/read] #      - read specified mail message number
  
   Examples:
@@ -24185,6 +30556,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; mail/read new
     &gt; mail new
     &gt; mail/read unread
+    &gt; mail/read 3-7
+    &gt; mail 2-8
     &gt; mail unread
   
   See Also: mail status, mail delete, mail mark, mail next, mail zap,
@@ -24358,51 +30731,6 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#mail reply">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
-<A HREF="#mail send">[NEXT]</A>
-<BR>
-<HR><A NAME="mail send"><H3>mail send</H3></A><PRE>
-  Topic: mail sending
-  
-  There are three ways that you can send mail with the mail system.  Depending 
-  on which way you prefer, this will point you to the correct help files.
-  
-  1.  Brandy/Mux style mail.  This is when you do 'mail user-list=subject'
-      Look at  :  'help mail send brandy' and 'help mail write cmdlist'
-      Needed   :  The BRANDY_MAIL toggle (help brandy_mail) 
-                  **NOTE**: @toggle me=brandy_mail to set it.
-      Syntax   :  mail user(s)=subject
-                  mail/reply &lt;msg#&gt;=subject
-                  mail/forward &lt;msg#&gt; &lt;user(s)&gt;=subject
-      Note:  Brandy/MUX mail wrappers may be in place on your RhostMUSH.
-             If it is, you may be able to use @mail like you're used to.
-  
-  2.  PennMUSH style mail.  This is used for the PennMUSH style mailing.
-      Needed   : The BRANDY_MAIL toggle must be UNSET and PENN_MAIL toggle
-                 must be set.  BRANDY_MAIL has precidence.
-      Syntax   : mail user(s)=subject/body
-      Note:  Penn mail wrappers may be in place on your RhostMUSH.  If it is,
-             you may be able to use @mail like you're used to.
-
-  3.  RhostMUSH line editor.  This is when you do 'mail/write &lt;start of text&gt;'
-      Look at  :  'help mail write' and 'help mail write cmdlist'
-      Syntax   :  mail/write Start Of Message
-  
-  4.  Mailing quickly.  This is when you do 'mail &lt;user-list&gt;=&lt;subj&gt;//&lt;body&gt;'
-      Look at  :  'help mail send quick' and 'help mail cmdlist'
-      Needed   :  The BRANDY_MAIL toggle must NOT be set. 
-                **NOTE**: @toggle me=!brandy_mail to remove it.
-      Syntax   :  mail user(s)=Optional Subject//Body
-                  mail user(s)=Body
-  
-  Please check @list options to see what current global settings are enabled
-  for the mail system.  Start a sendlist with a , for player's with spaces.
-  
-  See Also: PENN_MAIL, BRANDY_MAIL, mail write, mail send quick, 
-              mail send brandy
-  
-</PRE>
-<A HREF="#mail save">[PREV]</A>
-<A HREF="#topic index">[TOP]</A>
 <A HREF="#mail send brandy">[NEXT]</A>
 <BR>
 <HR><A NAME="mail send brandy"><H3>mail send brandy</H3></A><PRE>
@@ -24419,7 +30747,7 @@ Generated: Wed Jan 13 04:15:48 2016
   You need the BRANDY_MAIL toggle (@toggle me=brandy_mail) to use this syntax.
   
   You may also optionally set the MAIL_STRIPRETURN toggle to signal the mailer
-  to use spaces to seperate lines instead of a carrage return.
+  to use spaces to separate lines instead of a carriage return.
    
   This effects the commands:  mail, mail/reply, and mail/forward.
   
@@ -24430,7 +30758,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: BRANDY_MAIL, mail write, mail send quick, mail send brandy
   
 </PRE>
-<A HREF="#mail send">[PREV]</A>
+<A HREF="#mail save">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mail send examples">[NEXT]</A>
 <BR>
@@ -24487,6 +30815,7 @@ Generated: Wed Jan 13 04:15:48 2016
   automatically stripped out.
   
 { help mail send2 for more, or help mail send examples for examples }
+
 </PRE>
 <A HREF="#mail send examples">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -24528,6 +30857,51 @@ Generated: Wed Jan 13 04:15:48 2016
   
 </PRE>
 <A HREF="#mail send quick">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail sending">[NEXT]</A>
+<BR>
+<HR><A NAME="mail sending"><H3>mail sending</H3></A><PRE>
+  Topic: mail sending
+  
+  There are three ways that you can send mail with the mail system.  Depending 
+  on which way you prefer, this will point you to the correct help files.
+  
+  1.  Brandy/Mux style mail.  This is when you do 'mail user-list=subject'
+      Look at  :  'help mail send brandy' and 'help mail write cmdlist'
+      Needed   :  The BRANDY_MAIL toggle (help brandy_mail) 
+                  **NOTE**: @toggle me=brandy_mail to set it.
+      Syntax   :  mail user(s)=subject
+                  mail/reply &lt;msg#&gt;=subject
+                  mail/forward &lt;msg#&gt; &lt;user(s)&gt;=subject
+      Note:  Brandy/MUX mail wrappers may be in place on your RhostMUSH.
+             If it is, you may be able to use @mail like you're used to.
+  
+  2.  PennMUSH style mail.  This is used for the PennMUSH style mailing.
+      Needed   : The BRANDY_MAIL toggle must be UNSET and PENN_MAIL toggle
+                 must be set.  BRANDY_MAIL has precidence.
+      Syntax   : mail user(s)=subject/body
+      Note:  Penn mail wrappers may be in place on your RhostMUSH.  If it is,
+             you may be able to use @mail like you're used to.
+
+  3.  RhostMUSH line editor.  This is when you do 'mail/write &lt;start of text&gt;'
+      Look at  :  'help mail write' and 'help mail write cmdlist'
+      Syntax   :  mail/write Start Of Message
+  
+  4.  Mailing quickly.  This is when you do 'mail &lt;user-list&gt;=&lt;subj&gt;//&lt;body&gt;'
+      Look at  :  'help mail send quick' and 'help mail cmdlist'
+      Needed   :  The BRANDY_MAIL toggle must NOT be set. 
+                **NOTE**: @toggle me=!brandy_mail to remove it.
+      Syntax   :  mail user(s)=Optional Subject//Body
+                  mail user(s)=Body
+  
+  Please check @list options to see what current global settings are enabled
+  for the mail system.  Start a sendlist with a , for player's with spaces.
+  
+  See Also: PENN_MAIL, BRANDY_MAIL, mail write, mail send quick, 
+              mail send brandy
+  
+</PRE>
+<A HREF="#mail send2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mail setup_aliases">[NEXT]</A>
 <BR>
@@ -24583,7 +30957,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: help mail send 
   
 </PRE>
-<A HREF="#mail send2">[PREV]</A>
+<A HREF="#mail sending">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mail share">[NEXT]</A>
 <BR>
@@ -24689,6 +31063,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; mail/status U        (shows all the unread mail in your mailbox)
     &gt; mail/status B        (shows all the unread and new mail in your mailbox)
     &gt; mail/status /biff    (shows mail with subjects containing the word biff)
+    &gt; mail/status @folder  (shows all your mail of the specified folder)
   
   See Also: mail number, mail read, mail mark, mail unmark, mail save, 
             mail page
@@ -24730,7 +31105,7 @@ Generated: Wed Jan 13 04:15:48 2016
     mail-writing           mail-reading            mail-deleting
     mail-folders           mail-admin              mail-reviewing
     mail-sharing           mail-examples           mail-other
-    mail-aliases           mail-filtering
+    mail-aliases           mail-filtering          mail-attributes
   
     A tutorial can be seen with:
     mail tutorial
@@ -24749,9 +31124,13 @@ Generated: Wed Jan 13 04:15:48 2016
   The second is if you wish to just get on your feet with the mail system
   and learn the bare-bone basics (non-brandy interface)
   
-  For the brandy interface tutorial, please type:
+  For the brandy interface tutorial (+mail &amp; MUX/TM3 @mail), please type:
   
                        help mail btutor
+  
+  For the penn interface tutorial (Penn @mail), please type:
+  
+                       help mail ptutor
   
   For the default bare-bone tutorial, please type:
  
@@ -25747,6 +32126,33 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#mailMINUSaliases">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#mailMINUSattributes">[NEXT]</A>
+<BR>
+<HR><A NAME="mailMINUSattributes"><H3>mail-attributes</H3></A><PRE>
+  Topic: MAIL ATTRIBUTES
+  
+  The following attributes have special meaning in the mail system.
+    @mailsig     -- The signature that is assigned to any mail sent.
+    &amp;mailfilter  -- This is evaluated to auto-filter what folder mail goes to.
+    &amp;mailnotify  -- This is evaluated to auto-send notification to senders.
+    @mailtime    -- (Wizard only) Sets the auto-delete time on a player.
+    @mailsmax    -- (Wizard only) Sets the maximum saved messages on a player.
+    MailLock     -- (Internal) This is the lock mail/lock sets
+  
+  The following wildcard patterns are used for mail:
+    mail &amp;foo=text    -- This will check your personal FOO attribute for
+                         the player list you want to send to.
+                         This is non-evaluated.
+    mail ~foo=text    -- This will check your personal FOO attribute for
+                         the player list you want to send to.
+                         This is evaluated.
+  
+  See Also: @mailsig, &amp;mailfilter, &amp;mailnotify, mail lock, mail setup_aliases
+  For wizards, wizhelp: @mailsmax, @mailtime
+
+</PRE>
+<A HREF="#mailMINUSaliases2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#mailMINUSdeleting">[NEXT]</A>
 <BR>
 <HR><A NAME="mailMINUSdeleting"><H3>mail-deleting</H3></A><PRE>
@@ -25767,7 +32173,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: mail mark, mail save, mail unmark, mail delete, mail status
   
 </PRE>
-<A HREF="#mailMINUSaliases2">[PREV]</A>
+<A HREF="#mailMINUSattributes">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mailMINUSexamples">[NEXT]</A>
 <BR>
@@ -25836,6 +32242,10 @@ Generated: Wed Jan 13 04:15:48 2016
      - This displays all the mail in your mailbox
   9) mail/quick                  [help mail quick]
      - This gives you a quick status of your mailbox.
+ 10) mail +all
+     - This will read all your mail.
+ 11) mail/read/save 
+     - This option will output mail in an MBOX format
   
   See Also: mail quick, mail status, mail read, mail topics, mail main
   
@@ -25914,6 +32324,1356 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#mailMINUSsharing">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/alias">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/alias"><H3>mail/alias</H3></A><PRE>
+  Command: mail/alias
+  
+  The alias switch is used to display any global alias you have 
+  permission to access and will list all players that are attached
+  to that global alias.  Global aliases are maintained by the 
+  administration of the mush.  If you have ideas of global aliases,
+  suggest it to them and they will add them.
+  
+  Syntax: mail/alias
+  Wizards: wizhelp wmail alias
+  
+</PRE>
+<A HREF="#mailMINUSwriting">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/anonymous">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/anonymous"><H3>mail/anonymous</H3></A><PRE>
+  Command: mail/anon player=message
+           mail/anon/send player=message
+           mail/anon/forward &lt;msg#&gt; player=message
+           mail/anon/reply &lt;msg#&gt;=message
+  
+  The anon[ymous] switch is used in junction with the /send, /forward, or
+  /reply switches (or normal sending) to ANONYMOUSLY send the mail message
+  to the player.  Wizards are except from receiving anonymous mail due to
+  security issues.
+  
+  Attempting to forward anonymous mail shows the original message being
+  'anonymous'.  Attempting to reply to an anonymous mail will reply 
+  to the 'anonymous' player, while that player still receives the message.
+  
+  If you use the line editor, you can use -~ to send anonymously instead of
+  -- which would normally send the mail.
+   
+  See Also: mail send, mail reply, mail forward
+  
+</PRE>
+<A HREF="#mail/alias">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/autofor">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/autofor"><H3>mail/autofor</H3></A><PRE>
+  Command: mail/autofor &lt;player-name&gt;
+           mail/autofor +off
+  
+  Autoforwarding is used to autoforward mail that you would normally get
+  to another player.  This is handy in the event that you have
+  multiple players and wish to have mail all catagorized to a central
+  player.  All forwarded mail is sent as from the original sender, 
+  not from the player it was forwarded from.
+  
+  Autoforwarding can only be forwarded on a one-time basis.  It is not
+  recursive.  So in otherwords, you can not forward mail forwarded to you.
+  
+  To remove an autoforwarding use the command:
+      mail/autofor +off
+  
+  Mail that is autoforwarded will show up to the user sending you mail
+  where it got autoforwarded to.
+  
+  See Also: mail lock, mail share
+  
+</PRE>
+<A HREF="#mail/anonymous">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/check">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/check"><H3>mail/check</H3></A><PRE>
+  Command: mail/check &lt;target&gt;=&lt;#&gt;
+  
+  If someone has set up her mailbox to be shared with you, you can use this
+  command to read a particular message from the target's mailbox.
+   
+  Example:
+    &gt; mail/check tinyfriend=4    (read tinyfriend's message #4)
+   
+  See Also: mail read, mail number, mail share
+  
+</PRE>
+<A HREF="#mail/autofor">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/delete">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/delete"><H3>mail/delete</H3></A><PRE>
+  Command: mail/delete
+  
+  This command will delete all your marked messages in all your folders.
+  
+  See Also: mark, unmark, recall, save
+  
+</PRE>
+<A HREF="#mail/check">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/forward">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/forward"><H3>mail/forward</H3></A><PRE>
+  Command: mail/forward &lt;msg #&gt; [@|^]&lt;list&gt; [=[&lt;subject&gt;//]&lt;additional text&gt;]
+  
+  Forward a mail message to someone.  Note that you do not have to include your
+  own message, which is appended to the bottom of the message.  The
+  message number and the address list are separated by a space.  For the
+  format of the address list, see the help on the send sub-command
+  (help mail send).  You can only forward messages in the current folder.
+  
+  Examples:
+    &gt; mail/forward 3 myfriend
+    &gt; mail/forward 2 &amp;friendlist=Weird!!!//What do you think of this?
+    &gt; mail/forward 12 @friend1 #12345 friend2=Can you believe this?!
+  
+  Note:  If you have the BRANDY_MAIL @toggle set, the syntax would be this:
+    &gt; mail/forward 3 myfriend
+    &gt; mail/forward 2 &amp;friendlist=My Subject
+    &gt; mail/forward 12 @friend1 #12345 friend2=This is a subject
+  
+  You'd then use '-' for additional text and '--' to send the mail.
+  
+  See Also: mail reply, mail send
+  
+</PRE>
+<A HREF="#mail/delete">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/lock">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/lock"><H3>mail/lock</H3></A><PRE>
+  Command: mail/lock &lt;key&gt;
+  
+  You can lock your mailbox so that only certain people can (or cannot)
+  send you mail.  The key is the same as for any other lock.  Type:
+  
+                       'help @lock keys' 
+  
+  for a list of the keys you may use.  To unlock, use a
+  blank key.  IE: mail/lock  (this will unlock your mail lock)
+  
+  Examples:
+    &gt; mail/lock tinyspouse  (this locks to just tinyspouse)
+    &gt; mail/lock !tinyjerk   (this locks against tinyjerk)
+    &gt; mail/lock             (this removes your mail lock)
+   
+  The attribute it sets on you is 'MailLock' and is set like a normal lock.
+   
+  See Also: mail reject, mail recall
+  
+</PRE>
+<A HREF="#mail/forward">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/mark">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/mark"><H3>mail/mark</H3></A><PRE>
+  Command: mail/mark &lt;#&gt;|all|&lt;*player&gt;
+  
+  This command allows you to mark messages for deletion.  &lt;#&gt; indicates
+  a specific message to be marked.  To delete more than one message by
+  message number, separate the message numbers by spaces.  Specify &quot;all&quot;
+  to mark all messages.  Specify a person by name or db reference # to
+  mark all messages from that player.  You can only mark messages in the
+  current folder.
+  
+  You would add /save as a switch to mark a message for being saved instead
+  of marking it for deletion.  See 'help mail save' for more.
+    
+  Examples:
+    &gt; mail/mark 1        (mark message 1 for deletion)
+    &gt; mail/mark 1 5 8    (mark messages 1, 5, and 8 for deletion)
+    &gt; mail/mark all      (mark all your messages for deletion)
+    &gt; mail/mark *tinypal (mark messages from player 'tinypal' for deletion)
+    &gt; mail/mark #12345   (mark messages from player #12345 for deletion)
+    &gt; mail/mark 1-5 8 9  (mark messages 1 through 5, 8, and 9 for deletion)
+   
+  See Also: mail unmark, mail delete, mail status, mail save
+  
+</PRE>
+<A HREF="#mail/lock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/mark/save">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/mark/save"><H3>mail/mark/save</H3></A><PRE>
+  Command: mail/mark/save &lt;range&gt;
+           mail/unmark &lt;range&gt; (notice, you do not use /save with this)
+  
+  The save switch is used in junction with the MARK switch.  When used,
+  this will mark a mail message as SAVED and any autodeletion will
+  not remove the mail.  Please note that there is a maximum number of
+  saved messages available that you can use and once reached, you are
+  unable to save new ones w/o removing one of your prior ones.  To
+  unmark the message you may either use mail/mark (without a save)
+  or mail/unmark.  Saved mail shows up with a 'S' by the flag.
+  
+  See Also: mail mark
+  
+</PRE>
+<A HREF="#mail/mark">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/next">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/next"><H3>mail/next</H3></A><PRE>
+  Command:  mail/next
+  
+  This option will automatically view the next mail message from the one
+  you last read.  For example, if you typed:
+    mail 1 
+  
+  you would read mail message #1 (if you had mail)
+  If you typed:
+    mail/next
+  
+  you would read mail message #2 (if you had that number of messages)
+  
+  Note:  If you add a '-' after next (i.e. mail/next -) it will read the
+         previous message.
+  
+  See Also: mail status, mail zap, mail read
+  
+</PRE>
+<A HREF="#mail/mark/save">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/number">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/number"><H3>mail/number</H3></A><PRE>
+  Command: mail/number &lt;target&gt;=# 
+   
+  This command is similar to the status command.  If someone has set up 
+  his mailbox to be shared with you, you can use this command to see the 
+  status of the target's mailbox.
+   
+  As with the status command, the # here is optional.  If it is given
+  (in this case the second argument), it will have the same effect as it
+  would on the status command.
+   
+  Examples:
+    &gt; mail/number tinyspouse  (list all of tinyspouses mail [if you pass lock])
+    &gt; mail/number tinypal=2   (list just message 2 of tinyspouses mail)
+   
+  See Also: mail status, mail check, mail page, mail share
+  
+</PRE>
+<A HREF="#mail/next">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/page">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/page"><H3>mail/page</H3></A><PRE>
+  Command: mail/page &lt;value&gt;
+  
+  This sub-command sets the length of your pages.  When you specify a
+  page number in the status and number sub-commands, the pages are 
+  each composed of as many mail message headers as you set with the page
+  sub-command.
+   
+  A value of 0 means to not divide the status and number into separate
+  pages (i.e. all message headers are displayed on a single page).
+   
+  Examples:
+    &gt; mail/page 20
+    &gt; mail/status p1
+    &gt; mail/status p2
+   
+  See Also: mail status, mail number, mail quick
+  
+</PRE>
+<A HREF="#mail/number">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/password">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/password"><H3>mail/password</H3></A><PRE>
+  Command: mail/password +set=&lt;password&gt;
+           mail/password &lt;password&gt;    
+           mail/password +set         
+  
+  The first version of the password sub-command sets your password for
+  mail access.  Once you set your password, you must use the second form
+  of the password sub-command every time you connect to this mud in
+  order to access your mail.  Note that you only have to enter your mail
+  password once per login session.  If you have not set a mail password, you
+  do not need to enter a password at all to access your mail.
+   
+  To clear the password, use the +set format with a blank password.
+  Your mail password is separate from your login password.
+  
+  Examples:
+    &gt; mail/password +set=appleorange    (set mail password)
+    &gt; mail/password appleorrange        (enter password to access mail)
+    &gt; mail/password +set                (remove password)
+  
+  See Also: mail share, mail lock, mail autofor
+  
+</PRE>
+<A HREF="#mail/page">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/previous">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/previous"><H3>mail/previous</H3></A><PRE>
+  Command:  mail/next -
+  
+  Yes, you put a hyphen after the next.  This will in effect view the 
+  previous mail message from the one you last read.  For example, if
+  you typed:
+       mail 5
+  
+  You would read mail message #5 (if you had mail)
+  
+  If you typed:
+       mail/next -
+  
+  You would read mail message #4
+  
+  See Also: mail next, mail zap
+  
+</PRE>
+<A HREF="#mail/password">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/quick">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/quick"><H3>mail/quick</H3></A><PRE>
+  Command: mail/quick [&lt;folder&gt;]
+ 
+  Get a quick summary of how many new, unread, old, and marked messages
+  in the current folder.  Also reports the current folder.
+  
+  You may specify an optional folder to get quick a quick summary of that
+  particular mail folder.
+  
+  The /quick switch is optional for this command and you can just type 'mail'
+  standalone.  The /quick switch is required if you specify a folder.
+  
+  See Also: mail status, mail
+  
+</PRE>
+<A HREF="#mail/previous">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/quota">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/quota"><H3>mail/quota</H3></A><PRE>
+  Command:  mail/quota
+
+  Check how many mail messages are in your mailbox, as well as the maximum
+  amount of mail messages you are allowed to store in your mailbox.  It
+  will also display the total number of saved messages you are allowed
+  and the total number of saved messages you currently have used.
+  
+  See Also: quick, status
+  Wizards: wizhelp wmail size
+  
+</PRE>
+<A HREF="#mail/quick">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/read">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/read"><H3>mail/read</H3></A><PRE>
+  Command: mail[/read] &lt;msg #|new|unread|nall|uall|ball|1-N&gt;
+           mail/read/save &lt;msg #|new|unread|nall|uall|ball|1-N&gt;
+  
+  Read a mail message.  You can specify the message number, or to read the 
+  first new or unread mail message.  Check help on the status sub-command 
+  (wizhelp mail status)for information on how to see mail headers.  The /READ
+  switch is optional.  
+  
+  The optional /save switch when used in junction with the /read switch will
+  output the mail in a standard EMail format (MBOX) which you can then save to 
+  file and load in your favorite email program (mutt, pine, elm, outlook,
+  thunderbird, and so forth).  You would just import the file as an MBOX
+  formatted file.  Please refer to your mail program on how to read in this
+  mail format.
+  
+  Optional arguments to 'mail/read[/save]' is as follows:
+      mail[/read] +all   - read ALL your messages (spammy)
+      mail[/read] new    - read first new message
+      mail[/read] nall   - read ALL new messages
+      mail[/read] unread - read first unread message
+      mail[/read] uall   - read ALL unread messages
+      mail[/read] ball   - read ALL new AND unread messages
+      mail[/read] X-Y    - read messages starting at 'X' and until 'Y'
+      mail[/read] #      - read specified mail message number
+ 
+  Examples:
+    &gt; mail/read 2
+    &gt; mail 10
+    &gt; mail/read new
+    &gt; mail new
+    &gt; mail/read unread
+    &gt; mail/read 3-7
+    &gt; mail 2-8
+    &gt; mail unread
+  
+  See Also: mail status, mail delete, mail mark, mail next, mail zap,
+            mail unmark, mail save, mail new, mail unread, mail nall, 
+            mail ball, mail uall
+  
+</PRE>
+<A HREF="#mail/quota">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/read/save">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/read/save"><H3>mail/read/save</H3></A><PRE>
+  Command: mail[/read] &lt;msg #|new|unread|nall|uall|ball|1-N&gt;
+           mail/read/save &lt;msg #|new|unread|nall|uall|ball|1-N&gt;
+  
+  Read a mail message.  You can specify the message number, or to read the 
+  first new or unread mail message.  Check help on the status sub-command 
+  (wizhelp mail status)for information on how to see mail headers.  The /READ
+  switch is optional.  
+  
+  The optional /save switch when used in junction with the /read switch will
+  output the mail in a standard EMail format (MBOX) which you can then save to 
+  file and load in your favorite email program (mutt, pine, elm, outlook,
+  thunderbird, and so forth).  You would just import the file as an MBOX
+  formatted file.  Please refer to your mail program on how to read in this
+  mail format.
+  
+  Optional arguments to 'mail/read[/save]' is as follows:
+      mail[/read] +all   - read ALL your messages (spammy)
+      mail[/read] new    - read first new message
+      mail[/read] nall   - read ALL new messages
+      mail[/read] unread - read first unread message
+      mail[/read] uall   - read ALL unread messages
+      mail[/read] ball   - read ALL new AND unread messages
+      mail[/read] X-Y    - read messages starting at 'X' and until 'Y'
+      mail[/read] #      - read specified mail message number
+ 
+  Examples:
+    &gt; mail/read 2
+    &gt; mail 10
+    &gt; mail/read new
+    &gt; mail new
+    &gt; mail/read unread
+    &gt; mail/read 3-7
+    &gt; mail 2-8
+    &gt; mail unread
+  
+  See Also: mail status, mail delete, mail mark, mail next, mail zap,
+            mail unmark, mail save, mail new, mail unread, mail nall, 
+            mail ball, mail uall
+  
+</PRE>
+<A HREF="#mail/read">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/recall">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/recall"><H3>mail/recall</H3></A><PRE>
+  Command: mail/recall [ &lt;#&gt;|+all|*&lt;player&gt; [=&lt;player&gt;|+all] ]
+           mail/recall &lt;various options&gt;
+  
+  This command will let you recall (IE: delete) unread, unmarked
+  messages that you have sent to other players.  It allows you
+  you to either list all messages that you have sent that you can currently
+  recall, view a specified message that you sent that can be recalled,
+  and optionally recall from a single or multiple users or recall all messages.
+  
+  To view all messages that you can recall:
+    mail/recall
+  
+  This will display something like this:
+    Msg #:   1       To: Seawolf Wizard
+    Msg #:   8       To: Wizard George Freddie
+    Msg #:  10       To: TwinkMan
+    Mail: Done
+  
+  This will show mail you have sent that can still be recalled.  The Msg# may 
+  skip numbers if those messages have been previously read and can no longer 
+  be recalled.  *NOTE* You may specify a player with '*playername' to limit
+  the search on both 'mail/recall' and 'mail/recall/all'.
+  
+{ To continue [with examples], please type: help mail recall2 }
+
+</PRE>
+<A HREF="#mail/read/save">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/reject">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/reject"><H3>mail/reject</H3></A><PRE>
+  Command: mail/reject &lt;msg&gt;
+           mail/reject +list
+           mail/reject
+  
+  Will set the message sent when a player attempts to send a mail message to 
+  someone who has that player locked from mailing them.  This works similar
+  to the @reject for pages.  To see the current reject message use the 
+  +list option.  To clear the message, do mail/reject without a message.
+  Use the /lock switch to mail to establish a mail lock.
+   
+  Examples:
+    &gt; mail/reject I don't want you to mail me anymore.  Nayh!
+    &gt; mail/reject
+    &gt; mail/reject +list
+  
+  See Also: mail lock
+  
+</PRE>
+<A HREF="#mail/recall">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/reply">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/reply"><H3>mail/reply</H3></A><PRE>
+  Command: mail/reply [@|^]&lt;msg #&gt;[*]=[&lt;subject&gt;//]&lt;message&gt;.
+
+  Reply to a mail message with your own message.  The @, ^, and * are optional
+  to preface or follow the message number.  You can only reply to messages in
+  the current folder.  You may also specify an optional subject.
+  
+  To reply to all recipients of the mail message, in addition to the sender:
+     -preface the message number with @ for all recipients of your reply to
+      appear in the 'To' line.
+     -preface the message number with ^ for all recipients to see only their
+      own name in the 'To' line (i.e. not see who else received the reply).
+      This is the default.
+  
+  To include the original message in your reply:
+     -follow the message number with *.
+  
+  Examples:
+    &gt; mail/reply 2=Sure, I'll come to the party.  
+    &gt; mail/reply 1*=What did you mean?
+    &gt; mail/reply @12=Why don't we all get together tomorrow?
+    &gt; mail/reply ^9*=I'm not sure if we should build that.
+  
+  Note:  If you are @toggled BRANDY_MAIL, instead of &lt;message&gt; it would be your
+         subject.  Then you'd use '-' for additional text and '--' to send.
+  
+  See Also: mail forward, mail send
+  
+</PRE>
+<A HREF="#mail/reject">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/save">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/save"><H3>mail/save</H3></A><PRE>
+  Command: mail/mark/save &lt;range&gt;
+           mail/unmark &lt;range&gt; (notice, you do not use /save with this)
+  
+  The save switch is used in junction with the MARK switch.  When used,
+  this will mark a mail message as SAVED and any autodeletion will
+  not remove the mail.  Please note that there is a maximum number of
+  saved messages available that you can use and once reached, you are
+  unable to save new ones w/o removing one of your prior ones.  To
+  unmark the message you may either use mail/mark (without a save)
+  or mail/unmark.  Saved mail shows up with a 'S' by the flag.
+  
+  See Also: mail mark
+  
+</PRE>
+<A HREF="#mail/reply">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/save/read">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/save/read"><H3>mail/save/read</H3></A><PRE>
+  Command: mail[/read] &lt;msg #|new|unread|nall|uall|ball|1-N&gt;
+           mail/read/save &lt;msg #|new|unread|nall|uall|ball|1-N&gt;
+  
+  Read a mail message.  You can specify the message number, or to read the 
+  first new or unread mail message.  Check help on the status sub-command 
+  (wizhelp mail status)for information on how to see mail headers.  The /READ
+  switch is optional.  
+  
+  The optional /save switch when used in junction with the /read switch will
+  output the mail in a standard EMail format (MBOX) which you can then save to 
+  file and load in your favorite email program (mutt, pine, elm, outlook,
+  thunderbird, and so forth).  You would just import the file as an MBOX
+  formatted file.  Please refer to your mail program on how to read in this
+  mail format.
+  
+  Optional arguments to 'mail/read[/save]' is as follows:
+      mail[/read] +all   - read ALL your messages (spammy)
+      mail[/read] new    - read first new message
+      mail[/read] nall   - read ALL new messages
+      mail[/read] unread - read first unread message
+      mail[/read] uall   - read ALL unread messages
+      mail[/read] ball   - read ALL new AND unread messages
+      mail[/read] X-Y    - read messages starting at 'X' and until 'Y'
+      mail[/read] #      - read specified mail message number
+ 
+  Examples:
+    &gt; mail/read 2
+    &gt; mail 10
+    &gt; mail/read new
+    &gt; mail new
+    &gt; mail/read unread
+    &gt; mail/read 3-7
+    &gt; mail 2-8
+    &gt; mail unread
+  
+  See Also: mail status, mail delete, mail mark, mail next, mail zap,
+            mail unmark, mail save, mail new, mail unread, mail nall, 
+            mail ball, mail uall
+  
+</PRE>
+<A HREF="#mail/save">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/send">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/send"><H3>mail/send</H3></A><PRE>
+  Command:  mail/send [@]&lt;address list&gt;=[&lt;subject&gt;//]&lt;message&gt;
+  The address list can contain any number of recipients (up to the mush
+  buffer limit) and can be one of the following:
+      A player name  
+      A player number prefixed by a dbrief# 
+      A mail alias attribute located on the player prefixed by a &amp; 
+         (this is just an attribute on yourself with a list of players)
+      A global mail alias attribute prefixed by a +. 
+      A mail alias attribute location on optional target prefixed by a
+         ~ character.  This is evaluated like get_eval().
+  
+  The different elements in the address list need to be separated by spaces. 
+  If you include the optional '@', all recipients of a mail message will 
+  see the complete list of recipients. (This will show up as a 'CC' list).
+  To give an optional subject, enter text you want as a subject then 
+  separate that from the rest of the message with two /'s. (IE: // )
+     
+  There is an exception to the '@'.  Check @list options, if the To: is
+  automatically added, the '@' character's behavior is reversed.
+  
+  You can break up mail with either spaces OR commas and duplicates are
+  automatically stripped out.
+  
+{ help mail send2 for more, or help mail send examples for examples }
+
+</PRE>
+<A HREF="#mail/save/read">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/share">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/share"><H3>mail/share</H3></A><PRE>
+  Command: mail/share &lt;key&gt;
+  
+  Share lets you give access to your mailbox for other players who pass
+  the lock.  The key is a standard boolean lock expression, as documented
+  in 'help @lock keys'.
+   
+  Any player who passes the lock may do the /number and /check
+  sub-commands on your mailbox. If you do not have a share lock set on
+  your mail, this is the same as if nobody can pass the share lock. To
+  clear the lock, enter a blank expression.
+   
+  If you set a folder/share, players who pass the mail/share lock can
+  only see the folder you specify.
+   
+  Examples:
+    &gt; mail/share *tinyspouse             (allows tinyspouse into your mail)
+    &gt; mail/share *tinyspouse | *tinypal  (allows tinyspouse and tinypal)
+    &gt; mail/share                         (removes the sharelock)
+  
+  The attribute is 'ShareLock' on yourself.
+  
+  See Also: mail number, mail check, mail folders, mail folder, mail share
+  
+</PRE>
+<A HREF="#mail/send">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/status">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/status"><H3>mail/status</H3></A><PRE>
+  Command: mail/status [[p#] [*player] [#-#] [U/N/B/O/M/S] [/SUBJECT]]
+  
+  This will print out a list of the message headers in the current
+  folder for which the player has mail.  This will also show the current
+  folder.  The p# argument (where # is an integer) will print out the
+  specified page of message headers if the user has his/her paging value
+  set.  The page is determined from the paging value entered with the
+  page command which represents the number of messages on a page.  If
+  the user has no paging value set, entering a page number on this
+  command will have no effect.  If the user has a paging value set and
+  enters 0 for the page number, the user will get all message headers
+  without any page breaks.  
+  
+  Check out help on 'mail page' to see how to set your paging value.  
+  The '*player' option will show all mail sent to you from the given player, 
+  and the #-# is a range of messages you would like to see.  The letters 
+  U, N, B, O, M, and S are the special character representations for:
+     (U)nread             (N)ew                    (B)oth new and unread
+     (O)ld                (M)arked (for deletion)  (S)aved
+  
+  The /SUBJECT option will do a search for mail matching '/SUBJECT' in the
+  subject field.  The string after the '/' tells what to search for.
+  
+{ To continue with examples, see 'help mail status2' }
+  
+</PRE>
+<A HREF="#mail/share">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/unmark">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/unmark"><H3>mail/unmark</H3></A><PRE>
+  Command: mail/unmark &lt;#&gt;|all   (this works for saved messages as well)
+  
+  This command is similar to mark except that it unmarks messages.  You
+  may use mark and unmark to mark all but specific messages.  You can only
+  unmark messages in the current folder.  You would use this to unmark SAVED
+  messages as well.
+  
+  Examples:
+    &gt; mail/mark all
+    &gt; mail/unmark tinyspouse  (These two commands in this order mark
+                               all but tinyspouse's messages.)
+    &gt; mail/mark tinypal
+    &gt; mail/unmark 2 5         (These two commands in this order mark all
+                               of tinypal's messages, except messages 2 and 5).
+    &gt; mail/unmark 1-5         (unmark messages 1 through 5) 
+  
+  See Also: mail mark, mail delete, mail status, mail save
+  
+</PRE>
+<A HREF="#mail/status">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/version">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/version"><H3>mail/version</H3></A><PRE>
+  Command: mail/version
+  
+  this command will show the current version of the mailsystem.
+  
+</PRE>
+<A HREF="#mail/unmark">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write"><H3>mail/write</H3></A><PRE>
+  Topic: mail writing
+  
+  Note:  For help on creating new mail, please see 'help mail send'
+  
+  mail/write gives you the flexability of a line-editor within mail.  There
+  are various options with mail/write that you may use.  Help is available
+  on each of these topics.
+  
+  Topics:
+    ADDING         FORWARDING        QUICKSENDING  CMDLIST    AUTONOTIFY
+    EXAMPLES
+  
+  Write Functionality:
+    -         +edit     +del      +join     +justify   +split
+    +insert   +list     +forward  +reply    +subject   +forget
+    +send     +fedit    +editall  +feditall +cc        +bcc
+    +acc      +proof
+  
+  Type: help mail write &lt;option&gt; for help on these topics/functionality.
+  
+</PRE>
+<A HREF="#mail/version">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSacc">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSacc"><H3>mail/write +acc</H3></A><PRE>
+  Command: mail/write +acc=&lt;player-list&gt;
+  
+  The '+acc' subcommand is used to modify (add to) the target list of
+  players the mail is going out to.  Keep in mind, this ONLY works for
+  sending or forwarding.  This does *NOT* work for replies.
+  
+  This only works when you are @toggled BRANDY_MAIL and when you
+  start a message with 'mail player-list=subject' (or similiar).
+  
+  Example:
+    &gt; mail/write +acc=player1 player2 &amp;myalias +globalalias
+    Mail: New send player list stored.
+  
+  See Also: mail write +cc, mail write +bcc
+  
+</PRE>
+<A HREF="#mail/write">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSbcc">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSbcc"><H3>mail/write +bcc</H3></A><PRE>
+  Command: mail/write +bcc=&lt;player-list&gt;
+  
+  The '+bcc' subcommand is used to modify (add to) the target list 
+  and blind target list of players the mail is going out to.  Keep 
+  in mind, this ONLY works for sending or forwarding.  This does 
+  *NOT* work for replies.  If 'bcc_hidden' is ENABLED, then 
+  whoever is in the +bcc list will _NOT_ see who the mail was sent
+  to.  If 'bcc_hidden' is DISABLED, then whoever is in the +bcc
+  list WILL see who the mail was sent to, but no one outside the
+  +bcc list will.  In effect, bcc_hidden toggles the effect.
+  
+  Please check '@list options mail' for the current configuration.
+  
+  You may specify '!ALL' to clear the Bcc list without effecting
+  the To list.
+  
+  This only works when you are @toggled BRANDY_MAIL and when you
+  start a message with 'mail player-list=subject' (or similiar).
+   
+  Example:
+    &gt; mail/write +bcc=player1 player2 &amp;myalias +globalalias
+    Mail: New send player list stored.
+  
+  See Also: mail write +cc, mail write +acc
+  
+</PRE>
+<A HREF="#mail/write PLUSacc">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUScc">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUScc"><H3>mail/write +cc</H3></A><PRE>
+  Command: mail/write +cc=&lt;player-list&gt;
+  
+  The '+cc' subcommand is used to replace (not modify!) the target list of
+  players the mail is going out to.  Keep in mind, this ONLY works for
+  sending or forwarding.  This does *NOT* work for replies.
+  
+  This only works when you are @toggled BRANDY_MAIL and when you
+  start a message with 'mail player-list=subject' (or similiar).
+  
+  Example:
+    &gt; mail/write +cc=player1 player2 &amp;myalias +globalalias ~evalalias
+    Mail: New send player list stored.
+  
+  See Also: mail write +bcc, mail write +acc
+  
+</PRE>
+<A HREF="#mail/write PLUSbcc">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSdel">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSdel"><H3>mail/write +del</H3></A><PRE>
+  Command: mail/write +del=&lt;args&gt;
+  
+  The '+del' subcommand  to mail/write is used to delete a line of text.
+  
+  Examples:
+    &gt; mail/write A line of text
+    Mail: Write message started.
+    &gt; -Another line of txt
+    Mail: Write line 2 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: A line of text
+    2: Another line of txt
+    -------------------------------------------------------------------------
+    &gt; mail/write +del=1
+    Mail: Write line deleted.
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: Another line of txt
+    -------------------------------------------------------------------------
+  
+  Note: You can't delete line #1 if that's the only line there is.  
+        Use mail/write +forget to remove it.
+  
+  See Also: mail write +edit, mail write +split, mail write +forget
+    
+</PRE>
+<A HREF="#mail/write PLUScc">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSedit">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSedit"><H3>mail/write +edit</H3></A><PRE>
+  Command: mail/write +edit &lt;line&gt;=&lt;old&gt;,&lt;new&gt;
+  
+  The '+edit' subcommand to mail/write is used to edit a line of text.
+  This only edits the FIRST occurance of text in the line.
+  
+  Examples:
+    &gt; mail/write A line of text
+    Mail: Write message started.
+    &gt; -Another line of txt
+    Mail: Write line 2 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: A line of text
+    2: Another line of txt
+    -------------------------------------------------------------------------
+    &gt; mail/write +edit 2=txt,text
+    Mail: +edit done.
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: A line of text
+    2: Another line of text
+    -------------------------------------------------------------------------
+   
+  See Also: mail write +del, mail write +join, mail write +justify 
+  
+</PRE>
+<A HREF="#mail/write PLUSdel">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSeditall">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSeditall"><H3>mail/write +editall</H3></A><PRE>
+  Command: mail/write +editall=&lt;old&gt;,&lt;new&gt;
+  
+  The '+editall' subcommand to mail/write is used to edit ALL lines of text.
+  This only edits the FIRST occurance of text in the lines.
+  
+  Examples:
+    &gt; mail/write A line of txt txt
+    Mail: Write message started.
+    &gt; -Another line of txt txt
+    Mail: Write line 2 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: A line of txt
+    2: Another line of txt
+    -------------------------------------------------------------------------
+    &gt; mail/write +editall=txt,text
+    Mail: +editall done (2 lines edited)
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: A line of text txt
+    2: Another line of text txt
+    -------------------------------------------------------------------------
+  
+  See Also: mail write +feditall, mail write +edit, mail write +fedit
+   
+</PRE>
+<A HREF="#mail/write PLUSedit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSfedit">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSfedit"><H3>mail/write +fedit</H3></A><PRE>
+  Command: mail/write +fedit &lt;line&gt;=&lt;old&gt;,&lt;new&gt;
+  
+  The '+fedit' subcommand to mail/write is used to edit a line of text.
+  Unlike the '+edit' subcommand, this edits ALL occurances of the text
+  in the line.
+  
+  Examples:
+    &gt; mail/write A line of text
+    Mail: Write message started.
+    &gt; -Another line of txt
+    Mail: Write line 2 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: A line of text
+    2: Another line of txt
+    -------------------------------------------------------------------------
+    &gt; mail/write +fedit 2=txt,text
+    Mail: +fedit done.
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: A line of text
+    2: Another line of text
+    -------------------------------------------------------------------------
+   
+  See Also: mail write +del, mail write +join, mail write +justify,
+            mail write +fedit, mail write +editall, mail write +feditall
+  
+</PRE>
+<A HREF="#mail/write PLUSeditall">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSfeditall">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSfeditall"><H3>mail/write +feditall</H3></A><PRE>
+  Command: mail/write +feditall=&lt;old&gt;,&lt;new&gt;
+  
+  The '+feditall' subcommand to mail/write is used to edit ALL lines of text.
+  This edits ALL occurances of text in ALL the lines.
+  
+  Examples:
+    &gt; mail/write A line of txt txt
+    Mail: Write message started.
+    &gt; -Another line of txt txt
+    Mail: Write line 2 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: A line of txt
+    2: Another line of txt
+    -------------------------------------------------------------------------
+    &gt; mail/write +feditall=txt,text
+    Mail: +feditall done (2 lines edited)
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: A line of text text
+    2: Another line of text text
+    -------------------------------------------------------------------------
+  
+  See Also: mail write +editall, mail write +edit, mail write +fedit
+  
+</PRE>
+<A HREF="#mail/write PLUSfedit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSforget">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSforget"><H3>mail/write +forget</H3></A><PRE>
+  Command: mail/write +forget
+  
+  The '+forget' subcommand to mail/write is used to purge the mail in progress
+  effectively deleting all of the mail/write information.
+  
+  Examples:
+    &gt; mail/write Start of message
+    Mail: Write message started.
+    &gt; -another line
+    Mail: Write line 2 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    1: Start of message
+    2: another line
+    &gt; mail/write +forget
+    Mail: Write message forgotten.
+    &gt; mail/write +list
+    Mail: No write in progress.
+  
+  See Also: mail write +edit, mail write +del
+    
+</PRE>
+<A HREF="#mail/write PLUSfeditall">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSforward">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSforward"><H3>mail/write +forward</H3></A><PRE>
+  Command: mail/write +forward=&lt;message number&gt; &lt;player-list&gt;
+  
+  The '+forward' subcommand to mail/write is used to forward the mail
+  in progress to the player list while including the specified message
+  number from your mailbox.
+  
+  Examples:
+    &gt; mail/write TinyPlayer sent me this... what do you think?
+    Mail: Write message started.
+    &gt; mail/status
+    -------------------------------------------------------------------------
+    [0] ( 1)  From: TinyPlayer      &lt;Mon Jan  1 01:01:01 2000&gt;  (1095 Bytes)
+              Subj: Hey!
+    -------------------------------------------------------------------------
+  
+    Note: if the player 'TinyPlayer' was connected, they'd have a '*' before
+          the 'From:'.  i.e.  *From: TinyPlayer
+  
+    &gt; mail/write +forward=1 MyFriend
+    Mail: Message sent to -&gt; MyFriend
+  
+  See Also: mail write +reply, mail write quicksending, mail forward
+            mail status
+  
+</PRE>
+<A HREF="#mail/write PLUSforget">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSinsert">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSinsert"><H3>mail/write +insert</H3></A><PRE>
+  Command: mail/write +insert=&lt;args&gt;
+  
+  The '+insert' subcommand to mail/write is used to insert a line before
+  the specified line.
+  
+  Examples:
+    &gt; mail/write Start of mail
+    Mail: Write message started.
+    &gt; -Third line
+    Mail: Write line 2 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: Start of mail
+    2: Third line
+    -------------------------------------------------------------------------
+    &gt; mail/write +insert=2,Second line
+    Mail: Line inserted.
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: Start of mail
+    2: Second line
+    3: Third line
+    -------------------------------------------------------------------------
+  
+  See Also: mail write +del, mail write +join
+  
+</PRE>
+<A HREF="#mail/write PLUSforward">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSjoin">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSjoin"><H3>mail/write +join</H3></A><PRE>
+  Command: mail/write +join=&lt;args&gt;
+  
+  The '+join' subcommand to mail/write is used to join two lines of text.
+  
+  Examples:
+    &gt; mail/write This is
+    Mail: Write message started.
+    &gt; -This is the end of the line.
+    Mail: Write line 2 added
+    &gt; -a test
+    Mail: Write line 3 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: This is
+    2: This is the end of the line.
+    3: a test
+    -------------------------------------------------------------------------
+    &gt; mail/write +join=1,3
+    Mail: Line joined.
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: This is a test
+    2: This is the end of the line.
+    -------------------------------------------------------------------------
+  
+  See Also: mail write +del, mail write +split
+  
+</PRE>
+<A HREF="#mail/write PLUSinsert">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSjustify">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSjustify"><H3>mail/write +justify</H3></A><PRE>
+  Command: mail/write +justify=&lt;args&gt;
+  
+  The '+justify' subcommand to mail/write is used to justify the line.
+  Valid options are (l)eft, (c)enter, or (r)ight for justification.
+  
+  Examples:
+    &gt; mail/write This is a test
+    Mail: Write message started.
+    &gt; -This is the end of the line.
+    Mail: Write line 2 added
+    &gt; -ok, I lied.
+    Mail: Write line 3 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: This is a test
+    2: This is the end of the line.
+    3: ok, I lied.
+    -------------------------------------------------------------------------
+    &gt; mail/write +justify=1,c
+    Mail: Line justified.
+    &gt; mail/write +justify=2,r
+    Mail: Line justified.
+    &gt; mail/write +list
+    -------------------------------------------------------------------------
+    1:                            This is a test
+    2:                                          This is the end of the line.
+    3: ok, I lied.
+    -------------------------------------------------------------------------
+  
+  See Also: mail write +join, mail write +del
+  
+</PRE>
+<A HREF="#mail/write PLUSjoin">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSlist">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSlist"><H3>mail/write +list</H3></A><PRE>
+  Command: mail/write +list [=&lt;args&gt;]
+  
+  The '+list' subcommand to mail/write is used to list the lines of your
+  write message.
+  
+  Examples:
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: Line one
+    2: Line two
+    3: Line three
+    -------------------------------------------------------------------------
+    &gt; mail/write +list=2
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    2: Line two
+    3: Line three
+    -------------------------------------------------------------------------
+    &gt; mail/write +list=1,2
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: Line one
+    2: Line two
+    -------------------------------------------------------------------------
+  
+  See Also: mail write +forget, mail write +send
+  
+</PRE>
+<A HREF="#mail/write PLUSjustify">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSproof">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSproof"><H3>mail/write +proof</H3></A><PRE>
+  Command: mail/write +proof
+  
+  The '+proof' subcommand to mail/write is used to give you a 'snapshot' of 
+  approximately what the mail will look like when it is sent out.  This does
+  not show any text that will be included in forwarded or replied to mail
+  if you chose the options to include original text.
+  
+  Examples:
+    &gt; mail/write This is some text
+    Mail: Write message started.
+    &gt; mail/write +proof
+    ---------------------------------------------------------------------------
+    Message In Progress
+    Status: EDITING     From: You
+    To: (empty list)
+    Date/Time: Mon May 14 18:50:27 2011        Size: 18 Bytes
+    Subject: (None)
+    ---------------------------------------------------------------------------
+    This is some text
+    ---------------------------------------------------------------------------
+  
+  See Also: mail write +list, mail write
+  
+</PRE>
+<A HREF="#mail/write PLUSlist">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSreply">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSreply"><H3>mail/write +reply</H3></A><PRE>
+  Command: mail/write +reply=&lt;message number&gt;
+  
+  The '+reply' subcommand to mail/write is used to reply to the specified
+  message with the mail that is in progress.
+  
+  Examples:
+    &gt; mail/write Thanks for the mail.
+    Mail: Write message started.
+    &gt; mail/status
+    -------------------------------------------------------------------------
+    [0] ( 1)  From: TinyPlayer      &lt;Mon Jan  1 01:01:01 2000&gt;  (1095 Bytes)
+              Subj: Hey!
+    -------------------------------------------------------------------------
+    
+    Note: if the player 'TinyPlayer' was connected, they'd have a '*' before
+          the 'From:'.  i.e.  *From: TinyPlayer
+  
+    &gt; mail/write +reply=1
+    Mail: Message sent to -&gt; TinyPlayer
+  
+  See Also: mail write +forward, mail write quicksending, mail reply, 
+            mail status
+  
+</PRE>
+<A HREF="#mail/write PLUSproof">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSsend">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSsend"><H3>mail/write +send</H3></A><PRE>
+  Command: mail/write +send=&lt;player list&gt;
+  
+  The '+send' subcommand to mail/write is used to send the mail in progress to
+  a list of players.  You may specify a '@' before the player list to send the
+  list of players in a seeable 'CC' list.  Otherwise, it's assumed blank
+  carbon copies for everyone in the mail list.
+  
+  Examples:
+    &gt; mail/write Start of message
+    Mail: Write message started.
+    &gt; -second line.
+    Mail: Write line 2 added
+    &gt; -third line.
+    Mail: Write line 3 added
+    &gt; mail/write +send=@tinyplayer tinywizard
+    Mail: Message sent to -&gt; TinyPlayer
+    Mail: Message sent to -&gt; TinyWizard
+  
+  See Also: mail write +reply, mail write +forward, mail send, mail forward,
+            mail reply, mail status
+    
+</PRE>
+<A HREF="#mail/write PLUSreply">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSsplit">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSsplit"><H3>mail/write +split</H3></A><PRE>
+  Command: mail/write +split=&lt;args&gt;
+  
+  The '+split' subcommand to mail/write is used to split a line after the
+  specified word.
+  
+  Examples:
+    &gt; mail/write Start of mail
+    Mail: Write message started.
+    &gt; -Second line Third line
+    Mail: Write line 2 added
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: Start of mail
+    2: Second line Third line
+    -------------------------------------------------------------------------
+    &gt; mail/write +split=2,2
+    Mail: Line split.
+    &gt; mail/write +list
+    Mail: Your write message is:
+    -------------------------------------------------------------------------
+    1: Start of mail
+    2: Second line
+    3: Third line
+    -------------------------------------------------------------------------
+  
+  See Also: mail write +justify, mail write +join, mail write +del
+ 
+</PRE>
+<A HREF="#mail/write PLUSsend">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/write PLUSsubject">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/write PLUSsubject"><H3>mail/write +subject</H3></A><PRE>
+  Command: mail/write +subject=&lt;subject&gt;
+  
+  The '+subject' subcommand to mail/write is used to set a subject line for
+  your mail message.  You may use this command to also re-set it to something
+  else if you so desire.
+  
+  Examples:
+    &gt; mail/write Start of message
+    Mail: Write message started.
+    &gt; mail/write +list
+    Mail: Your write message is:
+    1: Start of message
+    &gt; mail/write +subject=My Subject
+    Mail: Write subject set
+    &gt; mail/write +list
+    Mail: Your write message is:
+    Subject: My Subject
+    1: Start of message
+    
+  See Also: mail write +send, mail write -, mail write +forget
+  
+</PRE>
+<A HREF="#mail/write PLUSsplit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mail/zap">[NEXT]</A>
+<BR>
+<HR><A NAME="mail/zap"><H3>mail/zap</H3></A><PRE>
+  Command:  mail/zap
+  
+  This option will automatically mark the present message and view the 
+  next message.  For example, if you typed:
+    mail 1
+  
+  you would read mail message #1 (if you had mail)
+  If you typed:
+    mail/zap
+  
+  You would mark message #1 for deletion and read message #2
+  (if you had two messages, in which it would only mark #1 and return
+   that you had no more mail to read)
+  
+  Note:  If you add a '-' after zap (i.e. mail/zap -) it will read the
+         previous message.
+  
+  See Also: mail status, mail next, mail mark, mail delete, mail read
+  
+</PRE>
+<A HREF="#mail/write PLUSsubject">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#mail_noparse toggle">[NEXT]</A>
 <BR>
 <HR><A NAME="mail_noparse toggle"><H3>MAIL_NOPARSE TOGGLE</H3></A><PRE>
@@ -25927,7 +33687,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: penn mail toggle, brandy_mail toggle
   
 </PRE>
-<A HREF="#mailMINUSwriting">[PREV]</A>
+<A HREF="#mail/zap">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mail_stripreturn toggle">[NEXT]</A>
 <BR>
@@ -25936,7 +33696,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   When this toggle is set on the player, whenever that player finishes
   writing mail using the BRANDY_MAIL toggle, all lines are combined
-  with spaces instead of carrage returns.  This will mimic more how
+  with spaces instead of carriage returns.  This will mimic more how
   Brandy's +mail or Mux's @mail works.
   
   See Also: penn_mail toggle, brandy_mail toggle
@@ -25974,10 +33734,48 @@ Generated: Wed Jan 13 04:15:48 2016
       Mail: You have new mail from -&gt; Tony [Subj: You smell]
       Mail: Auto-Moved to folder -&gt; Junk
   
-  See Also: @mailsig
+  See Also: @mailsig, &amp;mailnotify
  
 </PRE>
 <A HREF="#mail_stripreturn toggle">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#mailnotify">[NEXT]</A>
+<BR>
+<HR><A NAME="mailnotify"><H3>MAILNOTIFY</H3></A><PRE>
+  Attribute: &amp;MAILNOTIFY
+  
+  This attribute, when set on a player, will send a message to the person
+  mailing them depending on the evaluated text in the attribute.
+  
+  If the message evaluates to an empty string, no message is sent.
+  
+  The following arguments are passed for evaluation:
+              %0  - the dbref# of the player (or #-1 if anonymous)
+              %1  - the subject of the message
+              %2  - the body of the message
+              %3  - the date/time of the message
+  
+  Examples:
+    &gt; &amp;mailnotify me=Hi, [name(%0)]!  You sent me mail!
+    Set.
+    &gt; think [name(me)]
+    Bob
+    &gt; mail me=Test!
+    Hi, Bob!  You sent me mail!
+    Mail: You have new mail from -&gt; Bob
+    Mail: Message sent to -&gt; Bob
+    Mail: Done
+    &gt; think [name(me)]
+    Betty
+    &gt; mail bob=Test!
+    Hi, Betty! You sent me mail!
+    Mail: Message sent to -&gt; Bob
+    Mail: Done
+  
+  See Also: @mailsig, &amp;mailfilter
+
+</PRE>
+<A HREF="#mailfilter">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mailquick()">[NEXT]</A>
 <BR>
@@ -26004,7 +33802,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: mail cmdlist, mail write cmdlist
   
 </PRE>
-<A HREF="#mailfilter">[PREV]</A>
+<A HREF="#mailnotify">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mailvalidate toggle">[NEXT]</A>
 <BR>
@@ -26033,7 +33831,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   &lt;delim&gt;iter may be used to specify a delimiter other than space.
   
-  &lt;sep&gt;erator may be used to specify an output seperator other than a space.
+  &lt;sep&gt;erator may be used to specify an output separator other than a space.
   
   You may specify arguments &lt;arg1&gt; through &lt;argN&gt; that will be passed as %1
   for the first argument (or arg1) all the way through MAX_ARGS 
@@ -26047,7 +33845,7 @@ Generated: Wed Jan 13 04:15:48 2016
   You say &quot;2 3 4 5 6&quot;
   
   See Also: filter(), fold(), iter(), parse(), u(), munge(), citer(), 
-            nsiter(), sortlist()
+            nsiter(), sortlist(), inf()
   
 </PRE>
 <A HREF="#mailvalidate toggle">[PREV]</A>
@@ -26057,7 +33855,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker0"><H3>MARKER0</H3></A><PRE>
   Flag: MARKER0([0])  
   
-  This flag is a marker flag.  
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26069,7 +33868,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker1"><H3>MARKER1</H3></A><PRE>
   Flag: MARKER1([1])  
   
-  This flag is a marker flag. 
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26081,7 +33881,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker2"><H3>MARKER2</H3></A><PRE>
   Flag: MARKER2([2])
   
-  This flag is a marker flag.  
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26093,7 +33894,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker3"><H3>MARKER3</H3></A><PRE>
   Flag: MARKER3([3])  
   
-  This flag is a marker flag.  
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26105,7 +33907,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker4"><H3>MARKER4</H3></A><PRE>
   Flag: MARKER4([4])  
   
-  This flag is a marker flag.  
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26117,7 +33920,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker5"><H3>MARKER5</H3></A><PRE>
   Flag: MARKER5([5])  
   
-  This flag is a marker flag.  
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26129,7 +33933,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker6"><H3>MARKER6</H3></A><PRE>
   Flag: MARKER6([6])  
   
-  This flag is a marker flag.  
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26141,7 +33946,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker7"><H3>MARKER7</H3></A><PRE>
   Flag: MARKER7([7])  
   
-  This flag is a marker flag.  
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26153,7 +33959,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker8"><H3>MARKER8</H3></A><PRE>
   Flag: MARKER8([8])  
   
-  This flag is a marker flag.  
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26165,7 +33972,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="marker9"><H3>MARKER9</H3></A><PRE>
   Flag: MARKER9([9])  
   
-  This flag is a marker flag.  
+  This flag is a marker flag.  It is a dummy flag for reuse.
+  
   By default only #1 may set or unset it.  To change permissions
   of this flag, use the @flagdef command (in wizhelp).
   
@@ -26201,7 +34009,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say mask(3,4,^)
     You say &quot;7&quot;
   
-  See Also: strip(), edit(), editansi(), garble(), regedit()
+  See Also: edit(), regedit(), pack(), unpack(), packmath(), shl(), shr(),
+            crc32()
   
 </PRE>
 <A HREF="#marker9">[PREV]</A>
@@ -26239,6 +34048,30 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#mask()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#max args">[NEXT]</A>
+<BR>
+<HR><A NAME="max args"><H3>MAX ARGS</H3></A><PRE>
+  Topic: MAX ARGS
+  
+  Functions:
+    The maximum number of arguments you can pass functions, by default, is 30.
+    Anything over this tends to no longer be processed.  
+  
+    You can extend this by strfunc() to essentially turn any function into
+    a list function, which then extends the maximum number of arguments
+    to functions (that accept 1 to n as arguments) to a maximum of 1000.
+  
+    Functions that are hard-locked with strict arguments are not affected.
+  
+  Commands:
+    Commands, by default, have 10 arguments you can pass to them.  This is
+    hard limited and immutable.
+  
+  See Also: strfunc(), @list functions, @list commands, commands, functions
+    
+</PRE>
+<A HREF="#match()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#max()">[NEXT]</A>
 <BR>
 <HR><A NAME="max()"><H3>MAX()</H3></A><PRE>
@@ -26259,7 +34092,48 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: min(), alphamin(), alphamax()
   
 </PRE>
-<A HREF="#match()">[PREV]</A>
+<A HREF="#max args">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#max_name_protect">[NEXT]</A>
+<BR>
+<HR><A NAME="max_name_protect"><H3>max_name_protect</H3></A><PRE>
+  (CONTINUED)
+  Command: @protect[/&lt;switch&gt;] [&lt;player-name&gt;]  
+  
+  The following wizard @admin parameters exist (see wizhelp for help):
+    protect_addenh   -- this is the toggle that enables/disables enhanced adds
+    max_name_protect -- this controls total number of names to be protected
+  
+  Examples:
+    &gt; say [name(me)] [num(me)]
+    You say &quot;Bob #123&quot;
+    &gt; @protect/add
+    Your current name has been added to your protect list.
+    &gt; @protect/add Simon            (if enhanced mode enabled)
+    The name has been added to your protect list.
+    &gt; @protect/add Fred             (if enhanced mode enabled)
+    The name has been added to your protect list.
+    &gt; @protect/del Bob
+    You have successfully deleted 'Bob' from your protect list.
+    &gt; @protect/alias Simon
+    You have successfully activated 'simon' as an alias.
+    &gt; @protect/alias Fred
+    You have successfully activated 'fred' as an alias.
+    &gt; @protect/unalias Fred
+    You have successfully de-activated 'fred' as an alias.
+    &gt; @protect/list
+    +------------------------------+----------------------------------+-------+
+    | Player Name Protected        | Dbref#   [ Player Name         ] | Alias |
+    +------------------------------+----------------------------------+-------+
+    | Simon                        | #123     [ Bob                 ] |   Y   |
+    | Fred                         | #123     [ Bob                 ] |   N   |
+    +------------------------------+----------------------------------+-------+
+    You have 2 out of 10 names protected.
+  
+  See Also: @name, @alias, listprotection()
+  
+</PRE>
+<A HREF="#max()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#me">[NEXT]</A>
 <BR>
@@ -26275,7 +34149,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: HERE
   
 </PRE>
-<A HREF="#max()">[PREV]</A>
+<A HREF="#max_name_protect">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#member()">[NEXT]</A>
 <BR>
@@ -26351,7 +34225,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say mid(this is a test,3,6)
     You say &quot;s is a&quot;
   
-  See Also: delete(), ldelete(), remove()
+  See Also: delete(), ldelete(), remove(), ruler()
   
 </PRE>
 <A HREF="#merge()">[PREV]</A>
@@ -26370,7 +34244,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say min(2,4)
     You say &quot;2&quot;
     &gt; say min(-100,50,0,25)
-    You say &quot;-10&quot;
+    You say &quot;-100&quot;
    
   See Also: max(), alphamin(), alphamax()
   
@@ -26395,6 +34269,7 @@ Generated: Wed Jan 13 04:15:48 2016
   privatize() - All localized variables are initialized to null
   pushregs() - Preserves, and restores setq() registers.
   r() - Accesses local registers.
+  sandbox() - Evaluates code with specific function restrictions
   setq() - Copies a string into a local register.
   setq_old() - Like setq(), but uses old MUSH style evaluation.
   setqmatch() - Sets a register if a pattern matches &lt;string&gt;.
@@ -26402,6 +34277,7 @@ Generated: Wed Jan 13 04:15:48 2016
   setr_old() - Like setr(), but uses old MUSH style evaluation.
   soundex() - Returns the soundex pattern of a word.
   soundlike() - Compares the soundex of two words.
+  tag() - Returns the #dbref stored behind a named tag.
   trace() - Controls the trace flag on an object.
 
 </PRE>
@@ -26414,7 +34290,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   This function is similiar to map(), except it takes the arguments in the 
   lists and passes them into the attribute as %0 (for list1), %1 (for list2),
-  up to %9 (for list9).  &lt;delim&gt; is used as the delimiter to seperate items
+  up to %9 (for list9).  &lt;delim&gt; is used as the delimiter to separate items
   in each of the lists.  If the number of lists is 2, the delimiter may be
   optional, otherwise you are forced to provide a delimiter.  If no delimiter
   is specified, it's defaulted as a space but only for the above condition.
@@ -26432,7 +34308,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say mix(do_moremath,1,2,3,4,5,6,7 8,9 10 11 12,)
     You say &quot;37 18 11 12&quot;
   
-  See Also: map(), iter(), merge(), elements(), list(), elementpos()
+  See Also: map(), iter(), merge(), elements(), list(), elementpos(), inf()
   
 </PRE>
 <A HREF="#miscellaneous functions">[PREV]</A>
@@ -26586,7 +34462,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="monitor"><H3>MONITOR</H3></A><PRE>
   Flag: MONITOR(M)
-  
+    
   This flag does NOT return player connection/disconnection information.
   Check help @toggle for that.
    
@@ -26596,9 +34472,22 @@ Generated: Wed Jan 13 04:15:48 2016
   wildcarded &lt;pattern&gt;, then &lt;commandlist&gt; is executed, substituting %0 for
   the text that matched the first wildcard, %1 for the second, and so on.
   All matching attributes are executed, not just the first.
-  Parents of MONITOR objects are never checked for ^-patterns.
- 
-  See Also: LISTENING, PUPPET
+  
+  ^-listens are never checked on players.
+  
+  Note: Parents of MONITOR objects by default are never checked 
+        for ^-patterns.  This can be enabled with the 'listen_parents'
+        config parameter, but there will be a computational cost involved.
+   
+  Example:
+    &gt; say %n
+    You say &quot;Bob&quot;
+    &gt; &amp;MY_LISTEN MyObject=^* says &quot;*&quot;:@pemit %#=Object: %0 said '%1'
+    &gt; say &quot;Moo&quot;
+    You say &quot;Moo&quot;
+    Object: Bob said 'Moo'
+    
+  See Also: LISTENING, PUPPET, @listen, @ahear, $-commands, lcmds(), lattr()
   
 </PRE>
 <A HREF="#moneyname()">[PREV]</A>
@@ -26613,6 +34502,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Architect and above on a player which they control given that the
   player is also Architect or above in level. Additionally it can
   be set by a wizard on any player.
+  
 </PRE>
 <A HREF="#monitor">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -26789,6 +34679,74 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#moving3">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#msecs()">[NEXT]</A>
+<BR>
+<HR><A NAME="msecs()"><H3>MSECS()</H3></A><PRE>
+  Function: secs()
+            msecs()
+ 
+  Returns the number of elapsed seconds since midnight, January 1, 1970.
+  This is an easy way to time things.
+  
+  The msecs() function works like secs() but gives the fractional milisecond
+  of the current time.
+   
+  Example:
+     &gt; say secs()
+     You say &quot;692636020&quot;
+     ... wait a bit ...
+     &gt; say secs()
+     You say &quot;692636043&quot;
+     &gt; say msecs()
+     You say &quot;692636049.7&quot;
+  
+  See Also: convsecs(), convtime(), time(), timefmt()
+  
+</PRE>
+<A HREF="#mrpage">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#muddiff">[NEXT]</A>
+<BR>
+<HR><A NAME="muddiff"><H3>MUDDIFF</H3></A><PRE>
+  Topic: MUDDIFF
+  
+  Ok, so you come from a mudding background and want to jump on the mush
+  bandwagon.  The biggest thing behind the scenes is the power of the 
+  interpreted coding system (help coding).  Otherwise, here's the base
+  set of command differences you can use to get around things.
+  
+  As all muds are slightly different for command syntax, we obviously
+  can not cover all bases, but hopefully it's close enough you can grok
+  the changes.
+  
+  Mud Command                           Mush Equiv
+  ------------------------------------  -------------------------------------
+  tell &lt;player&gt; &lt;message&gt;               page &lt;player&gt;=&lt;message&gt;
+  emote &lt;text&gt;                          pose &lt;text&gt; (or :&lt;text&gt;)
+  say &lt;text&gt;                            say &lt;text&gt; (or &quot;&lt;text&gt;)
+  spoof &lt;text&gt;                          @emit &lt;text&gt; (or \\&lt;text&gt;)
+  inventory                             inventory
+  score                                 score (fairly meaningless)
+  examine/decompile                     examine/@decompile
+  oset &lt;id&gt;=&lt;attrib&gt;:&lt;value&gt;            &amp;&lt;attrib&gt; &lt;object&gt;=&lt;value&gt; or
+                                        @set &lt;object&gt;=&lt;attrib&gt;:&lt;value&gt;
+  mset &lt;id&gt;=&lt;attrib&gt;:&lt;value&gt;            &amp; or @set again.
+  @force                                @force
+  @teleport                             @teleport
+  home                                  home
+  look                                  look
+  goto/move                             goto/move (or just type exitname)
+  save                                  [mush saves automatically]
+  quit                                  quit
+  
+  There's obviously other similar commands, but this should get you going
+  on the basics.
+  
+  See Also: DIFFERENCES, CODING
+
+</PRE>
+<A HREF="#msecs()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#mudname()">[NEXT]</A>
 <BR>
 <HR><A NAME="mudname()"><H3>MUDNAME()</H3></A><PRE>
@@ -26806,7 +34764,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: version(), version
   
 </PRE>
-<A HREF="#mrpage">[PREV]</A>
+<A HREF="#muddiff">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mul()">[NEXT]</A>
 <BR>
@@ -26937,7 +34895,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#name()">[NEXT]</A>
 <BR>
 <HR><A NAME="name()"><H3>NAME()</H3></A><PRE>
-  name(&lt;dbref&gt;[,&lt;newname&gt;])
+  name(&lt;dbref&gt;[,&lt;newname&gt; [,&lt;key&gt;]])
    
   This function returns the name of the indicated object.  When called with
   an exit it returns the only the first alias.
@@ -26946,6 +34904,9 @@ Generated: Wed Jan 13 04:15:48 2016
   the target is set SIDEFX, you may use the second option of this to set
   the target dbref with the new name.  All permissions and limitations to
   @name hold true of this side-effect.
+  
+  If &lt;key&gt; is specified as '1', then name() will behave like @name/ansi and
+  combine @extansi and @name effectively colorzing the target name.
   
   Example:
     &gt; say name(me)
@@ -27053,12 +35014,15 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#neq()">[NEXT]</A>
 <BR>
 <HR><A NAME="neq()"><H3>neq()</H3></A><PRE>
-  Function: neq(&lt;integer1&gt;,&lt;integer2&gt;)
- 
-  Takes two integers, and returns 1 if they are not equal and 0 if they are
-  equal.  Warning: passing anything but integers will produce unexpected
+  Function: neq(&lt;integer1&gt;, &lt;integer2&gt; [,&lt;integer3&gt;,...])
+   
+  Takes two (or more) integers, and returns 1 if one of the integers
+  are different or '0' if they are all the same.  This function handles 
+  floating point numbers as well.
+  
+  Warning: passing anything but integers will produce unexpected
   results, as non-numeric strings usually are treated as numeric 0.
- 
+   
   Examples:
     &gt; say neq(1,-1)
     You say &quot;1&quot;
@@ -27066,6 +35030,10 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;0&quot;
     &gt; say neq(foo, bar)
     You say &quot;0&quot;
+    &gt; say neq(5,5,5,5,5,5)
+    You say &quot;0&quot;
+    &gt; say neq(5,5,5,3,5,5)
+    You say &quot;1&quot;
   
   See Also: lt(), lte(), gte(), gt(), eq(), not()
   
@@ -28219,10 +36187,29 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#npemit()">[NEXT]</A>
 <BR>
 <HR><A NAME="npemit()"><H3>NPEMIT()</H3></A><PRE>
-  Function: npemit(&lt;object&gt; [&lt;object2&gt; ...],&lt;string&gt;)
+  Function: npemit(&lt;object&gt; [&lt;object2&gt; ...],&lt;string&gt; [,&lt;key&gt;])
   
   The npemit() function works like pemit() except it won't strip spaces.
   
+  &lt;key&gt; if specified to '1' evaluates '##' as each &lt;object&gt; in the list.
+  
+  This executes the exact same code as pemit(), but with the assumption
+  of the compile time option secure_sideeffects enabled.  This is the
+  default behavior.
+  
+  Ergo: This function is exactly the same as pemit() with the compile
+        option 'secure_sideeffects' enabled.  This function is left
+        in to ensure 'secure_sideeffect' behavior exists for npemit
+        regardless of compile time options specified.
+  
+  This function is essentially left for compatibility reasons and not
+  really needed anymore, except when compiling specificaly without
+  the default behavior.  The example below will always be pretty much
+  the same regardless of what option you have.  Without the option
+  secure_sideeffect, it essentially causes a double-eval which while
+  not the preferred method is backward compatible to very old versions
+  of RhostMUSH, MUX, and TinyMUSH.
+     
   Example:
   &gt; @pemit/list me me=test
   test
@@ -28272,7 +36259,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say nsiter(Was it a cat I saw,words(##),s)
     You say &quot;141&quot;
   
-  See Also: iter(), citer(), @dolist, parse(), list()
+  See Also: iter(), citer(), @dolist, parse(), list(), inf()
   
 </PRE>
 <A HREF="#npemit()">[PREV]</A>
@@ -28290,7 +36277,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say [null(this is a test[setq(0,test)])]- [r(0)]
     You say &quot;- test&quot;
   
-  See Also: localize(), eval(), @@(), privatize()
+  See Also: localize(), eval(), subeval(), @@(), privatize(), sandbox(),
+            stderr()
   
 </PRE>
 <A HREF="#nsiter()">[PREV]</A>
@@ -28307,7 +36295,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say num(me)
     You say &quot;#123&quot;
    
-  See Also: locate(), rnum()
+  See Also: locate(), rnum(), objid()
   
 </PRE>
 <A HREF="#null()">[PREV]</A>
@@ -28323,7 +36311,9 @@ Generated: Wed Jan 13 04:15:48 2016
   digest()      - Returns digest information for encryption algorithms.
   fbound()      - Bounds a floating point between a min and max value.
   floor()       - Returns the largest integer less than &lt;number&gt;
+  mask()        - Applies a specified mask to a value.
   pack()        - Returns the equivalent of a given number using a radix.
+  packmath()    - Applies math to the compressed radix value.
   roman()       - Returns the Roman Numerals for the specified number.
   spellnum()    - List the long name of the number fed into it.
   tobin()       - Converts a number to binary.
@@ -28490,6 +36480,7 @@ Generated: Wed Jan 13 04:15:48 2016
   hasattrp()    - Like hasattr(), but also checks parents.
   hasflag()     - Returns true if an object has the specified flag set.
   hastoggle()   - Returns true if an object has the specified toggle set.
+  hastotem()    - Returns true if an object has the specified totem set.
   hastype()     - Returns true if an object is of the specified type.
   home()        - Returns the objects home.
   lastcreate()  - Returns the dbref of the object last created.
@@ -28500,6 +36491,7 @@ Generated: Wed Jan 13 04:15:48 2016
   lflags()      - Like flags, but returns the full string names of flags.
   lock()        - Returns the named lock on the object, or sets a lock.
   ltoggles()    - Lists all toggles a player has.
+  ltotems()     - Lists all totems a player has.
   lzone()       - Returns the zone list of an object.
   
   { Continued in object information functions2 }  
@@ -28515,8 +36507,10 @@ Generated: Wed Jan 13 04:15:48 2016
   name()        - Returns the name of an object.
   obj()         - Returns the proper objective pronoun of an object.
   objeval()     - Evaluates code from a specified objects' perspective.
-  orflag()      - Checks if the target has one of the specified flags.
+  orflag()      - Checks if the target has one of the specified flag letters.
   orflags()     - Checks if the target has any of the specified flags.
+  ortotem()     - Checks if the target has one of the specified totem letters.
+  ortotems()    - Checks if the target has any of the specified totems.
   parent()      - Returns the parent object of an object.
   pgrep()       - Returns a list of matching attributes over parents.
   poss()        - Returns the possessive pronoun of an object.
@@ -28584,10 +36578,34 @@ Generated: Wed Jan 13 04:15:48 2016
   This evaluates the lwho() function at citizen level even if you are
   a wizard.
   
-  See Also: u(), u2(), get_eval(), objeval(), ueval() 
+  See Also: u(), u2(), get_eval(), objeval(), ueval(), streval(), sandbox()
   
 </PRE>
 <A HREF="#object types">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#objid()">[NEXT]</A>
+<BR>
+<HR><A NAME="objid()"><H3>OBJID()</H3></A><PRE>
+  Function: objid(&lt;object&gt;)
+  
+  Returns the object id of the object.  This essentially is the dbref#
+  combined with the created time stamp (in julian seconds) that the object
+  was created to allow a fully unique identifier.
+  
+  This basically returns in the form &lt;dbref&gt;:&lt;secs&gt;.  
+  
+  If timestamps are not enabled on the mush, the object was created prior
+  to timestamps being enabled, or the object is toggled to ignore timestamps,
+  then this function will just return the dbref#.
+  
+  Example:
+    &gt; say objid(me)
+    You say &quot;#123:2848482828&quot;
+  
+  See Also: num(), rnum(), locate()
+
+</PRE>
+<A HREF="#objeval()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#oemit()">[NEXT]</A>
 <BR>
@@ -28616,17 +36634,17 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: lemit(), pemit(), emit(), @oemit, SIDEEFFECTS
   
 </PRE>
-<A HREF="#objeval()">[PREV]</A>
+<A HREF="#objid()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#ofparse()">[NEXT]</A>
 <BR>
 <HR><A NAME="ofparse()"><H3>OFPARSE()</H3></A><PRE>
   Function: ofparse(&lt;type&gt;, [&lt;eval1&gt; [,&lt;eval2&gt; ... &lt;evalN or delim&gt;]])
 
-  Type 1&amp;3: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 2&amp;4: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
-  Type 5&amp;7: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 6&amp;8: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
+  Type 1&amp;3: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 2&amp;4: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
+  Type 5&amp;7: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 6&amp;8: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
   
   This function will take each &lt;eval&gt; and returns it based on the &lt;type&gt;.
   
@@ -28670,10 +36688,10 @@ Generated: Wed Jan 13 04:15:48 2016
   (CONTINUED)
   Function: ofparse(&lt;type&gt;, [&lt;eval1&gt; [,&lt;eval2&gt; ... &lt;evalN or delim&gt;]])
 
-  Type 1&amp;3: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 2&amp;4: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
-  Type 5&amp;7: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 6&amp;8: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
+  Type 1&amp;3: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 2&amp;4: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
+  Type 5&amp;7: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 6&amp;8: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
   Examples:
     &gt; say ofparse(1,0,2)
     You say &quot;2&quot;
@@ -28836,6 +36854,91 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#orflag()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#ortotem()">[NEXT]</A>
+<BR>
+<HR><A NAME="ortotem()"><H3>ORTOTEM()</H3></A><PRE>
+  Function: ortotem(&lt;target&gt;, &lt;flag1&gt; [&lt;flag2&gt; ... &lt;flagN&gt;])
+  
+  This function checks if the target has one or more of the specified toggles.
+  
+  You may specify if the target does not have a given totem with the not (!)
+  operator.
+  
+  Examples:
+    &gt; say ltotems(me)
+    You say &quot;ONE TWO THREE FOUR&quot;
+    &gt; say ortotem(me,one zero seventeen)
+    You say &quot;1&quot;
+    &gt; say ortotem(me,zero notatotem)
+    You say &quot;0&quot;
+    &gt; say ortotem(me,!zero !notatotem)
+    You say &quot;1&quot;
+  
+  See Also: andtotems(), ortotems(), andtotem(), ltotems(), totems(),
+            hastotem(), @totem
+  
+</PRE>
+<A HREF="#orflags()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ortotems()">[NEXT]</A>
+<BR>
+<HR><A NAME="ortotems()"><H3>ORTOTEMS()</H3></A><PRE>
+  Function: ortotems(&lt;target&gt;, &lt;flag-list1&gt; [,&lt;flag-list2&gt;, [,&lt;flag-list3&gt;]])
+  
+  This function checks if the target has any of the specified totems.  You may
+  also specify the !&lt;letter&gt; to check if it does not have the specified totem.
+  
+  If there is a totem that contains a '\' or a '!' you must escape it out
+  with the '\' escape character.
+  
+  Any inclusion of a '!' character will do reverse checking of the letter
+  following it.
+  
+  Normal totems will be in the flag-list1.
+  Any totem letters surrounded by []'s will be in the flag-list2.
+  Any totem letters surrounded by {}'s will be in the flag-list3.
+  
+  Examples:
+    &gt; say totems(me)
+    You say &quot;123[456]{789}&quot;
+    &gt; say ortotems(me,1,4,7)
+    You say &quot;1&quot;
+    &gt; say ortotems(me,,,9)
+    You say &quot;1&quot;
+    &gt; say ortotems(me,X,Y,8)
+    You say &quot;1&quot;
+    &gt; say ortotems(me,X,Y,Z)
+    You say &quot;0&quot;
+    &gt; say ortotems(me,X,Y,!Z)
+    You say &quot;1&quot;
+  
+  See Also: andtotems(), ortotem(), andtotem(), ltotems(), totems(),
+            hastotem(), @totem
+
+</PRE>
+<A HREF="#ortotem()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#outpageformat">[NEXT]</A>
+<BR>
+<HR><A NAME="outpageformat"><H3>OUTPAGEFORMAT</H3></A><PRE>
+  Attribute: &amp;outpageformat &lt;object&gt;[=&lt;message&gt;]
+             &amp;pageformat &lt;object&gt;[=&lt;message&gt;]
+  
+  &amp;PAGEFORMAT changes the message seen by &lt;object&gt; when it receives a page.
+  &amp;OUTPAGEFORMAT sets the message seen by &lt;object&gt; when it sends a page.
+  
+  %0 - will be set to the page message (not including :, ; or &quot;).
+  %1 - will be set to ':' ';' or '&quot;' for pose, semipose and normal page, 
+       reespectively.
+  %2 - will be set to the alias of the pager, if any.
+  %3 - will be a space-separated list of recipient dbrefs.
+  %4 - will be set to the default message (based on pageformat/outpageformat).
+  
+  { See 'help &amp;pageformat2' for examples. }
+
+</PRE>
+<A HREF="#ortotems()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#outputprefix">[NEXT]</A>
 <BR>
 <HR><A NAME="outputprefix"><H3>OUTPUTPREFIX</H3></A><PRE>
@@ -28848,7 +36951,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @robot, OUTPUTSUFFIX, ROBOT
   
 </PRE>
-<A HREF="#orflags()">[PREV]</A>
+<A HREF="#outpageformat">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#outputsuffix">[NEXT]</A>
 <BR>
@@ -28916,10 +37019,49 @@ Generated: Wed Jan 13 04:15:48 2016
     -bVxTM
    
   See Also: unpack(), crc32(), mask(), tobin(), tohex(), tooct(), todec(), 
-            roman()
+            roman(), packmath()
   
 </PRE>
 <A HREF="#owner()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#packmath()">[NEXT]</A>
+<BR>
+<HR><A NAME="packmath()"><H3>PACKMATH()</H3></A><PRE>
+  Function: packmath(&lt;number&gt;, &lt;radix&gt;, &lt;offset&gt; [[,&lt;math&gt; ][,&lt;offset-radix&gt;])
+  
+  This function applies the specified &lt;math&gt; to &lt;number&gt; by applying
+  the value of &lt;offset&gt;.  The value returned will be in the same &lt;radix&gt;
+  that you specified.  The &lt;radix&gt; allowed is 2 to 64.  If no &lt;math&gt;
+  is specified it assumes '+' (addition).
+  
+  If your &lt;offset&gt; is not in decimal (base 10), you may specify the optional
+  &lt;offset-radix&gt; to specify the radix that the value is in.
+   
+  The valid values for &lt;math&gt; are:
+    +  - apply addition (default)
+    -  - apply subtraction
+    *  - apply multiplication
+    /  - apply division
+    %  - apply modulus (use two %'s)
+  
+  Examples:
+    &gt; think pack(629126998,64)
+    bVxTM
+    &gt; think packmath(bVxTM,64,100)
+    bVxUw
+    &gt; think unpack(bVxUw,64)
+    629127098
+    &gt; think add(629126998,100)
+    629127098
+    &gt; think unpack(packmath(pack(629126998,64),64,5555),64)
+    629132553
+    &gt; think add(629126998,5555)
+    629132553
+  
+  See Also: pack(), unpack(), strmath()
+
+</PRE>
+<A HREF="#pack()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#page">[NEXT]</A>
 <BR>
@@ -28933,6 +37075,9 @@ Generated: Wed Jan 13 04:15:48 2016
  
   Note: If you are paging people with spaces in their name, start the page
         with a comma.  i.e.  page ,player with space, player2 = message
+  
+  You may use the &amp;PAGEFORMAT and &amp;OUTPAGEFORMAT attributes for format
+  incoming and outgoing pages.
   
   &lt;control&gt; is the formatter for the page (&quot;, ;, :, etc)
   
@@ -28957,7 +37102,7 @@ Generated: Wed Jan 13 04:15:48 2016
 { 'help page2' for more }
   
 </PRE>
-<A HREF="#pack()">[PREV]</A>
+<A HREF="#packmath()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#page2 ">[NEXT]</A>
 <BR>
@@ -28981,15 +37126,69 @@ Generated: Wed Jan 13 04:15:48 2016
          the same.
   
   See Also: pose, say, whisper, :, ;, &quot;, @pemit, @away, @idle, @reject,
-            rpage, lpage, mrpage
+            rpage, lpage, mrpage, PAGEFORMAT, OUTPAGEFORMAT
   
 </PRE>
 <A HREF="#page">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#pageformat">[NEXT]</A>
+<BR>
+<HR><A NAME="pageformat"><H3>PAGEFORMAT</H3></A><PRE>
+  Attribute: &amp;outpageformat &lt;object&gt;[=&lt;message&gt;]
+             &amp;pageformat &lt;object&gt;[=&lt;message&gt;]
+  
+  &amp;PAGEFORMAT changes the message seen by &lt;object&gt; when it receives a page.
+  &amp;OUTPAGEFORMAT sets the message seen by &lt;object&gt; when it sends a page.
+  
+  %0 - will be set to the page message (not including :, ; or &quot;).
+  %1 - will be set to ':' ';' or '&quot;' for pose, semipose and normal page, 
+       reespectively.
+  %2 - will be set to the alias of the pager, if any.
+  %3 - will be a space-separated list of recipient dbrefs.
+  %4 - will be set to the default message (based on pageformat/outpageformat).
+  
+  { See 'help &amp;pageformat2' for examples. }
+
+</PRE>
+<A HREF="#page2 ">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#pageformat2">[NEXT]</A>
+<BR>
+<HR><A NAME="pageformat2"><H3>pageformat2</H3></A><PRE>
+  Attribute: &amp;outpageformat &lt;object&gt;[=&lt;message&gt;]    (CONTINUED)
+             &amp;pageformat &lt;object&gt;[=&lt;message&gt;]
+  
+  Examples:
+    &gt; &amp;pageformat me=\[[time()]\] %4
+    Set.
+    &gt; @outpageformat me=\[[time()]\] %4
+    Set.
+
+    (To obtain @toggle vpage behavior:)
+    &gt; &amp;pageformat me=[setq(0,%n[if(%2,%b(%2))],1,switch(%3,%!,,elist(iter(%3,
+                     name(##),%b,|),,|)))][switch(%1,&quot;,%q0 pages[if(%q1,%b%q1)]:
+                     %0,:,From afar[if(%q1,%b(to %q1))]\, %q0 %0,
+                     From afar[if(%q1, %b(to %q1))]\, %q0%0)]
+    Set.
+
+    (To obtain no @toggle vpage behavior:)
+    &gt; &amp;pageformat me=[setq(1,switch(%3,%!,,elist(iter(%3,name(##),%b,|),,|)))]
+                     [switch(%1,&quot;,%n pages[if(%q1,%b%q1)]: %0,:,From 
+                     afar[if(%q1,%b(to %q1))]\, %n %0,From 
+                     afar[if(%q1,%b(to %q1))]\, %n%0)]
+    Set.
+  
+    Both examples above will return how 'page' would normally show.
+  
+  See Also: page, lpage, rpage, mrpage
+
+</PRE>
+<A HREF="#pageformat">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#parenmatch()">[NEXT]</A>
 <BR>
 <HR><A NAME="parenmatch()"><H3>PARENMATCH()</H3></A><PRE>
-  Function: parenmatch([&lt;object&gt;/]&lt;attribute&gt; [,&lt;type&gt;, [&lt;key&gt;]])
+  Function: parenmatch([&lt;object&gt;/]&lt;attribute&gt; [,&lt;type&gt;, [&lt;key&gt;], [&lt;flags&gt;]])
   
   This function returns an ansified match of parenthesis, brackets, and braces
   while hilighting red any mis-matched of the three.  The comparison will 
@@ -28998,7 +37197,7 @@ Generated: Wed Jan 13 04:15:48 2016
   and braces, it is possible the result will be cut off as ansi takes up 
   extra spaces.  If this is the case, use type '1' to just return 
   errors (if any).  An optional key of '1' will issue a pretty-print of the
-  output in addition to the color output.
+  output in addition to the color output.  You may specify more than one flag.
   
   The following types exist:
     0 - Ansify the string and highlight red the first missmatch found (default)
@@ -29009,6 +37208,12 @@ Generated: Wed Jan 13 04:15:48 2016
     1 - pretty print the output.  Be aware on attribs that approach the 
         maximum output buffer size you may get values cut off.
   
+  The following flags exist:
+    s - put spaces after every , and ; character and before and after =
+    p - put spaces before ) and after (
+    b - put spaces before ] and after [
+    B - put spaces before } and after {
+  
   Examples:
     &gt; @va me=[add(1,1)]
     &gt; @vb me=[add(1,2))]
@@ -29016,11 +37221,13 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;[add(1,2))]&quot;       (The second ')' would be hilighted red)
     &gt; say parenmatch(vb,1)
     You say &quot;[add(1,2))]&quot;       (Just the second ')' would be colorized)
+    &gt; say parenmatch(vb,,,bps)
+    You say &quot;[ add( 1, 2 ) )]&quot;  (it stops adding spaces on an error)
   
   See Also: parenstr(), brackets(), pos(), totpos()
   
 </PRE>
-<A HREF="#page2 ">[PREV]</A>
+<A HREF="#pageformat2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#parenstr()">[NEXT]</A>
 <BR>
@@ -29181,10 +37388,21 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#parents()">[NEXT]</A>
 <BR>
 <HR><A NAME="parents()"><H3>PARENTS()</H3></A><PRE>
-  Function: parents(&lt;obj&gt;)
+  Function: parents(&lt;obj&gt; [,&lt;objid&gt;])
   
   Returns all the parents of &lt;obj&gt;.  Returns #-1 if &lt;obj&gt; cannot be found
   or has no parent or if you do not own and/or control &lt;obj&gt;
+  
+  If the optional &lt;objid&gt; is specified as '1', then it returns the objid's 
+  instead of the dbref#'s.
+  
+  By default, if you can not examine any of the parents in the chain, then
+  it will not show you the parent of that chain. 
+ 
+  If the @admin parameter 'parent_follow' is enabled, which is the default,
+  then if you control the &lt;obj&gt; you will see the entire parent chain,
+  regardless of your control or examine permissions of those parents in 
+  the chain.  We felt this should be the proper default behavior.
   
   Example:
     &gt; say parents(me)
@@ -29195,6 +37413,8 @@ Generated: Wed Jan 13 04:15:48 2016
     Parent set.
     &gt; say parents(#4)
     You say &quot;#5 #6&quot;
+    &gt; say parents(#4,1)
+    You say &quot;#5:8185828582 #6:8281859282&quot;
   
   See Also: parent(), children()
   
@@ -29204,12 +37424,12 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#parse()">[NEXT]</A>
 <BR>
 <HR><A NAME="parse()"><H3>PARSE()</H3></A><PRE>
-  Function: parse(&lt;list&gt;,&lt;eval&gt;[,&lt;delimiter&gt; [,&lt;output seperator&gt;]])
+  Function: parse(&lt;list&gt;,&lt;eval&gt;[,&lt;delimiter&gt; [,&lt;output separator&gt;]])
   
   This function takes each element of &lt;list&gt;, evaluates &lt;eval&gt; after
   substituting it for ##, and constructs a space-separated list of the
   results.  The special substitution of #@ can be used for the position
-  of the current item in the list.  You may specify an output seperator.
+  of the current item in the list.  You may specify an output separator.
   
   This function can be reproduced with the iter function and as
   such is considered depreciated but left for compatibility.
@@ -29232,7 +37452,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say nsiter(Was it a cat I saw,words(##),s)
     You say &quot;141&quot;
   
-  See Also: iter(), citer(), @dolist, parse(), list()
+  See Also: iter(), citer(), @dolist, parse(), list(), inf()
   
   
 </PRE>
@@ -29242,8 +37462,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="parsestr()"><H3>PARSESTR()</H3></A><PRE>
   Function: parsestr(&lt;string&gt;, &lt;eval&gt; [,&lt;delim&gt; [.&lt;output&gt; [,&lt;type&gt;]
-                       [,[&amp;]&lt;target&gt;] [,&lt;transchar&gt; [,&lt;endchar&gt; [,&lt;transeval&gt;]
-                       [,&lt;prefix&gt;]]]]])
+                       [,[&amp;]&lt;target&gt;] [,&lt;transchar&gt; [,&lt;endchar&gt; [,&lt;transeval&gt;
+                       [,&lt;prefix&gt; [,&lt;oocprefix&gt;]]]]]]])
   
   This function takes an input string and parses it, based on the 
   delimiters, in a 'staggered' method, and passes each substring to
@@ -29266,6 +37486,7 @@ Generated: Wed Jan 13 04:15:48 2016
                    processing on. (good for punctuation)
     &lt;transeval&gt; -- How you wish to parse the special processing string.
     &lt;prefix&gt;    -- The optional eval'd prefix to use for the 'say' string.
+    &lt;oocprefix&gt; -- optional prefix to use when the @emit (|) option used.
   
   Note on &lt;eval&gt;: All arguments passed will be as in the &lt;eval&gt; and &lt;transeval&gt;
             %0  -- The string being passed for evaluation.      
@@ -29303,7 +37524,7 @@ Generated: Wed Jan 13 04:15:48 2016
   If you do not specify a &lt;prefix&gt; then all prefix args are considered part
   of a normal string and ignored for special consideration.
   
-{ see 'help prsestr3' for examples }
+{ see 'help parsestr3' for examples }
 
 </PRE>
 <A HREF="#parsestr()">[PREV]</A>
@@ -29372,7 +37593,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Note: It will auto-close double quotes if it detects a non-escaped odd count.
         Also note the colorizations will be displayed appropiately.
   
-  See Also: garble(), parse(), iter(), strmath(), spellnum()
+  See Also: garble(), parse(), iter(), strmath(), spellnum(), inf()
   
 </PRE>
 <A HREF="#parsestr3">[PREV]</A>
@@ -29404,17 +37625,18 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#pemit()">[NEXT]</A>
 <BR>
 <HR><A NAME="pemit()"><H3>PEMIT()</H3></A><PRE>
-  Function: pemit(&lt;object&gt; [&lt;object2&gt; ...],&lt;string&gt; [,&lt;key&gt;])
+  Function: pemit(&lt;object1&gt; [&lt;object2&gt; ... &lt;objectN&gt;], &lt;string&gt; [,&lt;key&gt;])
   
   The pemit() function is a side-effect for the @pemit/list command.  All
   restrictions and permissions of that command follow this function.  The
-  SIDEFX flag is required to use pemit().
+  SIDEFX flag is required to use pemit().  Pemit() by default evaluates
+  for every target in the list.  It does NOT evaluate ## by default.
   
-  You may specify an optional &lt;key&gt; of '1' if you wish to have ##
-  substituted for every target object in the list.  Keep in mind the '##'
-  is pre-processed like iter's ## would be and could be a security risk
-  if used improperly.  I'd strongly suggest filtering the target list
-  as dbref#'s to keep it safe.
+  The following key values are allowable:
+    1 - will have ## substituted for every target object in the list.  Keep 
+        in mind the '##' is pre-processed like iter's ## would be and could 
+        be a security risk if used improperly.  
+    2 - only evaluate once.  This by default disables ## from evaluation.
   
   Type @list options to see if this side-effect is enabled.
   
@@ -29537,15 +37759,25 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#pickrand()">[NEXT]</A>
 <BR>
 <HR><A NAME="pickrand()"><H3>pickrand()</H3></A><PRE>
-  Function: randextract(&lt;string&gt;[, &lt;numwords&gt;, &lt;delim&gt;, &lt;type&gt;, &lt;output sep&gt;])
+  Function: randextract(&lt;str&gt;[, &lt;numwords&gt;, &lt;delim&gt;, &lt;type&gt;, &lt;osep&gt;, &lt;weight&gt;])
   
   The randextract() function is unique but somewhat similar to extract(). 
   The randextract() function takes &lt;numwords&gt; number of words from the string
-  &lt;string&gt; and returns those words in random order.  You may specify an 
+  &lt;str&gt; and returns those words in random order.  You may specify an 
   optional delimiter &lt;delim&gt; other than a space (the default).  You may also 
   specify what &lt;type&gt; of randextract() you wish to perform.  The following 
-  types exist.  You may specify an optional output seperator else it uses
-  the same character as the delimiter.
+  types exist.  You may specify an optional output separator &lt;osep&gt; else it 
+  uses the same character as the delimiter.  You may apply a &lt;weight&gt; to each
+  word (using the same separator) that is a 1 to 1 order to the words in
+  &lt;str&gt;.  Any weights not applied to a word is assigned a normal weight of
+  '0'.  Each weight is a fuzzy multiplier of how often a word will be allowed 
+  to be picked with randextract.  It does this by applying a filter of weights
+  PRIOR to extracting the list.  Weight values start at '0' and max at '100'.
+  A weight of 100 you can be fairly assured will always appear.  Two weights
+  of 100 will have a 50/50 chance of appearing while the remaining would
+  have a rough estimate of a 1/100 chance of appearing.
+  
+  Valid types are:
       L - Grab given number of words lineally from the first random selection
       R - Grab &lt;numwords&gt; number of words but do not duplicate matches
       D - Grab &lt;numwords&gt; number of words and allow duplicate matches
@@ -29561,6 +37793,10 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;this test a&quot;
     &gt; say randextract(this is a test,3,,D)
     You say &quot;this a this&quot;
+    &gt; say randextract(this is a test,3,,D,,0 3 0)
+    You say &quot;is this is is this test is this is is&quot; (is has a 3x more chance)
+    &gt; say randextract(this is a test,10,,D,,0 3 0)
+    You say &quot;is is is this is is this is is is&quot; (is has a 10x more chance)
   
   See Also: randpos(), randmatch(), extract(), extractword(), index(), rand()
   
@@ -29570,7 +37806,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#pid()">[NEXT]</A>
 <BR>
 <HR><A NAME="pid()"><H3>PID()</H3></A><PRE>
-  Function: pid([&lt;display&gt; [,&lt;seperator&gt; [,&lt;type&gt; [,&lt;target&gt;]]])
+  Function: pid([&lt;display&gt; [,&lt;separator&gt; [,&lt;type&gt; [,&lt;target&gt;]]])
   
   This function returns the queue process table based on various arguments.
   
@@ -29583,10 +37819,10 @@ Generated: Wed Jan 13 04:15:48 2016
     16   -  Show the STOP/RUNNING status of all the processes
     32   -  Show the commands queued for all the processes.
   
-  Adding the &lt;display&gt; values will return a combination of the values seperated
+  Adding the &lt;display&gt; values will return a combination of the values separated
   by the pipe (|) character.
   
-  &lt;seperator&gt; is your output seperator that you wish between processes.  
+  &lt;separator&gt; is your output separator that you wish between processes.  
   Default is a space.
   
   &lt;type&gt; can be one of many types.
@@ -29608,7 +37844,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="pid2"><H3>PID2</H3></A><PRE>
   CONTINUED
-  Function: pid([&lt;display&gt; [,&lt;seperator&gt; [,&lt;type&gt; [,&lt;target&gt;]]])
+  Function: pid([&lt;display&gt; [,&lt;separator&gt; [,&lt;type&gt; [,&lt;target&gt;]]])
  
   Examples:
     &gt; @ps/all 
@@ -29678,6 +37914,22 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#player">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#plushelp">[NEXT]</A>
+<BR>
+<HR><A NAME="plushelp"><H3>plushelp</H3></A><PRE>
+  If enabled (please check @list options), this will work just like normal
+  'help' does, but for +help.  This is intended for TINY/MUX compatibility
+  and is disabled by default.
+  
+  The following switches work for +help:
+    /search -- allow wildcard patterning for searches (Eg: help/search *@mail*)
+    /query  -- allow detailed searching and return (Eg: help/query *@mail*)
+  
+  See Also: help 
+
+</PRE>
+<A HREF="#player information functions">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#pmatch()">[NEXT]</A>
 <BR>
 <HR><A NAME="pmatch()"><H3>PMATCH()</H3></A><PRE>
@@ -29701,7 +37953,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: num(), pfind()
   
 </PRE>
-<A HREF="#player information functions">[PREV]</A>
+<A HREF="#plushelp">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#port()">[NEXT]</A>
 <BR>
@@ -29750,11 +38002,24 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="pose"><H3>pose</H3></A><PRE>
   Command: pose[/&lt;switches&gt;] &lt;message&gt;
+  
   Displays &lt;message&gt; to everyone in your current room, preceded by your name
-  and optionally a space.  Example: the command 'pose jumps for joy' produces
-  '&lt;yourname&gt; jumps for joy'.
+  and optionally a space.  
   
   No switches are available for the ':' or ';' shorthands.
+  
+  You may use two special attributes for pre and post processing of any
+  says you receive.  These attributes will have substitutions evaluated
+  but will not evaluate functions.  If these attributes are set NO_COMMAND
+  then they will not be processed.
+    SPEECH_PREFIX  -- Contents will be evaluated before the say/pose/emit.
+    SPEECH_SUFFIX  -- Contents will be evaluated after the say/pose/emit.
+  
+  Both of these attributes handle three arguments.  These are:
+    %0 - The original say/pose that triggered the attribute.
+    %1 - The date in the form MM/DD/YYYY
+    %2 - The time in the form HH:MM:SS
+    %3 - The dbref# of the player issuing the say/pose/emit (#-1 if spoofed)
    
   The following switches are available:
      /default - (default) Put a space between your name and the message
@@ -29764,6 +38029,10 @@ Generated: Wed Jan 13 04:15:48 2016
      /noansi   - Show the string literally and don't process ansi.  Only
                  useful with ZENTY_ANSI enabled (at compiletime).
  
+  Example: (assuming your name is Bob)
+    &gt; pose jumps for joy
+    Bob jumps for joy
+  
   See Also: page, say, whisper, :, ;, &quot;
   
 </PRE>
@@ -29838,6 +38107,73 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#power()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#printf borders">[NEXT]</A>
+<BR>
+<HR><A NAME="printf borders"><H3>PRINTF BORDERS</H3></A><PRE>
+  Function: printf(&lt;format string&gt;,&lt;arg1&gt; [,&lt;arg2&gt;, ..., &lt;argN&gt;])
+  
+  Borders for printf is actually pretty easy.  You assign a field width
+  and give it the '&amp;' option to tell it to repeat on a carriage return.
+  You then give it an argument of '%r' and it will continue to repeat
+  that column for as long as any other column has valid lines.   You can
+  have the field width greater than 1 char for multi-char borders.
+  
+  You will want to put a '.' for these fields to supress a final line
+  of carriage returns if the last line is empty.
+  
+  The following codes are utilized (see 'help printf codelist')
+    $ - Specify the start of the format
+    s - specify the end of the format (where the substitution occurs)
+    . - do not print last line if all fields have '.' and all fields empty 
+    : - use the specified filler specified between the ':''s (ergo :|:)
+    &amp; - repeat column if a carriage return is detected
+    - - left justify the column
+    | - wrap column if length of argument is greater than the field width
+    &quot; - wrap column on a space character (tab, space, etc) if possible
+    ; - handle indentation
+    / - handle cutting
+   10 - set column width to 10 characters
+    7 - set column width to 7 characters
+  
+{ see 'help printf borders2' for the examples }
+
+</PRE>
+<A HREF="#power10()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#printf borders2">[NEXT]</A>
+<BR>
+<HR><A NAME="printf borders2"><H3>PRINTF BORDERS2</H3></A><PRE>
+  Syntax for Example:
+    &gt; printf(&lt;codelist1&gt; &lt;codelist2&gt; &lt;codelist3&gt;, &lt;arg1&gt;, &lt;arg2&gt;, &lt;arg3&gt;)
+  
+  Example:
+    &gt; think printf($.1:|:&amp;s $-10|&quot;s $1.:|:&amp;s, %r, test, %r)
+    | test       |
+    &gt; think printf($.1:|:&amp;s $-10|&quot;s $1.:|:&amp;s, %r, test1 test2, %r)
+    | test1      |
+    | test2      |
+    &gt; think printf($.1:|:&amp;s $-10|&quot;s $1.:|:&amp;s, %r, test1 test2 test3, %r)
+    | test1      |
+    | test2      |
+    | test3      |
+    &gt; think printf($.7:|+=:&amp;s $-10|&quot;s $7.:|+=:&amp;s, %r, test1 test2 test3, %r)
+    |+=|+=| test1      |+=|+=|
+    |+=|+=| test2      |+=|+=|
+    |+=|+=| test3      |+=|+=|
+    &gt; think [repeat(-,26)]%r[printf($.7:|+=:&amp;s $-10|&quot;s $7.:|+=:&amp;s, %r, test1 test2
+            test3, %r)]%r[repeat(-,26)]  
+    --------------------------
+    |+=|+=| test1      |+=|+=|
+    |+=|+=| test2      |+=|+=|
+    |+=|+=| test3      |+=|+=|
+    --------------------------
+
+  See Also: printf(), printf examples
+
+
+</PRE>
+<A HREF="#printf borders">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#printf codelist">[NEXT]</A>
 <BR>
 <HR><A NAME="printf codelist"><H3>PRINTF CODELIST</H3></A><PRE>
@@ -29853,17 +38189,23 @@ Generated: Wed Jan 13 04:15:48 2016
          $ - specifies to tell printf() to start/initiate the format.
          s - specifies the location of a string substitution for formatting.
       Code Fields: 
-         ! - do not display value if null
+         . - if on every field, do not display line if on last line and if
+             all values will result in a completely blank line.
+         ! - do not display value if null (if using &lt; and/or &gt; place ! after)
+         @ - do not display value if null or previous value is null
+         &lt; - null current value if previous value was null
+         &gt; - null current value if next value is null
          - - left justify (right is default)
          ^ - center justify
          _ - stretch justify
          + - do not cut value if exceed value (default is cut off)
-         &amp; - process carrage returns and keep in same column field.  This
-             will break up lines based on carrage returns (%r) and keep
+         * - cut value from the right instead of the left.
+         &amp; - process carriage returns and keep in same column field.  This
+             will break up lines based on carriage returns (%r) and keep
              formatted into the same column specified in the format.
-         | - automatically format the text and insert carrage returns
+         | - automatically format the text and insert carriage returns
              at the specified padding field.  This does auto wrapping
-             like the '&amp;' option without the need for carrage returns.
+             like the '&amp;' option without the need for carriage returns.
          &quot; - When used in junction with '|' it will try to split columns
              on the first whitespace instead of always at width.
          ' - If specified on a field, and that column is empty, the 
@@ -29878,20 +38220,40 @@ Generated: Wed Jan 13 04:15:48 2016
                examples: :.:  -- fill with a single '.'
                          :!.: -- fill with a single '.' on non-blank lines.
                          :[ansi(hg,.,hb,.)]: -- fill with multi-color.
+             Note: For ':' in formatting, use %&lt;058&gt; instead of :
          / - The numerical value specified between /&lt;number&gt;/ will be used
              as a cut-off value when using the '|' wrap option.  
                examples: /10/ -- when using '|' cut off after 10 characters.
-             Valid values: 0-3998 (0 is unlimited)
+             Use of /w&lt;number&gt;/ cuts off on the line when '|' and '&quot;' is used.
+               examples: /w1/ -- when using '|&quot;' cut off after first line.
+             Valid values: 0 - (LBUF - 100) (0 is unlimited)
+         # - Convert tabs to spaces.  You may specify a value between #'s
+             to specify a specific number of spaces (from 1 to 10) otherwise
+             if uses the default of four (4) spaces.
+               examples: #   -- Convert all tabs to 4 spaces
+                         #7# -- Convert all tabs to 7 spaces
+         ; - indent the next wrapped line of text (used with | option only)
+             must be placed after the width value.  The maximum allowed
+             will be width - 1.  It will shorten to this if too large.
+             The maximum indent is 70 characters.  A period followed by
+             a number will specify the line it should start indenting.
+               examples: ;     -- indent default 4 (or width - 1) spaces
+                         ;8;   -- indent 8 spaces (or width -1) spaces
+                         ;8.3; -- indent 8 spaces after line 3.
       Value fields:
-         1-3000 - format value to padd
+         1-(LBUF-100) - format value to padd.  Current LBUF size - 100.
+                        See: @list options system for current LBUF size.
+                        Example: 4000 LBUF, it would be 1-3900
          0 - if prepending a number, tells it to padd 0's.
   
   Note: The ` and ' code fields won't work on single line columns.
+        The * option is not compatible with the &amp; option.
    
-  See Also: center(), just(), rjust(), rjc(), ljc(), wrap(), columns()
+  See Also: center(), just(), rjust(), rjc(), ljc(), wrap(), columns(), 
+            template()
   
 </PRE>
-<A HREF="#power10()">[PREV]</A>
+<A HREF="#printf borders2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#printf examples">[NEXT]</A>
 <BR>
@@ -30187,7 +38549,8 @@ Generated: Wed Jan 13 04:15:48 2016
   
   CR -- Carrage Return, LN - Line, SP - Space
    
-  See Also: center(), just(), rjust(), rjc(), ljc(), wrap(), columns()
+  See Also: center(), just(), rjust(), rjc(), ljc(), wrap(), columns(),
+            template()
 
 </PRE>
 <A HREF="#printf penn2">[PREV]</A>
@@ -30205,9 +38568,10 @@ Generated: Wed Jan 13 04:15:48 2016
   FORMAT SYNTAX:        help printf syntax
   EXAMPLES:             help printf examples
                         help printf penn      (for penn align-like examples)
+                        help printf borders   (a quick example on borders)
   
   See Also: center(), just(), rjust(), rjc(), ljc(), wrap(), columns(), 
-            wrapcolumns(), array()
+            wrapcolumns(), array(), template()
 
 </PRE>
 <A HREF="#printf syntax ">[PREV]</A>
@@ -30234,22 +38598,48 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#privatize()">[NEXT]</A>
 <BR>
 <HR><A NAME="privatize()"><H3>PRIVATIZE()</H3></A><PRE>
-  Function: privatize(&lt;value&gt;)
+  Function: privatize(&lt;boolean&gt;)
+            privatize(&lt;boolean&gt; [,&lt;string&gt;, [,&lt;register-list&gt;, [&lt;key&gt;]]])
   
-  This function takes two values.  1 to enable or 0 to disable (default).
-  When enabled, any function call that is using localization for registers,
-  such as localize(), ulocal(), ueval(), uzfun(), etc, will be initialized
-  to a null (empty string) instead of housing the contents that was passed
-  to it (which is the default).  Keep in mind, this only initializes the
-  localized values, and once the localization is finished, the values are
-  returned to their previous value, as how localization is intended.
+  This function has two uses.  
   
-  The Values allowed are:
+  First, if you just pass a boolean (1) value to the function, it will 
+  optionally privatize everything that is localized.  It does this by 
+  initializing to null every register that is referenced within the localized
+  register.  A boolean of '0' turns off privatization.
+  
+  The second option allows you to pass a string to be evaluated which will
+  combine localize() and privatize() for the duration of the evaluation
+  of the string.  
+  
+  The register list can be 0-9 or a-z.  You can not use labels.  These will
+  be, by default, what registers will be privatized/localized.  
+  
+  The &lt;key&gt; if '1' will reverse the effect of &lt;register-list&gt; and effective
+  turn the list to an omission list.
+  
+  Once privatization is finished, functionality returns as normally expected. 
+  
+  The &lt;boolean&gt; allowed are:
     1 - Toggle on the feature to initialize to null all registers (%q0-z)
         that are used in localized functions (localize(), ulocal(), etc)
     0 - Toggle off the feature to initialize to null registers (default).
   
-  Example:
+{ see 'help privatize2' for examples }
+</PRE>
+<A HREF="#private">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#privatize2">[NEXT]</A>
+<BR>
+<HR><A NAME="privatize2"><H3>PRIVATIZE2</H3></A><PRE>
+  (CONTINUED)
+  Function: privatize(&lt;boolean&gt;)
+            privatize(&lt;boolean&gt; [,&lt;string&gt;, [,&lt;register-list&gt;, [&lt;key&gt;]]])
+  
+  For Example 1, we will show the difference between calling the function,
+  localizing the function, the privatizing before localizing the function.
+
+  Example: (option 1)
     &gt; @va me=(before R0: [r(0)])[setq(0,internal)] --My R0:[r(0)]--
     Set.
     &gt; say [setq(0,external)][r(0)][u(va)][r(0)]
@@ -30259,19 +38649,38 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say [privatize(1)][setq(0,external)][r(0)][localize(u(va))][r(0)]
     You say &quot;external--(before R0: ) My R0:internal--external&quot;
   
-  See Also: pushregs(), ulocal(), zfunlocal(), eval(), localize(), @lfunction
+  For Example 2, we show what it's like to essentially privatize a specific
+  evaluation which auto-localizes the results.
+  
+  Example: (option 2)
+    &gt; @va me=[setr(0,ONE)]:[r(1)]
+    Set.
+    &gt; say [setr(0,TWO)]:[setr(1,CHEESE)], [privatize(1,u(va))], %q0:%q1
+    You say &quot;TWO:CHEESE, ONE:, TWO:CHEESE&quot;
+    &gt; say [setr(0,TWO)]:[setr(1,CHEESE)], [privatize(1,u(va),0)], %q0:%q1
+    You say &quot;TWO:CHEESE, ONE:CHEESE, TWO:CHEESE&quot;
+    &gt; say [setr(0,TWO)]:[setr(1,CHEESE)], [privatize(1,u(va),1)], %q0:%q1
+    You say &quot;TWO:CHEESE, ONE:, ONE:CHEESE&quot;
+    &gt; say [setr(0,TWO)]:[setr(1,CHEESE)], [privatize(1,u(va),0,1)], %q0:%q1
+    You say &quot;TWO:CHEESE, ONE:, ONE:CHEESE&quot;
+
+  See Also: pushregs(), ulocal(), zfunlocal(), eval(), localize(), 
+            sandbox(), subeval(), @lfunction
 
 </PRE>
-<A HREF="#private">[PREV]</A>
+<A HREF="#privatize()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#programmer()">[NEXT]</A>
 <BR>
 <HR><A NAME="programmer()"><H3>PROGRAMMER()</H3></A><PRE>
-  Function: programmer(&lt;player&gt;)
+  Function: programmer(&lt;player&gt; [,&lt;key&gt;])
   Returns the dbref# of the enactor who placed the target player inside a
   program.  If the target player is not in a program, or if you do not
   have access to check the information, it returns '#-1'.
   
+  If &lt;key&gt; is specified as '1', it will return the #obj/attribute pair
+  that the person is currently in the programon.
+   
   Examples:
     &gt; say %#
     You say &quot;#123&quot;
@@ -30285,13 +38694,56 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;1&quot;
     &gt; |say programmer(me)
     You say &quot;#123&quot;
+    &gt; |say programmer(me,1)
+    You say &quot;me/va&quot;
     &gt; |@quitprogram
     @program cleared.
   
   See Also: @program, @quitprogram, programmer()
   
 </PRE>
-<A HREF="#privatize()">[PREV]</A>
+<A HREF="#privatize2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#protect_addenh">[NEXT]</A>
+<BR>
+<HR><A NAME="protect_addenh"><H3>protect_addenh</H3></A><PRE>
+  (CONTINUED)
+  Command: @protect[/&lt;switch&gt;] [&lt;player-name&gt;]  
+  
+  The following wizard @admin parameters exist (see wizhelp for help):
+    protect_addenh   -- this is the toggle that enables/disables enhanced adds
+    max_name_protect -- this controls total number of names to be protected
+  
+  Examples:
+    &gt; say [name(me)] [num(me)]
+    You say &quot;Bob #123&quot;
+    &gt; @protect/add
+    Your current name has been added to your protect list.
+    &gt; @protect/add Simon            (if enhanced mode enabled)
+    The name has been added to your protect list.
+    &gt; @protect/add Fred             (if enhanced mode enabled)
+    The name has been added to your protect list.
+    &gt; @protect/del Bob
+    You have successfully deleted 'Bob' from your protect list.
+    &gt; @protect/alias Simon
+    You have successfully activated 'simon' as an alias.
+    &gt; @protect/alias Fred
+    You have successfully activated 'fred' as an alias.
+    &gt; @protect/unalias Fred
+    You have successfully de-activated 'fred' as an alias.
+    &gt; @protect/list
+    +------------------------------+----------------------------------+-------+
+    | Player Name Protected        | Dbref#   [ Player Name         ] | Alias |
+    +------------------------------+----------------------------------+-------+
+    | Simon                        | #123     [ Bob                 ] |   Y   |
+    | Fred                         | #123     [ Bob                 ] |   N   |
+    +------------------------------+----------------------------------+-------+
+    You have 2 out of 10 names protected.
+  
+  See Also: @name, @alias, listprotection()
+  
+</PRE>
+<A HREF="#programmer()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#ptimefmt()">[NEXT]</A>
 <BR>
@@ -30312,7 +38764,7 @@ Generated: Wed Jan 13 04:15:48 2016
   This function is intended to mimic Penn's timefmt() function.
   
 </PRE>
-<A HREF="#programmer()">[PREV]</A>
+<A HREF="#protect_addenh">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#ptimefmt2">[NEXT]</A>
 <BR>
@@ -30592,15 +39044,25 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#randextract()">[NEXT]</A>
 <BR>
 <HR><A NAME="randextract()"><H3>randextract()</H3></A><PRE>
-  Function: randextract(&lt;string&gt;[, &lt;numwords&gt;, &lt;delim&gt;, &lt;type&gt;, &lt;output sep&gt;])
+  Function: randextract(&lt;str&gt;[, &lt;numwords&gt;, &lt;delim&gt;, &lt;type&gt;, &lt;osep&gt;, &lt;weight&gt;])
   
   The randextract() function is unique but somewhat similar to extract(). 
   The randextract() function takes &lt;numwords&gt; number of words from the string
-  &lt;string&gt; and returns those words in random order.  You may specify an 
+  &lt;str&gt; and returns those words in random order.  You may specify an 
   optional delimiter &lt;delim&gt; other than a space (the default).  You may also 
   specify what &lt;type&gt; of randextract() you wish to perform.  The following 
-  types exist.  You may specify an optional output seperator else it uses
-  the same character as the delimiter.
+  types exist.  You may specify an optional output separator &lt;osep&gt; else it 
+  uses the same character as the delimiter.  You may apply a &lt;weight&gt; to each
+  word (using the same separator) that is a 1 to 1 order to the words in
+  &lt;str&gt;.  Any weights not applied to a word is assigned a normal weight of
+  '0'.  Each weight is a fuzzy multiplier of how often a word will be allowed 
+  to be picked with randextract.  It does this by applying a filter of weights
+  PRIOR to extracting the list.  Weight values start at '0' and max at '100'.
+  A weight of 100 you can be fairly assured will always appear.  Two weights
+  of 100 will have a 50/50 chance of appearing while the remaining would
+  have a rough estimate of a 1/100 chance of appearing.
+  
+  Valid types are:
       L - Grab given number of words lineally from the first random selection
       R - Grab &lt;numwords&gt; number of words but do not duplicate matches
       D - Grab &lt;numwords&gt; number of words and allow duplicate matches
@@ -30616,6 +39078,10 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;this test a&quot;
     &gt; say randextract(this is a test,3,,D)
     You say &quot;this a this&quot;
+    &gt; say randextract(this is a test,3,,D,,0 3 0)
+    You say &quot;is this is is this test is this is is&quot; (is has a 3x more chance)
+    &gt; say randextract(this is a test,10,,D,,0 3 0)
+    You say &quot;is is is this is is this is is is&quot; (is has a 10x more chance)
   
   See Also: randpos(), randmatch(), extract(), extractword(), index(), rand()
   
@@ -30671,6 +39137,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="read"><H3>read</H3></A><PRE>
   Command: read [&lt;object&gt;]
+  
   Displays the description of &lt;object&gt;, or the room you're in if you don't
   specify an object.  Specifying object as &lt;name&gt; or #&lt;dbref&gt; or 'me' or
   'here' is legal.  You can also use look to look at objects held by other
@@ -30700,6 +39167,7 @@ Generated: Wed Jan 13 04:15:48 2016
   listrlevels() - Lists available reality levels in a space-separated list.
   rxlevel()     - Returns a space-separated list of target's rxlevels.
   txlevel()     - Returns a space-separated list of target's txlevels.
+  rxdesc()      - Returns a space-separated list of target's visible descs.
 
 </PRE>
 <A HREF="#read">[PREV]</A>
@@ -30728,7 +39196,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say startsecs()
     You say &quot;2324234&quot;
    
-  See Also: startime(), secs(), startsecs(), reboottime()
+  See Also: startime(), secs(), startsecs(), reboottime(), msecs()
   
 </PRE>
 <A HREF="#reality levels">[PREV]</A>
@@ -30745,7 +39213,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say reboottime()
     You say &quot;Sat Dec  7 00:09:13 1991
     
-  See Also: convtime(), starttime(), rebootsecs(), startsecs()
+  See Also: convtime(), starttime(), rebootsecs(), startsecs(), msecs()
   
 </PRE>
 <A HREF="#rebootsecs()">[PREV]</A>
@@ -30986,6 +39454,94 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#regeditilit()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#regexp casesensitive">[NEXT]</A>
+<BR>
+<HR><A NAME="regexp casesensitive"><H3>REGEXP CASESENSITIVE</H3></A><PRE>
+  Topic: REGEXPS2 (continued)
+  
+  Regular expressions are extremely useful when you want to enforce
+  a data type. For example, if you have a command where you want a
+  player to enter a string and a number ('+setnum &lt;player&gt;=&lt;number&gt;',
+  for example), you might do it like this:
+  
+  &gt; &amp;DO_NUM Command Object=$^\+setnum (.+)=([0-9]+)$: @va me=Data: %1 = %2
+  Set.
+  &gt; @set Command Object/DO_NUM = regexp
+  Set.
+  &gt; +setnum cookie=30
+  &gt; ex Command Object/va
+  Data: cookies = 30
+  &gt; &amp;DO_ZZ Command Object=$^zz:@pemit %#=I am case insensitive.
+  &gt; zz
+  I am case insensitive.
+  &gt; &amp;DO_ZZ Command Object=$^(?-i)zz:@pemit %#=I am case sensitive.
+  &gt; zz
+  I am case sensitive.
+  &gt; ZZ
+  Huh?  (Type 'help' for help)
+  
+  How it works:
+  '+setnum cookies=30' would set VA to &quot;Data: cookies = 30&quot;.
+  This eliminates your having to check to see if the player entered
+  a number, since the regular expression matches only numbers.
+  Furthermore, the '+' guarantees that there needs to be at least
+  one character there, so a player can't enter '+setnum cookies='
+  or '+setnum =10' or similarly malformed input.
+  
+  The '+' sign in the command has to be escaped out, or it is taken as
+  a regexp token. Furthermore, the pattern-match has to be anchored
+  with ^ and $, or something like 'try +setnum cookies=30 now' would
+  also match. Regexps are case-sensitive; wildcard globbing is not.
+  
+  Regular expression syntax is explained in 'help regexp syntax'.
+
+</PRE>
+<A HREF="#regeditlit()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#regexp casesensitivity">[NEXT]</A>
+<BR>
+<HR><A NAME="regexp casesensitivity"><H3>REGEXP CASESENSITIVITY</H3></A><PRE>
+  Topic: REGEXPS2 (continued)
+  
+  Regular expressions are extremely useful when you want to enforce
+  a data type. For example, if you have a command where you want a
+  player to enter a string and a number ('+setnum &lt;player&gt;=&lt;number&gt;',
+  for example), you might do it like this:
+  
+  &gt; &amp;DO_NUM Command Object=$^\+setnum (.+)=([0-9]+)$: @va me=Data: %1 = %2
+  Set.
+  &gt; @set Command Object/DO_NUM = regexp
+  Set.
+  &gt; +setnum cookie=30
+  &gt; ex Command Object/va
+  Data: cookies = 30
+  &gt; &amp;DO_ZZ Command Object=$^zz:@pemit %#=I am case insensitive.
+  &gt; zz
+  I am case insensitive.
+  &gt; &amp;DO_ZZ Command Object=$^(?-i)zz:@pemit %#=I am case sensitive.
+  &gt; zz
+  I am case sensitive.
+  &gt; ZZ
+  Huh?  (Type 'help' for help)
+  
+  How it works:
+  '+setnum cookies=30' would set VA to &quot;Data: cookies = 30&quot;.
+  This eliminates your having to check to see if the player entered
+  a number, since the regular expression matches only numbers.
+  Furthermore, the '+' guarantees that there needs to be at least
+  one character there, so a player can't enter '+setnum cookies='
+  or '+setnum =10' or similarly malformed input.
+  
+  The '+' sign in the command has to be escaped out, or it is taken as
+  a regexp token. Furthermore, the pattern-match has to be anchored
+  with ^ and $, or something like 'try +setnum cookies=30 now' would
+  also match. Regexps are case-sensitive; wildcard globbing is not.
+  
+  Regular expression syntax is explained in 'help regexp syntax'.
+
+</PRE>
+<A HREF="#regexp casesensitive">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#regexp classes">[NEXT]</A>
 <BR>
 <HR><A NAME="regexp classes"><H3>REGEXP CLASSES</H3></A><PRE>
@@ -31014,7 +39570,7 @@ Generated: Wed Jan 13 04:15:48 2016
 {continued in 'help regexp classes2'}
 
 </PRE>
-<A HREF="#regeditlit()">[PREV]</A>
+<A HREF="#regexp casesensitivity">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#regexp classes2">[NEXT]</A>
 <BR>
@@ -31109,7 +39665,7 @@ Generated: Wed Jan 13 04:15:48 2016
               or,  extends the meaning of ( after a (
        *      0 or more quantifier
        +      1 or more quantifier
-
+  
 {continued in 'help regexp syntax3'}
 
 </PRE>
@@ -31261,6 +39817,9 @@ Generated: Wed Jan 13 04:15:48 2016
   
   (This help text is largely from PennMUSH, with permission)
   
+  If you wish to see the help for the normal globbing command execution,
+  please refer to the help 'ARBITRARY COMMANDS'.
+  
   The majority of matching in MUSH is done with wildcard (&quot;globbing&quot;)
   patterns. There is a second type of matching, using regular expressions,
   that is available in certain circumstances.
@@ -31290,10 +39849,24 @@ Generated: Wed Jan 13 04:15:48 2016
   player to enter a string and a number ('+setnum &lt;player&gt;=&lt;number&gt;',
   for example), you might do it like this:
   
-  &amp;DO_NUM Command Object=$^\+setnum (.+)=([0-9]+)$: @va me=Data: %1 = %2
-  @set Command Object/DO_NUM = regexp
+  &gt; &amp;DO_NUM Command Object=$^\+setnum (.+)=([0-9]+)$: @va me=Data: %1 = %2
+  Set.
+  &gt; @set Command Object/DO_NUM = regexp
+  Set.
+  &gt; +setnum cookie=30
+  &gt; ex Command Object/va
+  Data: cookies = 30
+  &gt; &amp;DO_ZZ Command Object=$^zz:@pemit %#=I am case insensitive.
+  &gt; zz
+  I am case insensitive.
+  &gt; &amp;DO_ZZ Command Object=$^(?-i)zz:@pemit %#=I am case sensitive.
+  &gt; zz
+  I am case sensitive.
+  &gt; ZZ
+  Huh?  (Type 'help' for help)
   
-  Then, '+setnum cookies=30' would set VA to &quot;Data: cookies = 30&quot;.
+  How it works:
+  '+setnum cookies=30' would set VA to &quot;Data: cookies = 30&quot;.
   This eliminates your having to check to see if the player entered
   a number, since the regular expression matches only numbers.
   Furthermore, the '+' guarantees that there needs to be at least
@@ -31309,6 +39882,56 @@ Generated: Wed Jan 13 04:15:48 2016
 
 </PRE>
 <A HREF="#regexps">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#register">[NEXT]</A>
+<BR>
+<HR><A NAME="register"><H3>register</H3></A><PRE>
+  Command: co  &lt;name&gt; &lt;password&gt;  (short for connect)
+           cd  &lt;name&gt; &lt;password&gt;  (short for cdark)
+           ch  &lt;name&gt; &lt;password&gt;  (short for chidden)
+           cr  &lt;name&gt; &lt;password&gt;  (short for create)
+           reg &lt;name&gt; &lt;password&gt;  (short for register)
+  
+  Note:  To create/log in a character with spaces in their name, please use
+         &quot;&lt;name&gt;&quot;.  Ergo, surround your name with double quotes.
+         The 'register' command does not allow creation with spaces.
+  
+  These commands are only useful on the connect screen.  They are used to
+  create/connect to your account &lt;name&gt; with the provided &lt;password&gt;.  
+  These commands are not useable once you are connected to the mush.
+  
+  These commands are as follows:
+     co  -- This option is the default and normal method to connect.
+            This option has no special conditions or privilages.
+            Syntax: co player password
+                    co &quot;Player With Spaces&quot; password
+  
+     ch  -- Wizards and anyone with the NOWHO @power (to @hide) can use this.
+            This option will auto-hide the player when connecting.
+            It defaults to the 'co' option if you can't @hide.
+            Syntax: ch player password
+                    ch &quot;Player With Spaces&quot; password
+  
+     cd  -- Wizards and higher can use this to connect dark to the game.
+            This effectively connects wiz-cloaked to the game.
+            Immortals get auto-added to supercloak.
+            Syntax: cd player password
+                    cd &quot;Player With Spaces&quot; password
+     
+     cr  -- Allows creation of a player from the connect screen.
+            Syntax: cr player password
+                    cr &quot;Player With Spaces&quot; password
+  
+     reg -- If offline registration is enabled, allows the player to register
+            a character with a supplied email that is then used to email them
+            their password.
+            Syntax: reg player email@address
+                    reg &quot;Player With Spaces&quot; email@address
+  
+  See Also: @aconnect, @adisconnect, @hide, @register
+            
+</PRE>
+<A HREF="#regexps2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#reglmatch()">[NEXT]</A>
 <BR>
@@ -31339,7 +39962,7 @@ Generated: Wed Jan 13 04:15:48 2016
   'help regexp syntax' for an explanation of regular expressions.
 
 </PRE>
-<A HREF="#regexps2">[PREV]</A>
+<A HREF="#register">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#reglmatchall()">[NEXT]</A>
 <BR>
@@ -31563,7 +40186,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#regraball()">[NEXT]</A>
 <BR>
 <HR><A NAME="regraball()"><H3>REGRABALL()</H3></A><PRE>
-  Function: regraball(&lt;string&gt;,&lt;regexp&gt;[,&lt;delim&gt;][,&lt;output seperator&gt;])
+  Function: regraball(&lt;string&gt;,&lt;regexp&gt;[,&lt;delim&gt;][,&lt;output separator&gt;])
   
   These functions work identically to the grab() and regrab()/regrabi()
   functions, save that they return all matches, not just the first: They
@@ -31586,7 +40209,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#regraballi()">[NEXT]</A>
 <BR>
 <HR><A NAME="regraballi()"><H3>REGRABALLI()</H3></A><PRE>
-  Function: regraballi(&lt;string&gt;,&lt;regexp&gt;[,&lt;delim&gt;][,&lt;output seperator&gt;])
+  Function: regraballi(&lt;string&gt;,&lt;regexp&gt;[,&lt;delim&gt;][,&lt;output separator&gt;])
   
   These functions work identically to the grab() and regrab()/regrabi()
   functions, save that they return all matches, not just the first: They
@@ -31785,7 +40408,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#remflags()">[NEXT]</A>
 <BR>
 <HR><A NAME="remflags()"><H3>REMFLAGS()</H3></A><PRE>
-  Function: remflags(&lt;list&gt;, [&amp;|]&lt;flag(s)&gt; [,&lt;delim&gt;[,&lt;output delim&gt;]])
+  Function: remflags(&lt;list&gt;,[&amp;|]&lt;flag(s)&gt;[,&lt;delim&gt;[,&lt;output delim&gt;][,&lt;type&gt;]])
   
   The remflags function removes all dbref#'s in the given list that contains
   the flags specified.  You must use one of the operators for flag checks:
@@ -31794,6 +40417,8 @@ Generated: Wed Jan 13 04:15:48 2016
   
   This function returns the list of dbref#'s that correctly match up the
   flags you specified.
+  
+  You may specify a &lt;type&gt; of 1 to return values as objid's.
   
   Examples: (#1 is a wizard, nothing else is)
     &gt; say remflags(#1 #2 #3 #4,&amp;W)
@@ -31814,12 +40439,14 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#remit()">[NEXT]</A>
 <BR>
 <HR><A NAME="remit()"><H3>REMIT()</H3></A><PRE>
-  Function: remit(&lt;list of locations&gt;,&lt;string&gt; [,&lt;to-reality-toggle&gt;])
+  Function: remit(&lt;list of locations&gt;, &lt;string&gt; [,&lt;to-reality-tog&gt;] [,&lt;key&gt;])
   
   The remit() side-effect function is used to emit the given &lt;string&gt; to every
   location specified in the &lt;list of locations&gt;.
   
-  This works similarilly to @pemit/list/contents.
+  This works similarilly to @pemit/list/contents.  By default ## is substitute
+  for every &lt;location&gt; in the list.  This evaluates by default for every 
+  location in the list.
   
   This function relies on the config parameter 'pemit_any_object' to
   be enabled to allow remitting to any room, otherwise, it will only
@@ -31828,10 +40455,14 @@ Generated: Wed Jan 13 04:15:48 2016
   This side-effect must be enabled (@list options to see if it is) before it
   can be used.  Anything using it must have the SIDEFX flag set.
    
-  If the &lt;to-reality-toggle&gt; is set to '1', then it assumes the remit is
+  If the &lt;to-reality-tog&gt; is set to '1', then it assumes the remit is
   a 'to-reality' model, in which the &lt;list of locations&gt; takes the form:
   
        reality1 reality2 ... realityN/location1 location2 ... locationN
+  
+  Following &lt;key&gt; values exist:
+    1 - Disable ## from evaluating in &lt;string&gt;.
+    2 - Only evaluate once.  By default this disables ## from evaluating.
  
   Example:
     &gt; say remit(here #0,Boo)
@@ -31876,7 +40507,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#remtype()">[NEXT]</A>
 <BR>
 <HR><A NAME="remtype()"><H3>REMTYPE()</H3></A><PRE>
-  Function: remtype(&lt;string&gt;,&lt;type(s)&gt;[,&lt;delim&gt;[,&lt;output delim&gt;]])
+  Function: remtype(&lt;string&gt;,&lt;type(s)&gt;[,&lt;delim&gt;[,&lt;output delim&gt;][,&lt;type&gt;]])
  
   The remtype function removes all types of 'type' from the string 'string'.
   The different types are standard MUSH object types:
@@ -31886,9 +40517,14 @@ Generated: Wed Jan 13 04:15:48 2016
       EXIT   - specifying exits
       OTHER  - specifying anything not fitting a MUSH 'type'.
   
-  You may specify optional seperators and output seperators.   You may specify
+  You may specify optional separators and output separators.   You may specify
   more than one type at once.
   
+  If you specify &lt;type&gt; as 1, the results are always returned as dbref#'s, 
+  otherwise the values are returned as the element in &lt;string&gt;.
+    
+  If you specify &lt;type&gt; as 2, the results are returned as objid's.
+    
   Examples: (#0 is a room, #1 #55 and #584 are players, #-1 is invalid (other))
     &gt; say remtype(#0 #1 #55 #584 #-1,player)
     You say &quot;#0 #-1&quot;
@@ -31909,10 +40545,14 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#repeat()">[NEXT]</A>
 <BR>
 <HR><A NAME="repeat()"><H3>REPEAT()</H3></A><PRE>
-  Function: repeat(&lt;string&gt;,&lt;number&gt;)
+  Function: repeat(&lt;string&gt;,&lt;number&gt; [,&lt;ansi&gt;])
   
   This function simply repeats &lt;string&gt;, &lt;number&gt; times.  No spaces are
   inserted between each repetition.
+  
+  You may specify the &lt;ansi&gt; toggle to '1' to make repeat ansi aware
+  which optimizes ansi but will have a cost in performance.  This 
+  defaults to '0'.
   
   Example:
     &gt; say repeat(Test, 5)
@@ -31926,7 +40566,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#replace()">[NEXT]</A>
 <BR>
 <HR><A NAME="replace()"><H3>REPLACE()</H3></A><PRE>
-  Function: replace(&lt;list&gt;, &lt;pos&gt; [&lt;pos2&gt;...&lt;posN&gt;], &lt;word&gt;[, &lt;delim&gt;])
+  Function: replace(&lt;list&gt;, &lt;pos&gt; [&lt;pos2&gt;..&lt;posN&gt;], &lt;word&gt;[[,&lt;sep&gt;] [,&lt;osep&gt;]])
    
   This function inserts a word into &lt;list&gt; so that the word becomes the
   &lt;pos&gt;'th element of the list, and the word previously in that position
@@ -31935,10 +40575,15 @@ Generated: Wed Jan 13 04:15:48 2016
   position.  This function may not be used to append a word to a list.
   You may specify more than one position.
    
-  &lt;delim&gt; may be used to specify a delimiter other than a space.
-  
   The &lt;pos&gt; fields may be negative to take the argument from the right
   instead of the left.
+  
+  You may specify a separate &lt;sep&gt; seperator or it assumes space if not
+  provided.  
+  
+  The &lt;osep&gt; output delimiter may be more than one character, and if 
+  enabled, '@@' can be used as another method for a null.  You may specify 
+  an empty &lt;osep&gt; as well.
    
   Examples:
     &gt; say replace(This is a test, 4, quiz)
@@ -31951,6 +40596,22 @@ Generated: Wed Jan 13 04:15:48 2016
   
 </PRE>
 <A HREF="#repeat()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#require_trees">[NEXT]</A>
+<BR>
+<HR><A NAME="require_trees"><H3>REQUIRE_TREES</H3></A><PRE>
+  Flag: REQUIRE_TREES(q)
+  
+  When set on a target, that target will require the TREE method for all
+  sets when it uses a character that is identified as a tree separator.
+  This is a way to help better enforce tree sets on targets.  Keep in mind,
+  this only affects sets, and nothing else as Rhost natively does not
+  handle trees.
+  
+  See Also: ATTRIBUTE TREES
+
+</PRE>
+<A HREF="#replace()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#rest()">[NEXT]</A>
 <BR>
@@ -31974,7 +40635,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: first(), before(), after(), extract(), extractword()
   
 </PRE>
-<A HREF="#replace()">[PREV]</A>
+<A HREF="#require_trees">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#reswitch()">[NEXT]</A>
 <BR>
@@ -32055,9 +40716,13 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="reverse()"><H3>REVERSE()</H3></A><PRE>
   Function: reverse(&lt;string&gt;)
+            trreverse(&lt;string&gt;)
  
   Reverses the order of the characters of &lt;string&gt;.
- 
+  
+  trreverse() works like reverse() except it transposes characters that 
+  are reverseable.  Ergo, &gt; to &lt;, ] to [, } to { and so forth.
+   
   Examples:
     &gt; say reverse(This is a test)
     You say &quot;tset a si sihT&quot;
@@ -32065,6 +40730,10 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;...yllaeR ,tset a si sihT&quot;
     &gt; say reverse(A man, a plan, a canal -- Panama!)
     You say &quot;!amanaP -- lanac a ,nalp a ,nam A&quot;
+    &gt; say reverse(&gt;&gt;test&lt;&lt;)
+    You say &quot;&lt;&lt;tset&gt;&gt;&quot;
+    &gt; say trreverse(&gt;&gt;test&lt;&lt;)
+    You say &quot;&gt;&gt;tset&lt;&lt;&quot;
   
   See Also: revwords()
   
@@ -32074,6 +40743,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#revisions">[NEXT]</A>
 <BR>
 <HR><A NAME="revisions"><H3>revisions</H3></A><PRE>
+  For historical changes file, please see 'help historical'
+  
   All credits to players, codebases, or other is presented in the RHOST.CHANGES
   file in the readme directory in the source distribution.  The credits are too
   diverse and well too detailed to be sufficient as a small snippit in online
@@ -32091,15 +40762,18 @@ Generated: Wed Jan 13 04:15:48 2016
   Any versioning of Rhost version 1.0 through 3.0 was sadly lost to time.
   
   The developers who may appear in these files are:
-    ASH - Ashen-Shugar      * AMB - Ambrosia            EEH - Noltar
-    KRK - Loki                LNS - Lensman             ODN - Odin
-    SEA - Seawolf             THO - Thorin              NYS - Nyctasia
-    ROK - Rook
+     ASH - [Ashen-Shugar]     * AMB -  Ambrosia            EEH - [Noltar]
+     KRK - [Loki]               LNS - [Lensman]            ODN -  Odin
+     SEA - [Seawolf]            THO - [Thorin]             NYS - [Nyctasia]
+     ROK -  Rook                KAG -  Kage
   
   The current Lead Developer (which we change up) is marked with a '*'.
+  Developers who are MIA or retired are surrounded in []'s.
    
-  Current Revision: 3.9.5p3
-
+  ***************************************************************************
+  *** Current Revision: 4.1.0p2
+  ***************************************************************************
+  
   Available Revisions:
     1.0.0: 1.0.0p0 (NycMUD)
     1.5.0: 1.5.0p0 (NycMUSE
@@ -32114,7 +40788,11 @@ Generated: Wed Jan 13 04:15:48 2016
     3.9.2: 3.9.2p0, 3.9.2p1
     3.9.3: 3.9.3p0, 3.9.3p1, 3.9.3p2
     3.9.4: 3.9.4p0, 3.9.4p1, 3.9.4p2, 3.9.4p3, 3.9.4p4, 3.9.4p5
-    3.9.5: 3.9.5p0, 3.9.5p1, 3.9.5p2, 3.9.5p3
+    3.9.5: 3.9.5p0, 3.9.5p1, 3.9.5p2, 3.9.5p3, 3.9.5p4
+    4.0.0: 4.0.0p0, 4.0.0p1, 4.0.0p2, 4.0.0p3, 4.0.0p4
+    4.1.0: 4.1.0p0, 4.1.0p1, 4.1.0p2
+  
+  See Also: historical, credits
 
 </PRE>
 <A HREF="#reverse()">[PREV]</A>
@@ -32136,7 +40814,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say revwords(Was it a cat I saw?)
     You say &quot;saw? I cat a it Was&quot;
   
-  See Also: reverse()
+  See Also: reverse(), trreverse()
   
 </PRE>
 <A HREF="#revisions">[PREV]</A>
@@ -32144,10 +40822,17 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#right()">[NEXT]</A>
 <BR>
 <HR><A NAME="right()"><H3>RIGHT()</H3></A><PRE>
-  Function: right(&lt;string&gt;, &lt;position&gt;)
+  Function: right(&lt;string&gt;, &lt;position&gt; [,&lt;key&gt;])
   
   Right will take a string and return the right-most position of characters
   from the string.  
+  
+  You may specify a &lt;key&gt; of 1 to tell right() to take the string raw and
+  not do ansi-aware processing.  This will speed up the function.
+  The default is '0' which does ansi processing.
+  
+  Note: the config param 'ansi_default' handles if the ansi handling is 
+        configured default or not.  In which case the 'key' is reversed.
   
   Example:
     &gt; say right(this is a test,5)
@@ -32210,7 +40895,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say =[printf($:.:5s,bar)]=       (The default justification is right)
     You say &quot;=..bar=&quot;
   
-  See Also: rjc(), ljust(), ljc(), strlen(), printf(), wrap()
+  See Also: rjc(), ljust(), ljc(), strlen(), printf(), wrap(), template()
   
 </PRE>
 <A HREF="#rindex()">[PREV]</A>
@@ -32233,7 +40918,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say -[rjc(this is foo,6)]-
     You say &quot;-this i-&quot;
    
-  See Also: rjust(), ljc(), ljust(), printf(), wrap()
+  See Also: rjust(), ljc(), ljust(), printf(), wrap(), template()
  
 </PRE>
 <A HREF="#rj()">[PREV]</A>
@@ -32265,7 +40950,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say =[printf($:.:5s,bar)]=       (The default justification is right)
     You say &quot;=..bar=&quot;
   
-  See Also: rjc(), ljust(), ljc(), strlen(), printf(), wrap()
+  See Also: rjc(), ljust(), ljc(), strlen(), printf(), wrap(), template()
   
 </PRE>
 <A HREF="#rjc()">[PREV]</A>
@@ -32273,7 +40958,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#rloc()">[NEXT]</A>
 <BR>
 <HR><A NAME="rloc()"><H3>RLOC()</H3></A><PRE>
-  Function: rloc(&lt;object&gt;,&lt;levels&gt;)
+  Function: rloc(&lt;object&gt;,&lt;levels&gt;,[&lt;type&gt;])
  
   This function may be used to get the location of an object's location
   (for which you would previously use 'loc(loc(&lt;object&gt;))', which fails if you
@@ -32289,6 +40974,19 @@ Generated: Wed Jan 13 04:15:48 2016
   rloc(&lt;object&gt;,0) is the same as num(&lt;object&gt;), and rloc(&lt;object&gt;,1) is the
   same as loc(&lt;object&gt;).
   
+  When used on an exit, it will return the exits dbref#.  Exits do not have
+  a nested location so it returns itself.  If you want the exit's location 
+  use the home() function. If you want the exit's destination use the loc()
+  function.
+
+  Optionally, you can supply a &lt;type&gt; argument. This can be either &quot;OBJECT&quot;,
+  &quot;THING&quot;, or &quot;PLAYER&quot;. OBJECT is an alias for THING in this case.
+  If supplied, once rloc encounters such an object type as the location on the
+  way 'down' it will immediately stop and return that #dbref instead - handy
+  for exotic cases like trying to find players sitting inside objects inside
+  other players - you could use rloc(&lt;target&gt;,5,PLAYER) and it would return
+  the player #DBREF if &lt;target&gt; was in some way nexted inside a player object.
+   
   Example:
     &gt; look
     Object(#123p)
@@ -32303,7 +41001,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say rloc(me,2)
     You say &quot;#124&quot;
   
-  See Also: loc(), where()
+  See Also: loc(), where(), home()
   
 </PRE>
 <A HREF="#rjust()">[PREV]</A>
@@ -32330,7 +41028,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say rnum(thingy,#124)
     You say &quot;#122&quot;
   
-  See Also: locate(), num()
+  See Also: locate(), num(), objid()
   
 </PRE>
 <A HREF="#rloc()">[PREV]</A>
@@ -32418,7 +41116,10 @@ Generated: Wed Jan 13 04:15:48 2016
   Returns the number of the room that &lt;obj&gt; is in, or would be in if it
   executed LEAVE commands until it got to a room.  You can find out the
   containing room of objects you own, nearby objects, and findable players.
- 
+  
+  If used on an exit, it returns the exits *destination*.  If you wish to
+  return the location of the exit, use the home() function.
+   
   Example:
     &gt; I
     You are carrying:
@@ -32575,10 +41276,63 @@ Generated: Wed Jan 13 04:15:48 2016
   &gt; say rset(me,safe)
   You say &quot;safe&quot;
   
-  See Also: set(), writable(), &amp;, @set, SIDEEFFECTS, ATTRIBUTE TREES
+  See Also: toggle(), totemset(), lset(), set(), writable(), &amp;, @set, 
+            SIDEEFFECTS, ATTRIBUTE TREES
   
 </PRE>
 <A HREF="#rpage">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ruler()">[NEXT]</A>
+<BR>
+<HR><A NAME="ruler()"><H3>RULER()</H3></A><PRE>
+  Function: ruler(&lt;object&gt;/&lt;attribute&gt;, &lt;ruler value&gt;)
+  
+  This function will provide a ruler to quickly eyeball the character position
+  of the output of the given attribute.  The &lt;ruler value&gt; must be a mulitple
+  of 10, and must be between 0 and 100.  
+  
+  The ruler is color coded to help make it easier to quickly eyeball and 
+  count out the position.  Handy for some functions that require positional
+  arguments like creplace(), mid(), and @label.
+  
+  The output of this command works like a side-effect so the output can not
+  be captured other than with @pipe.
+  
+  Examples:
+    &gt; &amp;TEST me=Testing 1 2 3 Testing 1 2 3 Testing 1 2 3
+    Set.
+    &gt; think ruler(me/test,60)
+           | ---------|10-------|20-------|30-------|40-------|50-------|60 |
+           | Testing 1 2 3 Testing 1 2 3 Testing 1 2 3                      |
+    0      | 123456789012345678901234567890123456789012345678901234567890   |
+           | ---------|10-------|20-------|30-------|40-------|50-------|60 |
+  
+  See Also: mid(), creplace(), @label
+
+</PRE>
+<A HREF="#rset()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#rxdesc()">[NEXT]</A>
+<BR>
+<HR><A NAME="rxdesc()"><H3>RXDESC()</H3></A><PRE>
+  Function: rxdesc(&lt;target&gt;)
+  
+  Returns a space separated list of all realitylevel-based descriptions that
+  are visible to &lt;target&gt;. You must control &lt;target&gt;. If no levels are listed,
+  nothing is returned. If you do not control the target, or if the target does
+  not exist, '#-1' is returned.
+  
+  Example:
+    &gt; say rxdesc(me)
+    You say 'Real specialDesc'.
+    &gt; say rxlevel(me)
+    You say &quot;&quot;
+  
+  See Also: hasrxlevel(), hastxlevel(), rxlevel(), txlevel(), listrlevels(),
+            chkreality()
+
+</PRE>
+<A HREF="#ruler()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#rxlevel()">[NEXT]</A>
 <BR>
@@ -32603,32 +41357,41 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;&quot;
   
   See Also: hasrxlevel(), hastxlevel(), txlevel(), listrlevels(), chkreality()
+            rxdesc()
   
 </PRE>
-<A HREF="#rset()">[PREV]</A>
+<A HREF="#rxdesc()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#s()">[NEXT]</A>
 <BR>
 <HR><A NAME="s()"><H3>S()</H3></A><PRE>
   Function: s(string)
  
-  This function performs pronoun substitution in a string, and then returns
-  that string.  As usually, %n is the name, %s the subjective pronoun, %o the
-  objective, %p the possessive, and %a the absolute possessive.  It is
-  important to note that the pronoun is that of the triggering object.
+  This function works like eval() in that it evaluates the string doing full 
+  pronoun substitution and function evaluation and then returns that string.  
+  As usually, %n is the name, %s the subjective pronoun, %o the objective, 
+  %p the possessive, and %a the absolute possessive.  It is important to 
+  note that the pronoun is that of the triggering object.
  
   So, if the ve of an object were: &quot;[s(This is %n)], and I were to 
   type @trigger &lt;object&gt;/ve, it would return &quot;This is &lt;myname&gt;&quot;, but 
   if vf were @trigger me/ve, then triggering the vf makes the ve 
   return &quot;This is &lt;object&gt;&quot;
   
+  As stated, this will also evaluate functions as well.  If you wish to
+  only evaluate substitutions, please refer to the subeval() function.
+  
   Example:
     &gt; @sex me=male
     Set.
-    &gt; s(this [add(1,1)] %s)
+    &gt; s(this [add(1,1)] %p)
     You say &quot;this 2 his&quot; 
+    &gt; eval(this [add(1,1)] %p)
+    You say &quot;this 2 his&quot; 
+    &gt; subeval(this [add(1,1)] %p)
+    You say &quot;this [add(1,1)] his&quot; 
   
-  See Also: SUBSTITUTIONS
+  See Also: SUBSTITUTIONS, eval(), subeval(), ueval(), streval(), u(), v()
   
 </PRE>
 <A HREF="#rxlevel()">[PREV]</A>
@@ -32652,7 +41415,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#safebuff()">[NEXT]</A>
 <BR>
 <HR><A NAME="safebuff()"><H3>SAFEBUFF()</H3></A><PRE>
-  Function: safebuff(&lt;list&gt; [,&lt;delim&gt;])
+  Function: safebuff(&lt;list&gt; [[,&lt;delim&gt;, [&lt;length&gt;]])
   
   This function will return the list, by cutting off from the end any partial
   string, based on the delimeter you specify &lt;delim&gt;.  If no delimeter is
@@ -32663,15 +41426,20 @@ Generated: Wed Jan 13 04:15:48 2016
   the buffer is cut back.  Thus, any ansi sequence given to this function
   will be removed.
   
+  You may specify an optional length to which it will apply the logic
+  to go to the first buffer.
+  
   Example:
     &gt; say search(eval=*)
     You say &quot;#0 #1 ... #883 #884 #88&quot; (in this case, '#885' would be cut off)
     &gt; say safebuff(search(eval=*))
     You say &quot;#0 #1 ... #883 #884&quot; (the partial string '#885' was omitted)
+    &gt; say safebuff(aaa aa aaaa,,8)
+    You say &quot;aaa aa&quot;
   
   In the above examples, the '...' would be the huge ammount of output.
   
-  See Also: lit(), s(), t()
+  See Also: lit(), s(), t(), printf(), ljc(), rjc()
   
 </PRE>
 <A HREF="#safe">[PREV]</A>
@@ -32690,27 +41458,108 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#safebuff()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#sandbox()">[NEXT]</A>
+<BR>
+<HR><A NAME="sandbox()"><H3>SANDBOX()</H3></A><PRE>
+  Function: sandbox(&lt;string&gt;, &lt;function list&gt; [,&lt;key&gt; [,&lt;local&gt; [,&lt;type&gt;]]])
+  
+  This function sandboxes the evaluated &lt;string&gt; based on the list of
+  space separated functions in &lt;function list&gt;.  Any function that matches
+  any function in the list will have restricted access.
+  
+  The following &lt;key&gt; exists:
+    0 - Set the function deny (default)
+    1 - Set the function ignore and check for local function.
+  
+  The following &lt;local&gt; key exists:
+    0 - Don't check for local functions (@function/@lfunction) (default)
+    1 - Check against @functions (in addition to built-in functions)
+    2 - Check against @lfunctions (in addition to built-in functions)
+    3 - Check against all possible function combinations
+  
+  The following &lt;type&gt; exists:
+    0 - The function list is the list of functions denied. (default)
+    1 - The function list is the list of functions allowed.
+  
+  A &lt;key&gt; of deny will return the #-1 PERMISSION DENIED
+  A &lt;key&gt; of ignore will return the #-1 FUNCTION (blah) NOT FOUND
+  
+  Once you have the &lt;type&gt; defined as '1', it remains that way through
+  all iterations of the sandbox()'d evaluation, regardless of how
+  often sandbox() may be called recursively from inside it.
+  
+{ see 'help sandbox2' for examples }
+
+</PRE>
+<A HREF="#safelog toggle">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#sandbox2">[NEXT]</A>
+<BR>
+<HR><A NAME="sandbox2"><H3>SANDBOX2</H3></A><PRE>
+  (CONTINUED)
+  Function: sandbox(&lt;string&gt;, &lt;function list&gt; [,&lt;key&gt; [,&lt;local&gt; [,&lt;type&gt;]]])
+  
+  Examples:
+    &gt; @va me=BOO
+    Set.
+    &gt; @lfunction boo=me/va
+    LOCAL Function boo defined.
+    &gt; say sandbox(Test - [add(1,1)] [sub(1,1)] [boo()],add)
+    You say &quot;Test - #-1 PERMISSION DENIED 0 BOO&quot;
+    &gt; say sandbox(Test - [add(1,1)] [sub(1,1)] [boo()],sub)
+    You say &quot;Test - 2 #-1 PERMISSION DENIED BOO&quot;
+    &gt; say sandbox(Test - [add(1,1)] [sub(1,1)] [boo()],sub boo)
+    You say &quot;Test - 2 #-1 PERMISSION DENIED BOO&quot;
+    &gt; say sandbox(Test - [add(1,1)] [sub(1,1)] [boo()],sub boo,,3)
+    You say &quot;Test - 2 #-1 PERMISSION DENIED #-1 PERMISSION DENIED&quot;
+    &gt; say sandbox(Test - [add(1,1)] [sub(1,1)] [boo()],sub,,3,1)
+    You say &quot;Test - #-1 PERMISSION DENIED 0 #-1 PERMISSION DENIED&quot;
+    &gt; say sandbox(Test - [add(1,1)] [sub(1,1)] [boo()],sub boo,,1,1)
+    You say &quot;Test - #-1 PERMISSION DENIED 0 #-1 PERMISSION DENIED&quot;
+    &gt; say sandbox(Test - [add(1,1)] [sub(1,1)] [boo()],sub boo,,3,1)
+    You say &quot;Test - #-1 PERMISSION DENIED 0 BOO&quot;
+  
+  See Also: pushregs(), ulocal(), zfunlocal(), eval(), privatize(), 
+            localize(), subeval(), @lfunction
+
+</PRE>
+<A HREF="#sandbox()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#save">[NEXT]</A>
 <BR>
 <HR><A NAME="save"><H3>save</H3></A><PRE>
   RhostMUSH, unlike lp's, merc's, diku's or similiar mud derivitives, does not
-  have a 'save' option.  Your character, upon creation, is automatically saved.
+  have a 'save' option.  Your player, upon creation, is automatically saved.
   Everything you do, whenever you do it, is also automatically saved.  So just
   have fun, relax, and enjoy your time on.   Leave the saving to us :)
   
 </PRE>
-<A HREF="#safelog toggle">[PREV]</A>
+<A HREF="#sandbox2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#say">[NEXT]</A>
 <BR>
 <HR><A NAME="say"><H3>say</H3></A><PRE>
   Command: say[/&lt;switches&gt;] &lt;message&gt;
+  
   Says &lt;message&gt; out loud to everyone in your current room. You can also
   use '&quot;&lt;message&gt;'.  No switches are allowed with the '&quot;' shorthand.
   
   The following switches exist for the say command:
     /noansi    - Show the string literally and don't process ansi.  Only
                  useful with ZENTY_ANSI enabled (at compiletime).
+  
+  You may use two special attributes for pre and post processing of any
+  says you receive.  These attributes will have substitutions evaluated
+  but will not evaluate functions.  If these attributes are set NO_COMMAND
+  then they will not be processed.
+    SPEECH_PREFIX  -- Contents will be evaluated before the say/pose.
+    SPEECH_SUFFIX  -- Contents will be evaluated after the say/pose.
+  
+  Both of these attributes handle three arguments.  These are:
+    %0 - The original say/pose that triggered the attribute.
+    %1 - The date in the form MM/DD/YYYY
+    %2 - The time in the form HH:MM:SS
+    %3 - The dbref# of the player issuing the say/pose/emit (#-1 if spoofed)
   
   See Also: page, pose, whisper, :, ;, &quot;, @saystring
   
@@ -32753,7 +41602,9 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="search classes"><H3>search classes</H3></A><PRE>
   Topic: SEARCH CLASSES
  
-  You may use the following classes in @search, search() and searchng()
+  You may use the following classes in @search, search(), searchng(),
+  searchobjid(), and searchngobjid()
+  
   function calls:
   
   TYPE      - Restricts to objects of the indicated type (OBJECTS, ROOMS,
@@ -32768,6 +41619,9 @@ Generated: Wed Jan 13 04:15:48 2016
               &lt;restriction&gt; set..
   FLAGS2    - Restricts to objects which have the flags listed in
               &lt;restriction&gt; set.. (uses next set of flags)
+  TOTEMS    - Restricts to objects which have the tier 0 totem letters.
+  TOTEMS2   - Restricts to objects which have the tier 1 totem letters.
+  TOTEMS3   - Restricts to objects which have the tier 2 totem letters.
   EVAL      - Evaluates the restriction for each object, replacing ##
               with the object's database number.  Evaluations that return
               TRUE (IE, not 0 or #-1) are selected.
@@ -32784,14 +41638,20 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="search()"><H3>SEARCH()</H3></A><PRE>
   Function: search([&lt;player&gt;] [&lt;class&gt;=&lt;restriction&gt;[,&lt;low&gt;[,&lt;high&gt;]]])
- 
+            searchobjid([&lt;player&gt;] [&lt;class&gt;=&lt;restriction&gt;[,&lt;low&gt;[,&lt;high&gt;]]])
+  
+  Note: See 'help search classes' on what you can search for.
+  
   The search() function returns a list of objects that match the search
   criteria, which are the same as with the @search command.  This function
   costs as much as the @search command, so repeated use is expensive.
  
   Caution: if you use the [ and ] characters in an Eval selection you will
   need to escape them.
- 
+  
+  The searchobjid() function works like search() but returns the objid's
+  instead of the dbref#'s.
+   
   Examples:
     &gt; say search()
     You say &quot;#226 #289 #325 #364 #368 #369&quot;
@@ -32801,6 +41661,8 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;#289 #325 #364 #368 #369&quot;
     &gt; say search(player=wizard)
     You say &quot;#1&quot;
+    &gt; say searchobjid(me)
+    You say &quot;#226:8128285820 #289:8929292929&quot;
   
   See Also: searchng(), @search, @find, @stat, SEARCH CLASSES
 
@@ -32811,45 +41673,119 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="searchng()"><H3>SEARCHNG()</H3></A><PRE>
   Function: searchng([&lt;player&gt;] [&lt;class&gt;=&lt;restriction&gt;[,&lt;low&gt;[,&lt;high&gt;]]])
+            searchngobjid([&lt;player&gt;] [&lt;class&gt;=&lt;restriction&gt;[,&lt;low&gt;[,&lt;high&gt;]]])
+  
+  Note: See 'help search classes' on what you can search for.
   
   This function works exactly as search(), except it will not return any
   garbage (going/recover) objects in the results.
   
+  The searchngobjid() function works like searchng() but returns the objid's
+  instead of the dbref#'s.
+  
   Examples:
     &gt; say searchng()
     You say &quot;#226 #289 #325 #364 #368 #369&quot;
+    &gt; say searchngobjid(me)
+    You say &quot;#226:8128285820 #289:8929292929&quot;
   
   See Also: search(), @search, @find, @stat, SEARCH CLASSES
   
 </PRE>
 <A HREF="#search()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#searchngobjid()">[NEXT]</A>
+<BR>
+<HR><A NAME="searchngobjid()"><H3>SEARCHNGOBJID()</H3></A><PRE>
+  Function: searchng([&lt;player&gt;] [&lt;class&gt;=&lt;restriction&gt;[,&lt;low&gt;[,&lt;high&gt;]]])
+            searchngobjid([&lt;player&gt;] [&lt;class&gt;=&lt;restriction&gt;[,&lt;low&gt;[,&lt;high&gt;]]])
+  
+  Note: See 'help search classes' on what you can search for.
+  
+  This function works exactly as search(), except it will not return any
+  garbage (going/recover) objects in the results.
+  
+  The searchngobjid() function works like searchng() but returns the objid's
+  instead of the dbref#'s.
+  
+  Examples:
+    &gt; say searchng()
+    You say &quot;#226 #289 #325 #364 #368 #369&quot;
+    &gt; say searchngobjid(me)
+    You say &quot;#226:8128285820 #289:8929292929&quot;
+  
+  See Also: search(), @search, @find, @stat, SEARCH CLASSES
+  
+</PRE>
+<A HREF="#searchng()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#searchobjid()">[NEXT]</A>
+<BR>
+<HR><A NAME="searchobjid()"><H3>SEARCHOBJID()</H3></A><PRE>
+  Function: search([&lt;player&gt;] [&lt;class&gt;=&lt;restriction&gt;[,&lt;low&gt;[,&lt;high&gt;]]])
+            searchobjid([&lt;player&gt;] [&lt;class&gt;=&lt;restriction&gt;[,&lt;low&gt;[,&lt;high&gt;]]])
+  
+  Note: See 'help search classes' on what you can search for.
+  
+  The search() function returns a list of objects that match the search
+  criteria, which are the same as with the @search command.  This function
+  costs as much as the @search command, so repeated use is expensive.
+ 
+  Caution: if you use the [ and ] characters in an Eval selection you will
+  need to escape them.
+  
+  The searchobjid() function works like search() but returns the objid's
+  instead of the dbref#'s.
+   
+  Examples:
+    &gt; say search()
+    You say &quot;#226 #289 #325 #364 #368 #369&quot;
+    &gt; @stats me
+    6 objects = 0 rooms, 0 exits, 5 things, 1 players. (0 garbage)
+    &gt; say search(eval=\[eq(money(##),1)\])
+    You say &quot;#289 #325 #364 #368 #369&quot;
+    &gt; say search(player=wizard)
+    You say &quot;#1&quot;
+    &gt; say searchobjid(me)
+    You say &quot;#226:8128285820 #289:8929292929&quot;
+  
+  See Also: searchng(), @search, @find, @stat, SEARCH CLASSES
+
+</PRE>
+<A HREF="#searchngobjid()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#secs()">[NEXT]</A>
 <BR>
 <HR><A NAME="secs()"><H3>SECS()</H3></A><PRE>
   Function: secs()
+            msecs()
  
   Returns the number of elapsed seconds since midnight, January 1, 1970.
   This is an easy way to time things.
- 
+  
+  The msecs() function works like secs() but gives the fractional milisecond
+  of the current time.
+   
   Example:
      &gt; say secs()
      You say &quot;692636020&quot;
      ... wait a bit ...
      &gt; say secs()
      You say &quot;692636043&quot;
+     &gt; say msecs()
+     You say &quot;692636049.7&quot;
   
   See Also: convsecs(), convtime(), time(), timefmt()
   
 </PRE>
-<A HREF="#searchng()">[PREV]</A>
+<A HREF="#searchobjid()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#secure()">[NEXT]</A>
 <BR>
 <HR><A NAME="secure()"><H3>SECURE()</H3></A><PRE>
   Function: secure(&lt;string&gt;)
- 
-  Returns &lt;string&gt; after replacing the characters [](){};%\$, with spaces.
+  
+  Returns &lt;string&gt; after replacing the characters [](){};%\^,$ with spaces.
   This prevents strings entered by players from causing undesired side
   effects when used, such as making your object perform unintended commands
   or give out information to which you have access.  Note that this function
@@ -33057,12 +41993,17 @@ Generated: Wed Jan 13 04:15:48 2016
   worked with @set will work with set().  It follows the same permissions and
   restrictions of the command.  The SIDEFX flag is required to use set().
   
-  You may specify the optional &lt;tree&gt; of '1' to specifically set a TREE with
-  all branches filled (that do not exist) on the target.  A TREE set will
-  also verify permission on every branch of that tree prior to setting.  
-  Failure to set any of the branches, for any reason, will disallow 
+  You may specify the optional &lt;tree&gt; of '1' or '3' to specifically set a 
+  TREE with all branches filled (that do not exist) on the target.  A TREE 
+  set will also verify permission on every branch of that tree prior to 
+  setting.  Failure to set any of the branches, for any reason, will disallow 
   setting the attribute as well.
   
+  You may specify an optional &lt;tree&gt; of '2' or '3' to specify that all
+  attributes set will ignore the special case of '_' (third example above) 
+  when setting attributes.  Otherwise, doing '_foo/bar' will try to fetch
+  attribute 'bar' from object '_foo' and set it to that attribute. 
+    
   The &lt;tree&gt; toggle is ignored on any method of set() that does not 
   set or clear attributes.
    
@@ -33073,8 +42014,13 @@ Generated: Wed Jan 13 04:15:48 2016
   Set.
   &gt; say set(me,safe)
   You say &quot;&quot;
+  &gt; say set(me,_content_)
+  You say &quot;No match.&quot;
+  &gt; say set(me,_content_,2)
+  You say &quot;&quot;
   
-  See Also: rset(), writable(), &amp;, @set, SIDEEFFECTS, ATTRIBUTE TREES
+  See Also: toggle(), totemset() lset(), rset(), writable(), &amp;, @set, 
+            SIDEEFFECTS, ATTRIBUTE TREES
   
 </PRE>
 <A HREF="#session">[PREV]</A>
@@ -33091,7 +42037,7 @@ Generated: Wed Jan 13 04:15:48 2016
   in the list.
   
   If &lt;sep&gt; is specified, it will be used (rather than a space) for the output
-  seperator for the list.
+  separator for the list.
   
   If &lt;sorttype&gt; is specified, you may have a different sort than the default
   alphanumerical sort.  (d)bref, (n)umeric, (f)loat, (a)lphanumeric.
@@ -33119,7 +42065,7 @@ Generated: Wed Jan 13 04:15:48 2016
   in the list.
    
   If &lt;sep&gt; is specified, it will be used (rather than a space) for the output
-  seperator for the list.
+  separator for the list.
   
   If &lt;sorttype&gt; is specified, you may have a different sort than the default
   alphanumerical sort.  (d)bref, (n)umeric, (f)loat, (a)lphanumeric.
@@ -33138,10 +42084,15 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#setq()">[NEXT]</A>
 <BR>
 <HR><A NAME="setq()"><H3>SETQ()</H3></A><PRE>
-  Function: setq(&lt;number&gt;,&lt;string&gt;[,&lt;label&gt;])
+  Function: setq(&lt;register&gt;,&lt;string&gt;[,&lt;label&gt;])
             setq(&lt;label&gt;,&lt;string&gt;[,&lt;label&gt;)
             setq(!,&lt;string&gt;,&lt;label&gt;)
             setq(+,&lt;string&gt;,&lt;label&gt;)
+  
+      -- Penn Compatibility (if enabled via penn_setq admin param) 
+            setq(&lt;label|register&gt;,&lt;string&gt;)
+            setq(+,&lt;string&gt;,&lt;label&gt;)
+            setq(!,&lt;string&gt;,&lt;label&gt;)
  
   The setq() function is used to copy strings into local registers.
   It returns a null string; it is a purely &quot;side effect&quot; function.
@@ -33188,10 +42139,15 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#setq_old()">[NEXT]</A>
 <BR>
 <HR><A NAME="setq_old()"><H3>SETQ_OLD()</H3></A><PRE>
-  Function: setq_old(&lt;number&gt;,&lt;string&gt;[,&lt;label&gt;])
+  Function: setq_old(&lt;register&gt;,&lt;string&gt;[,&lt;label&gt;])
             setq_old(&lt;label&gt;,&lt;string&gt;[,&lt;label&gt;])
             setq_old(!,&lt;string&gt;,&lt;label&gt;)
             setq_old(+,&lt;string&gt;,&lt;label&gt;)
+  
+      -- Penn Compatibility (if enabled via penn_setq admin param) 
+            setq_old(&lt;label|register&gt;,&lt;string&gt;)
+            setq_old(+,&lt;string&gt;,&lt;label&gt;)
+            setq_old(!,&lt;string&gt;,&lt;label&gt;)
   
   This functions exactly like setq(), except it is using the old MUSH 
   method of evaluation.  This tends to be less abraisive on braces and
@@ -33276,10 +42232,15 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#setr()">[NEXT]</A>
 <BR>
 <HR><A NAME="setr()"><H3>SETR()</H3></A><PRE>
-  Function: setr(&lt;number&gt;,&lt;string&gt;[,&lt;label&gt;])
+  Function: setr(&lt;register&gt;,&lt;string&gt;[,&lt;label&gt;])
             setr(&lt;label&gt;,&lt;string&gt;[,&lt;label&gt;])
             setr(!,&lt;string&gt;,&lt;label&gt;)
             setr(+,&lt;string&gt;,&lt;label&gt;)
+  
+      -- Penn Compatibility (if enabled via penn_setq admin param) 
+            setr(&lt;label|register&gt;,&lt;string&gt;)
+            setr(+,&lt;string&gt;,&lt;label&gt;)
+            setr(!,&lt;string&gt;,&lt;label&gt;)
  
   The setr() function is used to copy strings into local registers.
   Unlike setq(), it returns its &lt;string&gt; argument.
@@ -33315,10 +42276,15 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#setr_old()">[NEXT]</A>
 <BR>
 <HR><A NAME="setr_old()"><H3>SETR_OLD()</H3></A><PRE>
-  Function: setr_old(&lt;number&gt;,&lt;string&gt;[,&lt;label&gt;])
+  Function: setr_old(&lt;register&gt;,&lt;string&gt;[,&lt;label&gt;])
             setr_old(&lt;label&gt;,&lt;string&gt;[,&lt;label&gt;])
             setr_old(!,&lt;string&gt;,&lt;label&gt;)
             setr_old(+,&lt;string&gt;,&lt;label&gt;)
+  
+      -- Penn Compatibility (if enabled via penn_setq admin param) 
+            setr_old(&lt;label|register&gt;,&lt;string&gt;)
+            setr_old(+,&lt;string&gt;,&lt;label&gt;)
+            setr_old(!,&lt;string&gt;,&lt;label&gt;)
   
   This functions exactly like setr(), except it is using the old MUSH 
   method of evaluation.  This tends to be less abraisive on braces and
@@ -33355,7 +42321,7 @@ Generated: Wed Jan 13 04:15:48 2016
   in the list.
    
   If &lt;sep&gt; is specified, it will be used (rather than a space) for the output
-  seperator for the list.
+  separator for the list.
   
   If &lt;sorttype&gt; is specified, you may have a different sort than the default
   alphanumerical sort.  (d)bref, (n)umeric, (f)loat, (a)lphanumeric.
@@ -33423,6 +42389,12 @@ Generated: Wed Jan 13 04:15:48 2016
   appropiate @ufail messages (ufail, aufail, oufail), if there is a
   matching $command and the object is uselocked against you.
   
+  If the object is set SHOWFAILCMD in addition to STOP, then the
+  error is showed appropiately and all command processing is 
+  stopped at that point as well.
+  
+  See Also: @ufail, @fail
+  
 </PRE>
 <A HREF="#shl()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -33458,13 +42430,13 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Example:
     &gt; say shuffle(This is a test)
-    You say &quot;This a is test&quot;               (seperator is a space ' ')
+    You say &quot;This a is test&quot;               (separator is a space ' ')
     &gt; say shuffle(This is a test)
     You say &quot;a test This is&quot;
     &gt; say shuffle(This@is@a@test,@)
-    You say &quot;is@a@This@test&quot;               (seperator is a '@')
+    You say &quot;is@a@This@test&quot;               (separator is a '@')
     &gt; say shuffle(This@is@a@test,@,|)
-    You say &quot;This|test|a|is&quot;               (seperator is '@', filler is '|')
+    You say &quot;This|test|a|is&quot;               (separator is '@', filler is '|')
   
   See Also: rand(), scramble(), sort(), setdiff(), setinter(), setunion() 
   
@@ -33495,6 +42467,7 @@ Generated: Wed Jan 13 04:15:48 2016
   r()             - Accesses local registers, and outputs its contents.
   remit()         - Emits text to a specified room.
   rset()          - Like set(), but returns the string that is set.
+  ruler()         - Display a ruler outline of contents of an attribute.
   rxlevel()       - Sets or unsets a reality receive level for an object.
   set()           - Sets an attribute on an object.
   setq()          - Copies a string into a local register.
@@ -33503,6 +42476,7 @@ Generated: Wed Jan 13 04:15:48 2016
   setr_old()      - Like setr(), but with old-style MUSH functionality.
   tel()           - Teleports an object to a location.
   toggle()        - Toggles a toggle on an object.
+  totemset()      - Set/remove a @totem on a target.
   txlevel()       - Sets or unsets a reality transmit level for an object.
   wipe()          - Wipes attribute(s) from object.
   zemit()         - Emits a string to every room of a zone.
@@ -33538,13 +42512,19 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Type '@list options' to see what side-effects are currently in effect.
     
-  MUX sideeffects supported:   TEL, SET, PEMIT, CREATE, LIST, and LINK
-  PENN sideeffects supported:  TEL, SET, PEMIT, CREATE, LINK, DIG, OPEN, EMIT,
-                               LEMIT, OEMIT, CLONE, LOCK, PARENT, NAME,
-                               WIPE, ZEMIT, and REMIT
+  MUX sideeffects supported:   SET, CREATE, LINK, PEMIT, TEL, LIST, OEMIT,
+                               PARENT, and DESTROY
+  PENN sideeffects supported:  SET, CREATE, LINK, PEMIT, TEL, DIG, OPEN, 
+                               EMIT, OEMIT, CLONE, PARENT, LOCK, LEMIT, 
+                               REMIT, WIPE, ZEMIT, NAME, and LSET
   OTHER sideeffects supported: DESTROY, TOGGLE, TXLEVEL, RXLEVEL, RSET, 
                                and MOVE
-  DATABASE sideeffects supported: SQLITE_QUERY
+
+  The following sideeffects are handled by the database portion as a
+  separate entity.
+  
+  DB sideeffects supported:    SQLITE_QUERY, SQL, SQLON, SQLOFF, 
+                               SQLESCAPE, SQLPING
   
   Help is available on MUX, PENN and OTHER side-effects by name.
   
@@ -33636,7 +42616,14 @@ Generated: Wed Jan 13 04:15:48 2016
  
   This function converts seconds to a single time element which is
   the lowest approximation to the given number of &lt;seconds&gt;.
- 
+  
+  The following letters are relevant:
+    s - second    d - day     y - year               e - epoch
+    m - minute    w - week    C - century
+    h - hour      M - month   a - annum(Millennium)
+  
+  Note:  an epoch is 1 million years or more.
+    
   Example:
     &gt; say singletime(45)
     You say &quot;45s&quot;
@@ -33646,6 +42633,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;1d&quot;
  
   Related Topics: secs(), time(), timefmt()
+
 </PRE>
 <A HREF="#singlethreading">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -33718,7 +42706,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * If &lt;delim&gt; is specified, it (rather than a space) is used to separate items
     in the list.  You may specify an alternate delimiter without specifying
     a sort type by passing a null &lt;sort type&gt; parameter.
-  * If &lt;sep&gt; is specified, it (rather than a space) is used to seperate items
+  * If &lt;sep&gt; is specified, it (rather than a space) is used to separate items
     in the output.
    
   Examples:
@@ -33769,12 +42757,20 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#sortlist()">[NEXT]</A>
 <BR>
 <HR><A NAME="sortlist()"><H3>SORTLIST()</H3></A><PRE>
-  Function: sortlist(&lt;order&gt;, &lt;sep&gt;, &lt;list1&gt;, &lt;list2&gt;, [...,&lt;listN&gt;])
+  Function: sortlist(&lt;order&gt;, &lt;sep&gt;[;&lt;osep&gt;], &lt;list1&gt;, &lt;list2&gt;, [...,&lt;listN&gt;])
   
   This function takes 2 or more lists and chooses from each sample the max
   or min value based on the sorting value type.  The &lt;order&gt; must have as the
   first character a + for maxsort or a - for minsort.  If you do not specify
   a sort type after the +/- or if the value is invalid, it assumes alphanum.
+  
+  You may specify a seperator of &lt;sep&gt; for the elements in the list.  This can
+  only be one character.  If part of the &lt;sep&gt; value is a semicolon followed 
+  by a string, it will take the first char as the &lt;sep&gt; value and anything
+  after the semi-colon (;) as the &lt;osep&gt; output seperator for the list.  
+  The &lt;osep&gt; may be more than one character.  An example is '%b;FOO' where
+  '%b' (a space) would be the &lt;sep&gt; value, and 'FOO' would be the &lt;osep&gt;
+  value.
   
   The lists may be unequal lists.
   
@@ -33787,29 +42783,49 @@ Generated: Wed Jan 13 04:15:48 2016
     -f  -- sort floating numerically by minimum value
     +d  -- sort dbref#'s numerically by maximum valid dbref# (#-1 if invalid)
     -d  -- sort dbref#'s numerically by minimum valid dbref# (#-1 if invalid)
+  +/-m  -- merge all the lists into a single list (+ or - does same thing)
+  +/-m| -- same as above, but anything after the '|' will be taken as the 
+           output delimiter between elements in each &lt;list&gt;. 
   
   With the dbref# sort, any invalid dbref# is assigned the value #-1.  If all
   arguments in that list order are all invalid, #-1 will be seen for the
   value.
+  
+{ see 'help sortlist2' for examples }
+
+</PRE>
+<A HREF="#sortby()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#sortlist2">[NEXT]</A>
+<BR>
+<HR><A NAME="sortlist2"><H3>SORTLIST2</H3></A><PRE>
+  (CONTINUED)
+  Function: sortlist(&lt;order&gt;, &lt;sep&gt;[;&lt;osep&gt;], &lt;list1&gt;, &lt;list2&gt;, [...,&lt;listN&gt;])
   
   Examples:
     &gt; say sortlist(+n,,1 2 3,10 0 20, 0 0 0)
     You say &quot;10 2 20&quot;
     &gt; say sortlist(-n,,1 2 3,10 0 20, -100 100 200)
     You say &quot;-100 0 3&quot;
-    &gt; say sortlist(-n,:,1:2:3,5:6:7,4:4:4,0:9:20)
+    &gt; say sortlist(+n,:,1:2:3,5:6:7,4:4:4,0:9:20)
     You say &quot;5:9:20&quot;
     &gt; say sortlist(+f,,1.2 2.5 3.3,1.3 2.4 -1.2)
     You say &quot;1.3 2.5 3.3&quot;
     &gt; say sortlist(+d,,#1 #2 #3,#10 #0 #20 #3735 #100 #200 #333,#-1 #3 #3735)
     (Note: #3735 in this example is a Garbage/Recover/Non-Existant dbref#)
     You say &quot;#10 #3 #20 #-1 #100 #200 #333&quot;
+    &gt; say sortlist(+m,,a b c d e,1 2 3 4 5,v w x y z)
+    You say &quot;a1v b2w c3x d4y e5z&quot;
+    &gt; say sortlist(+m|++,,a b c d e,1 2 3 4 5,v w x y z)
+    You say &quot;a++1++v b++2++w c++3++x d++4++y e++5++z&quot;
+    &gt; say sortlist(+m|++,%b;@,a b c d e,1 2 3 4 5,v w x y z)
+    You say &quot;a++1++v@b++2++w@c++3++x@d++4++y@e++5++z&quot;
   
   See Also: sort(), munge(), map(), setinter(), setunion(), setdiff(),
             listinter(), listunion(), listdiff()
 
 </PRE>
-<A HREF="#sortby()">[PREV]</A>
+<A HREF="#sortlist()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#soundex()">[NEXT]</A>
 <BR>
@@ -33830,7 +42846,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: soundlike()
   
 </PRE>
-<A HREF="#sortlist()">[PREV]</A>
+<A HREF="#sortlist2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#soundex2">[NEXT]</A>
 <BR>
@@ -33936,24 +42952,105 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#space()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#special characters">[NEXT]</A>
+<BR>
+<HR><A NAME="special characters"><H3>SPECIAL CHARACTERS</H3></A><PRE>
+  Topic: special characters
+  
+  There are characters considered 'special' based on the situation where
+  they are used in mush.  They usually do not have a global meaning for
+  these cases, but only in special situations.
+  
+    $ - Specify the start of a command, or used in regexp matching.
+    ^ - Specify the start of a listen, or used in regexp matching.
+    \ - Escape character to escape the next character in a string.
+    % - substitution character.  Also used for the ansi-markup.
+    , - function separation character to separate arguments to functions.
+    ; - command seperation character to separate commands in a list.
+   () - used in functions to denote start and end of a function call.
+   [] - also used in functions to help with function separation calls.
+   {} - a method to string together commands, strings, lists, or similar
+        into a single command or call.
+    &amp; - the start of an attribute set command.
+    @ - the start of most general built in commands or attribute calls.
+    | - used to break out of @program and execute an outside command
+    ! - used to break out of the current @door and execute a command
+        to the previous calling mush.
+    # - Specify the start of a dbref#
+    * - Specify a long-distance lookup of a player
+  
+  Some functions and commands also have unique one-off use of characters
+  or strings for special purposes as well, and this document will not
+  cover those cases.
+  
+  See Also: escape(), search()
+
+</PRE>
+<A HREF="#speak()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#speech_prefix">[NEXT]</A>
+<BR>
+<HR><A NAME="speech_prefix"><H3>SPEECH_PREFIX</H3></A><PRE>
+  Topic: special attributes
+  
+  These attributes are settable with &amp;SPEECH_PREFIX and &amp;SPEECH_SUFFIX.
+  They are pre and post handlers for the say and pose commands which will
+  be triggered upon these commands being issued.  These will only evaluate
+  substitutions and will not evaluate functions.
+  
+  If these attributes are set NO_COMMAND they will not return any message.
+  
+  See Also: say, pose, &quot;, :, ;
+   
+</PRE>
+<A HREF="#special characters">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#speech_suffix">[NEXT]</A>
+<BR>
+<HR><A NAME="speech_suffix"><H3>SPEECH_SUFFIX</H3></A><PRE>
+  Topic: special attributes
+  
+  These attributes are settable with &amp;SPEECH_PREFIX and &amp;SPEECH_SUFFIX.
+  They are pre and post handlers for the say and pose commands which will
+  be triggered upon these commands being issued.  These will only evaluate
+  substitutions and will not evaluate functions.
+  
+  If these attributes are set NO_COMMAND they will not return any message.
+  
+  See Also: say, pose, &quot;, :, ;
+   
+</PRE>
+<A HREF="#speech_prefix">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#spellnum()">[NEXT]</A>
 <BR>
 <HR><A NAME="spellnum()"><H3>SPELLNUM()</H3></A><PRE>
-  Function: spellnum(&lt;number&gt;)
+  Function: spellnum(&lt;number&gt; [,&lt;key&gt;])
   
   This function, when fed a number (decimal or floating point) will return
   the long name of the number (or in other wordes, the number in words).
   
+  A 'key' of 1 specifies the ordinal number instead of the pure numeric.
+  Ergo, 'tenth' instead of 'ten' or 'first' instead of 'one'. 
+  
+  Ordinals do not work with decimal notation and will be ignored.
+   
   Examples:
     &gt; say spellnum(10)
     You say &quot;ten&quot;
+    &gt; say spellnum(10,1)
+    You say &quot;tenth&quot;
+    &gt; say spellnum(1)
+    You say &quot;one&quot;
+    &gt; say spellnum(1,1)
+    You say &quot;first&quot;
     &gt; say spellnum(1010)
     You say &quot;one thousand ten&quot;
   
   See Also: strmath()
 
 </PRE>
-<A HREF="#speak()">[PREV]</A>
+<A HREF="#speech_suffix">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#splice()">[NEXT]</A>
 <BR>
@@ -33969,7 +43066,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   &lt;delim&gt; may be used to specify a delimiter other than a space.  
   
-  &lt;sep&gt; may be used to specify an output seperator other than a space.
+  &lt;sep&gt; may be used to specify an output separator other than a space.
    
   Example:
     &gt; say splice(foo bar baz,eek moof gleep,bar)
@@ -33987,7 +43084,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="spoofing"><H3>SPOOFING</H3></A><PRE>
   Topic: SPOOFING
  
-  Spoofing is the act of making other characters think that a person said or
+  Spoofing is the act of making other players think that a person said or
   did something that they did not.  This is very easy to accomplish, and has
   some good effects, which is why it is allowed.  Note that the NOSPOOF flag
   allows players to see exactly who is spoofing what.  Be warned, wizards are
@@ -34240,6 +43337,41 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#squish()">[NEXT]</A>
 <BR>
 <HR><A NAME="squish()"><H3>SQUISH()</H3></A><PRE>
+  Function squish(&lt;string&gt;[,&lt;delimeter&gt; [,&lt;count&gt;])
+  
+  This function will remove multiple spaces (or specified delimiter) from
+  the string.  This is meant for the ability to remove excess spaces from
+  strings.  The delimeter defaults to a space.
+  
+  You may specify a &lt;count&gt; of how many repeated characters will be 
+  inserted between the values in the string.  The count defaults to 1.
+  
+  Examples:
+    &gt; @wait 0=@va me=Test[space(20)]Test
+    Set.
+    &gt; say u(va)
+    You say &quot;Test                    Test&quot;
+    &gt; say squish(u(va))
+    You say &quot;Test Test&quot;
+    &gt; say squish(u(va),,5)
+    You say &quot;Test     Test&quot;
+    &gt; @vb me=TestaaaaaaaaaaaaaaaaaTest
+    Set.
+    &gt; say u(vb)
+    You say &quot;TestaaaaaaaaaaaaaaaaaTest&quot;
+    &gt; say squish(u(vb),a)
+    You say &quot;TestaTest&quot;
+    &gt; say squish(u(vb),a,5)
+    You say &quot;TestaaaaaTest&quot;
+  
+  See Also: s(), strip(), creplace(), trim()
+  
+</PRE>
+<A HREF="#sqrt()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#squish()">[NEXT]</A>
+<BR>
+<HR><A NAME="squish()"><H3>SQUISH()</H3></A><PRE>
   Function: squish(string)
   
   This function takes out all leading and ending spaces and reduces all spaces
@@ -34249,35 +43381,7 @@ Generated: Wed Jan 13 04:15:48 2016
    &gt;say squish([space(10)]hi![space(10)]Bye![space(10)])
     You say &quot;hi! Bye!&quot;
   
-  See Also: s()
-  
-</PRE>
-<A HREF="#sqrt()">[PREV]</A>
-<A HREF="#topic index">[TOP]</A>
-<A HREF="#squish()">[NEXT]</A>
-<BR>
-<HR><A NAME="squish()"><H3>SQUISH()</H3></A><PRE>
-  Function squish(&lt;string&gt;[,&lt;delimeter&gt;])
-  
-  This function will remove multiple spaces (or specified delimiter) from
-  the string.  This is meant for the ability to remove excess spaces from
-  strings.
-  
-  Examples:
-    &gt; @wait 0=@va me=Test[space(20)]Test
-    Set.
-    &gt; say v(va)
-    You say &quot;Test                    Test&quot;
-    &gt; say squish(v(va))
-    You say &quot;Test Test&quot;
-    &gt; @vb me=TestaaaaaaaaaaaaaaaaaTest
-    Set.
-    &gt; say v(vb)
-    You say &quot;TestaaaaaaaaaaaaaaaaaTest&quot;
-    &gt; say squish(v(vb),a)
-    You say &quot;TestaTest&quot;
-  
-  See Also: s(), strip(), creplace(), trim()
+  See Also: s(), trim(), edit(), tr()
   
 </PRE>
 <A HREF="#squish()">[PREV]</A>
@@ -34317,7 +43421,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say startsecs()
     You say &quot;2324234&quot;
    
-  See Also: startime(), secs(), rebootsecs(), reboottime()
+  See Also: startime(), secs(), rebootsecs(), reboottime(), msecs()
   
 </PRE>
 <A HREF="#stack">[PREV]</A>
@@ -34334,7 +43438,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say starttime()
     You say &quot;Sat Dec  7 00:09:13 1991
   
-  See Also: convtime(), reboottime(), startsecs(), rebootsecs()
+  See Also: convtime(), reboottime(), startsecs(), rebootsecs(), msecs()
   
 </PRE>
 <A HREF="#startsecs()">[PREV]</A>
@@ -34364,10 +43468,40 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; @stats/all
     377 objects = 51 rooms, 165 exits, 134 things, 20 players. (7 garbage)
   
-  See Also: @stats, @search, search(), searchng()
+  See Also: @stats, @search, search(), searchng(), searchobjid(),
+            searchngobjid()
   
 </PRE>
 <A HREF="#starttime()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#stderr()">[NEXT]</A>
+<BR>
+<HR><A NAME="stderr()"><H3>STDERR()</H3></A><PRE>
+  Function: stderr(&lt;string&gt; [,&lt;key&gt;])
+  
+  This function will take the input string and optionally redirect it based
+  on it being a recognized function error (starting with #-1) or not.  By
+  default, this function will null out the error entirely.  
+  
+  The following keys are available:
+    0 - null the output of the string that starts with #-1 (default)
+    1 - null the output of the string that starts with #-1
+        In addition, notify() to the player the actual error that started
+        with #-1 so it's no longer part of the function stack.
+  
+  Examples:
+    &gt; say [iter(1 3 5 [lrand(1,3)],##)]
+    You say &quot;1 3 5 #-1 FUNCTION (LRAND) EXPECTS 3 OR 4 ARGUMENTS [RECEIVED 2]&quot; 
+    &gt; say [iter(1 3 5 [stderr(lrand(1,3))],##)]
+    You say &quot;1 3 5&quot;
+    &gt; say [iter(1 3 5 [stderr(lrand(1,3),1)],##)]
+    STDError: #-1 FUNCTION (LRAND) EXPECTS 3 OR 4 ARGUMENTS [RECEIVED 2]
+    You say &quot;1 3 5&quot;
+  
+  See Also: null(), @@()
+
+</PRE>
+<A HREF="#stats()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#step()">[NEXT]</A>
 <BR>
@@ -34394,10 +43528,10 @@ Generated: Wed Jan 13 04:15:48 2016
   
   This function provided for compatibility with TinyMUSH 3.0
   
-  See Also: while(), map(), munge(), iter(), columns()
+  See Also: while(), map(), munge(), iter(), columns(), inf()
   
 </PRE>
-<A HREF="#stats()">[PREV]</A>
+<A HREF="#stderr()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#sticky">[NEXT]</A>
 <BR>
@@ -34438,10 +43572,10 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="strallof()"><H3>STRALLOF()</H3></A><PRE>
   Function: ofparse(&lt;type&gt;, [&lt;eval1&gt; [,&lt;eval2&gt; ... &lt;evalN or delim&gt;]])
 
-  Type 1&amp;3: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 2&amp;4: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
-  Type 5&amp;7: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 6&amp;8: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
+  Type 1&amp;3: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 2&amp;4: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
+  Type 5&amp;7: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 6&amp;8: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
   
   This function will take each &lt;eval&gt; and returns it based on the &lt;type&gt;.
   
@@ -34579,7 +43713,8 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say streval(Test: [s(%0)],citizen,[bittype(me)])
     You say &quot;Test: 1&quot;
   
-  See Also: ueval(), u(), default(), @lfunction
+  See Also: ueval(), u(), default(), subeval(), sandbox(), objeval(), 
+            @lfunction
     
 </PRE>
 <A HREF="#streq()">[PREV]</A>
@@ -34589,10 +43724,10 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="strfirstof()"><H3>STRFIRSTOF()</H3></A><PRE>
   Function: ofparse(&lt;type&gt;, [&lt;eval1&gt; [,&lt;eval2&gt; ... &lt;evalN or delim&gt;]])
 
-  Type 1&amp;3: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 2&amp;4: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
-  Type 5&amp;7: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
-  Type 6&amp;8: ofparse(1,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output seperator&gt;)
+  Type 1&amp;3: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 2&amp;4: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
+  Type 5&amp;7: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;default&gt;)
+  Type 6&amp;8: ofparse(&lt;type&gt;,[&lt;eval1&gt; ,&lt;eval2&gt; ... &lt;evalN&gt;], &lt;output separator&gt;)
   
   This function will take each &lt;eval&gt; and returns it based on the &lt;type&gt;.
   
@@ -34636,7 +43771,7 @@ Generated: Wed Jan 13 04:15:48 2016
   Function: strfunc(&lt;function&gt;, &lt;list of arguments&gt;[,&lt;delim&gt;])
   
   The strfunc (string function) function is used to transform a 
-  string of arguments into seperate identified arguments and feed 
+  string of arguments into separate identified arguments and feed 
   them into the specified function.  If you do not have access to the 
   function or if you give the target function an invalid number of 
   arguments, an error message will be displayed.
@@ -34714,8 +43849,10 @@ Generated: Wed Jan 13 04:15:48 2016
   Continued from String Functions.
       
   isnum()       - Returns true if input is a number.
+  isobjid()     - Returns true if input is an objid.
   ispunct()     - Returns true if first character of input is a punctuation.
   isspace()     - Returns true if first character of input is a whitespace.
+  istag()       - Returns true if passed a valid tag.
   isword()      - Returns true if the argument contains only alpha characters. 
   isxdigit()    - Returns true if first character of input is a hexadecimal.
   lcstr()       - Lowercases a string.
@@ -34743,7 +43880,7 @@ Generated: Wed Jan 13 04:15:48 2016
   rjust()       - Right justifies a string by padding it with specified char.
   rotl()        - Rotates a string X characters to the left.
   rotr()        - Rotates a string X characters to the right.
-  s()           - Performs pronoun substitution on a string.
+  s()           - Force evaluation of a string.
   
   { Continued in string functions3 }
 
@@ -34755,6 +43892,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="string functions3"><H3>string functions3</H3></A><PRE>
   Continued from string functions2
     
+  sandbox()     - Evaluates code with specific function restrictions
   scramble()    - Scrambles a string, returning the characters randomly.
   secure()      - Removes special characters from a string.
   securex()     - Like secure(), but you can specify characters not to remove.
@@ -34764,6 +43902,7 @@ Generated: Wed Jan 13 04:15:48 2016
   space()       - Returns X number of whitespace.
   splice()      - Splices two lists together.
   squish()      - Removes excess spaces or delimiters from a string.
+  stderr()      - Convert all #-1 errors to notify() and not the stack.
   str()         - Like after(), and similar to C strstr().
   strdistance() - Calculates the levenshtein distance between two strings.
   streq()       - Compares two strings, returning true if they match.
@@ -34774,10 +43913,12 @@ Generated: Wed Jan 13 04:15:48 2016
   strlenraw()   - Returns the length of the RAW string.
   strlenvis()   - Returns the length of the VISUAL string.
   strmatch()    - Returns true if a pattern is found in a string.
+  subeval()     - Performs pronoun substitution on a string.
   subnetmatch() - Returns true if an IP address is part of a subnet.
   switch()      - Powerful string-pattern conditional.
   switchall()   - Like switch(), but matches all occurrences of a pattern.
   t()           - Unifies MUSH responses of 0, null or #-* to return 0.
+  template()    - Direct WYSIWYG substitution in a template string.
   totpos()      - Returns all the positions of a match in a string.
   tr()          - Transforms a string based on find and replace lists.
   translate()   - Translates special characters to percent substitutions.
@@ -34849,7 +43990,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say stripansi(ansi(hr,red))
     You say &quot;red&quot;
   
-  See Also: NO_FLASH, ANSI, ANSICOLOR, stripaccents()
+  See Also: NO_FLASH, ANSI, ANSICOLOR, stripaccents(), ansipos()
   
 </PRE>
 <A HREF="#stripaccents()">[PREV]</A>
@@ -34971,29 +44112,54 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#strmath()">[NEXT]</A>
 <BR>
 <HR><A NAME="strmath()"><H3>strmath()</H3></A><PRE>
-  Function: strmath(&lt;str&gt;,&lt;num&gt;,&lt;math&gt;[,&lt;dlm&gt;,&lt;sep&gt;,&lt;st&gt;,&lt;amt&gt;,&lt;idlm&gt;,&lt;isep&gt;)
+  Function: strmath (syntax follows)
+  strmath(&lt;str&gt;,&lt;num&gt;,&lt;math&gt;[,&lt;dlm&gt;,&lt;sep&gt;,&lt;st&gt;,&lt;amt&gt;,&lt;idlm&gt;,&lt;isep&gt;,&lt;low&gt;,&lt;hi&gt;)
   
   The strmath function is used to apply math to the entire string.  Numbers
   in the string are modified based on the math chosen applied to the number.
-  You may specify optional input and output seperators.  You may also specify
+  You may specify optional input and output separators.  You may also specify
   the word to start (&lt;st&gt;) the math on and how many words (&lt;amt&gt;) after the 
   start you wish to use. If no math is specified, '+' is used as a default.
-  The &lt;idlm&gt; and &lt;isep&gt; are inner delimiter and seperator to use for the 
+  The &lt;idlm&gt; and &lt;isep&gt; are inner delimiter and separator to use for the 
   normal delimited string.  This is so you can separate values such as:
+  
                     To hit:5|To Damage:10|Base AC:15
   
   Note:  It handles floating point notation, so values with decimals are seen.
    
     Key:  str  -- input string    num  -- value to apply  math -- math to use
-          dlm  -- delimiter       sep  -- seperator       st   -- start value
+          dlm  -- delimiter       sep  -- separator       st   -- start value
           amt  -- word count      idlm -- inner delim     isep -- inner sep
+          low  -- low val match   hi   -- high val match
   
-  Valid math arguments are:
+  You may specify the 'low' and 'hi' values to specify a range of what values
+  you wish to apply the math to.
+   
+{ see 'help strmath2' for value values for &lt;math&gt; and examples }
+
+</PRE>
+<A HREF="#strmatch()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#strmath2">[NEXT]</A>
+<BR>
+<HR><A NAME="strmath2"><H3>strmath2</H3></A><PRE>
+  Function: strmath (syntax follows)  (CONTINUED)
+  strmath(&lt;str&gt;,&lt;num&gt;,&lt;math&gt;[,&lt;dlm&gt;,&lt;sep&gt;,&lt;st&gt;,&lt;amt&gt;,&lt;idlm&gt;,&lt;isep&gt;,&lt;low&gt;,&lt;hi&gt;)
+  
+  Valid &lt;math&gt; arguments are:
         + - apply addition to all numbers in the string.
         - - apply subtraction to all numbers in the string.
         / - apply division to all numbers in the string.
         * - apply multiplication to all numbers in the string.
        %% - return remainder of division. (you need to use two %%'s)
+  
+  Valid conditional &lt;math&gt; arguments are:
+         &lt;VALUE - set to &lt;num&gt; for every condition &lt; VALUE (eg. &lt;10)
+         &gt;VALUE - set to &lt;num&gt; for every condition &gt; VALUE (eg. &gt;10)
+         =VALUE - set to &lt;num&gt; for every condition = VALUE (eg. =10)
+        !=VALUE - set to &lt;num&gt; for every condition != VALUE (eg. !=10)
+        &lt;=VALUE - set to &lt;num&gt; for every condition &lt;= VALUE (eg. &lt;=10)
+        &gt;=VALUE - set to &lt;num&gt; for every condition &gt;= VALUE (eg. &gt;=10)
   
   Examples:
     &gt; say strmath(1 fish 2 fish green fish blue fish,10,+)   (default)
@@ -35004,21 +44170,36 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;1 fish 12 fish 13 shoe 4 shoe&quot;
     &gt; say strmath(To hit:5|To Damage:10|Base AC:15,150,+,|,|,1,0,:,:)
     You say &quot;To hit:155|To Damage:10|Base AC:15&quot;
+    &gt; say strmath(10 beats 5 but is less than 100,0,&lt;40)
+    You say &quot;0 beats 0 but is less than 100&quot;
+    &gt; say strmath(10 beats 5 but is less than 100,0,&gt;40)
+    You say &quot;10 beats 5 but is less than 0&quot;
+    &gt; say strmath(10 beats 5 but is less than 100,0,=5)
+    You say &quot;10 beats 0 but is less than 100&quot;
+    &gt; say strmath(10 beats 5 but is less than 100,0,!=5)
+    You say &quot;0 beats 5 but is less than 0&quot;
   
   See Also: add(), sub(), mul(), div(), mod(), strfunc(), spellnum()
   
 </PRE>
-<A HREF="#strmatch()">[PREV]</A>
+<A HREF="#strmath()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#strtrunc()">[NEXT]</A>
 <BR>
 <HR><A NAME="strtrunc()"><H3>STRTRUNC()</H3></A><PRE>
-  Function: left(&lt;string&gt;, &lt;position&gt;)
-   (Alias): strtrunc(&lt;string&gt;,&lt;position&gt;)
+  Function: left(&lt;string&gt;, &lt;position&gt; [,&lt;key&gt;])
+   (Alias): strtrunc(&lt;string&gt;,&lt;position&gt; [,&lt;key&gt;])
   
   Left will take a string and return the left-most position of characters
   from the string.
   
+  You may specify a &lt;key&gt; of 1 to tell left() to take the string raw and
+  not do ansi-aware processing.  This will speed up the function.
+  The default is '0' which does ansi processing.
+  
+  Note: the config param 'ansi_default' handles if the ansi handling is 
+        configured default or not.  In which case the 'key' is reversed.
+   
   Example:
     &gt; say left(this is a test,5)
     You say &quot;this &quot;
@@ -35030,7 +44211,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: right(), mid(), delete(), ljc(), rjc()
   
 </PRE>
-<A HREF="#strmath()">[PREV]</A>
+<A HREF="#strmath2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#sub()">[NEXT]</A>
 <BR>
@@ -35053,6 +44234,40 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#strtrunc()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#subeval()">[NEXT]</A>
+<BR>
+<HR><A NAME="subeval()"><H3>SUBEVAL()</H3></A><PRE>
+  Function: subeval(&lt;string&gt; [,,&lt;key&gt;])
+            subeval(&lt;thing&gt;, &lt;attribute&gt; [,&lt;key&gt;])
+  
+  This function will evaluate &lt;string&gt; by parsing all substitutions but will 
+  not evaluate functions, built in or otherwise.
+  
+  The second form will evaluate &lt;attribute&gt; from &lt;thing&gt; parsing all
+  substitutions but not evaluating any functions, built in or otherwise.
+  
+  You must be able to control &lt;thing&gt; to fetch the attribute.
+  
+  You may specify an optional &lt;key&gt; in both forms of 1 to force a double-parse
+  of substitutions.
+  
+  Example:
+    &gt; @va me=[add(1,1)] %# %n %%#
+    Set
+    &gt; say [subeval(%# %N %%# [sub(1,1)])]
+    You say &quot;#123 Tester %# [sub(1,1)]&quot;
+    &gt; say [subeval(%# %N %%# [sub(1,1)],,1)]
+    You say &quot;#123 Tester #123 [sub(1,1)]&quot;
+    &gt; say [subeval(me,va)]
+    You say &quot;[add(1,1)] #123 Tester %#&quot;
+    &gt; say [subeval(me,va,1)]
+    You say &quot;[add(1,1)] #123 Tester #123&quot;
+  
+  See Also: s(), eval(), sandbox(), ueval()
+
+</PRE>
+<A HREF="#sub()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#subj()">[NEXT]</A>
 <BR>
 <HR><A NAME="subj()"><H3>SUBJ()</H3></A><PRE>
@@ -35071,7 +44286,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: SUBSTITUTIONS, obj(), poss(), aposs()
   
 </PRE>
-<A HREF="#sub()">[PREV]</A>
+<A HREF="#subeval()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#subnetmatch()">[NEXT]</A>
 <BR>
@@ -35105,27 +44320,37 @@ Generated: Wed Jan 13 04:15:48 2016
   displayed, not the object that stored the message or which is running the
   action list.  The substitutions available are:
  
-    %s, %S  = Name, he, she, it, they.        (subjective)
-    %o, %O  = Name, him, her, it, them.       (objective)
-    %p, %P  = Name's, his, her, its, their.   (possessive)
-    %a, %A  = Name's, his, hers, its, theirs. (absolute possessive)
-    %n, %N  = the player's name.
-    %k, %K  = the player's colorized/accented name.
-    %w, %W  = the target dbref# of the twinklock (if applicable)
-    %r      = carriage return.
-    %t      = tab character.
-    %b      = space character.
-    %%      = literal '%' character.
-    %0-%9   = Value of positional parameter/stack location 0 through 9.
-    %-      = Stack 10+ that are comma delimited
-    %i0-%i9 = Equivalent to itext(0) through itext(9). [%il for outer]
-    %d0-%d9 = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
-              Only useable with /inline only.
-    %q0-%q9 = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
-    %qa-%qz = Extended value of registers.
-    %va-%vz = Contents of attribute va through vz.
-  
-  Note: %q&lt;label&gt; works for setq labels.  ie.  [setq(0,foo,bar)]%q&lt;bar&gt;
+    %s, %S     = Name, he, she, it, they.        (subjective)
+    %o, %O     = Name, him, her, it, them.       (objective)
+    %p, %P     = Name's, his, her, its, their.   (possessive)
+    %a, %A     = Name's, his, hers, its, theirs. (absolute possessive)
+    %n, %N     = the player's name.
+    %k, %K     = the player's colorized/accented name.
+    %w, %W     = the target dbref# of the twinklock (if applicable)
+    %r         = carriage return.
+    %t         = tab character.
+    %b         = space character.
+    %%         = literal '%' character.
+    %0-%9      = Value of positional parameter/stack location 0 through 9.
+    %-&lt;num&gt;    = Stack 10+ that are comma delimited or if &lt;num&gt; specified
+                 the positional stack location 0 through 999.  BANGS supported.
+    %-m        = The last command executed that issued @hook.  
+    %i0-%i99   = Equivalent to itext(0) through itext(99). [%il for outer]
+    %i_0-%i_99 = Equivalent to inum(0) through inum(99) [%i_l for outer]
+                 BANGS supported.  Note: '99' depends on recursion limit.
+    %d0-%d9    = Equivalent to dtext(0) through dtext(9).  [%dl for outer]
+                 Only useable with /inline only.  BANGS supported.
+    %q0-%q9    = Value of registers.  Basically equivalent to [r(0)] - [r(9)].
+                 Note: You may use %q&lt;label&gt;/%q&lt;0&gt; as well.  BANGS supported.
+    %qa-%qz    = Extended value of registers.
+    %va-%vz    = Contents of attribute va through vz.
+   
+    NOTE: Anything that says BANGS supported may use BANGS for the process.
+          example: %-!!$22 (see if arg 22 contains a string)
+                   %q&lt;!!$0&gt; (see if register 0 is a string)
+                   %q&lt;!!$foo&gt; (see if register with label 'foo' is a string)
+                   %i!!$0 (see if iter()'s itext(0) is a string)
+                   %d!!$0 (see if @dolist/inline's dtext(0) is a string)
   
 { 'help substitutions2' for more }
 
@@ -35136,6 +44361,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="substitutions2"><H3>substitutions2</H3></A><PRE>
     %#      = Database number of the object that caused the message to be
+              displayed or the action list to be run.
+    %:      = Database object-id of the object that caused the message to be
               displayed or the action list to be run.
     %l      = Database number of the location of the object that caused the
               message to be displayed or the action list to be run.
@@ -35233,12 +44460,22 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;A&quot;
     &gt; say switch(f,*a*,A,*b*,B,*c*,C,*d*,D)  
     You say &quot;&quot;
+    ----- if penn_switches enabled
+    &gt; say switch(3,&gt;=2,Y,N)
+    You say &quot;Y&quot;
+    ----- if float_switches enabled
+    &gt; say switch(2.23,&gt;=2.22,Y,N)
+    You say &quot;Y&quot;
   
   If configured, you may use #$ as a substition.   #$ is substituted with 
   the value of &lt;string&gt;. In this way, the commands in &lt;res11&gt;..&lt;dflt&gt; 
   have a short-hand way of getting at the matched value. 
   
-  Please check @list options if this has been enabled. 
+  Note: The following config parameters effect how this functions.
+        penn_switches  -- if enabled allows &gt;, &lt;, &gt;=. &lt;= for math.
+        float_switches -- if enabled allows floating values as well.
+  
+  Refer: '@list options boolean *switch*' to check switch options.
   
   See Also: @switch, match(), case(), ifelse(), switchall()
   
@@ -35264,12 +44501,22 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;ABC&quot;
     &gt; say switchall(f,*a*,A,*b*,B,*c*,C,*d*,D)  
     You say &quot;&quot;
+    ----- if penn_switches enabled
+    &gt; say switch(3,&gt;=2,Y,N)
+    You say &quot;Y&quot;
+    ----- if float_switches enabled
+    &gt; say switch(2.23,&gt;=2.22,Y,N)
+    You say &quot;Y&quot;
   
   If configured, you may use #$ as a substition.   #$ is substituted with 
   the value of &lt;string&gt;. In this way, the commands in &lt;res11&gt;..&lt;dflt&gt; 
   have a short-hand way of getting at the matched value. 
   
-  Please check @list options if this has been enabled. 
+  Note: The following config parameters effect how this functions.
+        penn_switches  -- if enabled allows &gt;, &lt;, &gt;=. &lt;= for math.
+        float_switches -- if enabled allows floating values as well.
+  
+  Refer: '@list options boolean *switch*' to check switch options.
   
   See Also: @switch, match(), case(), ifelse(), switch()
   
@@ -35297,6 +44544,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="t()"><H3>T()</H3></A><PRE>
   Function: t(&lt;string&gt;)
   
+  This is a TRUE BOOLEAN function.
+  
   Returns a '0' if the string is null (empty), a '0', or a # followed by any
   negative number, or a string containing nothing but spaces.  
   Otherwise, it returns a '1'.
@@ -35315,10 +44564,37 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say t(space(100))
     You say &quot;0&quot;
   
-  See Also: isdbref(), isspace(), s()
+  See Also: isobjid(), isdbref(), istag(), isspace(), s()
   
 </PRE>
 <A HREF="#switches">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#tag()">[NEXT]</A>
+<BR>
+<HR><A NAME="tag()"><H3>TAG()</H3></A><PRE>
+  Function: tag(&lt;string&gt;)
+ 
+  This function returns the #dbref stored behind the tag named &lt;string&gt;.
+  These tags get created with Rhost's tag system ( see 'wizhelp @tag' and
+  'wizhelp tags' ) by admins, and can be useful to avoid having hardcoded
+  #dbrefs in mushcode.
+ 
+  These tags can also be used on-the-fly in the client, for example using
+  something like 'ex tag(weather_globals)' to examine the object of which
+  the #dbref is stored in the 'weather_globals' tag.
+ 
+  If a non-existant tagname is supplied in the tag() function, it always
+  returns #-1.
+
+  NOTE: An alternative to using tag() is to look up a tag with #&lt;tagname&gt;
+   as a replacement for #dbref. For example, &quot;tag(weather_globals)&quot; and
+  &quot;#weather_globals&quot; will return the same #dbref.
+ 
+  Also See: help wizhelp tags, wizhelp @tag, wizhelp listtags(),
+            wizhelp tagmatch()
+  
+</PRE>
+<A HREF="#t()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#take">[NEXT]</A>
 <BR>
@@ -35344,7 +44620,7 @@ Generated: Wed Jan 13 04:15:48 2016
 { 'help take2' for more }
   
 </PRE>
-<A HREF="#t()">[PREV]</A>
+<A HREF="#tag()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#take2">[NEXT]</A>
 <BR>
@@ -35473,6 +44749,51 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#tel()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#template()">[NEXT]</A>
+<BR>
+<HR><A NAME="template()"><H3>TEMPLATE()</H3></A><PRE>
+  Function: template(&lt;string&gt;, &lt;arg0&gt; [,&lt;arg1&gt;, ..., &lt;arg9&gt;])
+  
+  This function will take an input string &lt;string&gt; as the template string
+  and do substitution based on the arguments you pass to it.  It will
+  walk through each of the arguments one character at a time and replace
+  the specified characters in the template.  The following characters
+  specify each of the template replacements in question:
+  
+    1 or more 0's -- will be a one to one replacement of chars in arg0
+    1 or more 1's -- will be a one to one replacement of chars in arg1
+    1 or more 2's -- will be a one to one replacement of chars in arg2
+    1 or more 3's -- will be a one to one replacement of chars in arg3
+    1 or more 4's -- will be a one to one replacement of chars in arg4
+    1 or more 5's -- will be a one to one replacement of chars in arg5
+    1 or more 6's -- will be a one to one replacement of chars in arg6
+    1 or more 7's -- will be a one to one replacement of chars in arg7
+    1 or more 8's -- will be a one to one replacement of chars in arg8
+    1 or more 9's -- will be a one to one replacement of chars in arg9
+  
+  You may have any order of substitions in the template.  You may
+  use numbers that have no arguments.  In such a case the template will
+  be replaced with a space character.  If the argument is shorter than
+  the number of substitutions in the template, spaces are used as filler.
+  
+  Tabs will be replaced with a single space. 
+  
+  This function is ansi and accent aware.
+  
+  Examples:
+    &gt; say template(test &lt;0123&gt; test &lt;0123&gt; test,aaaaaaa,bbbbbbb,cccccc,dddddd)
+    You say &quot;test &lt;abcd&gt; test &lt;abcd&gt; test&quot;
+    &gt; say template(test 001 wheee 100,----,&lt;&gt;)
+    You say &quot;test --&lt; wheee &gt;--&quot;
+    &gt; think template(&gt;&gt;&gt; 000000 &lt;&lt;&lt;%r&gt;&gt;&gt; 000000 &lt;&lt;&lt;,abcde%rtuvwy)
+    &gt;&gt;&gt; abcde  &lt;&lt;&lt;
+    &gt;&gt;&gt; tuvwy  &lt;&lt;&lt;
+  
+  See Also: printf(), edit(), regedit(), template()
+
+</PRE>
+<A HREF="#telok">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#temple">[NEXT]</A>
 <BR>
 <HR><A NAME="temple"><H3>TEMPLE</H3></A><PRE>
@@ -35484,7 +44805,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: score
   
 </PRE>
-<A HREF="#telok">[PREV]</A>
+<A HREF="#template()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#terse">[NEXT]</A>
 <BR>
@@ -35506,6 +44827,45 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#temple">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#testlock()">[NEXT]</A>
+<BR>
+<HR><A NAME="testlock()"><H3>TESTLOCK()</H3></A><PRE>
+  Function: testlock(&lt;key&gt;, &lt;target&gt; [,&lt;type&gt;])
+            testlock(&lt;key&gt;, &lt;target1&gt; [... &lt;targetN&gt;], &lt;type&gt;, &lt;sep&gt;[, &lt;osep&gt;])
+  
+  The first example of the testlock function will evaluate a lock that you 
+  pass against the target &lt;target&gt;.  It will evaluate permissions based 
+  on the enactor.
+  
+  The second example of the testlock function will evaluate a lock that you
+  pass against a list of target(s).  It will return each target's dbref#
+  based on the &lt;key&gt; and only evaluates &lt;key&gt; once for quicker processing.
+  You may specify an optional &lt;sep&gt; seperator, or leave blank for a default
+  of a space.  An optional &lt;osep&gt; for an output seperator may be specified
+  or it defaults to what the &lt;sep&gt; value is.
+  
+  The key &lt;key&gt; may be any normal key found in locks.  Please see
+  'help @lock' for more information on how locks work and keys available.
+  
+  You may specify an optional type &lt;type&gt; for specialized locks that
+  may require a subtype.  Following types are allowed:
+    0 - default lock.  Neither a $command nor a ^listen
+    1 - $command lock
+    2 - ^listen lock
+  
+  Examples:
+    &gt; say testlock(*tester&amp;&amp;!*tester,*tester)
+    You say &quot;0&quot;
+    &gt; say testlock(*tester,*tester)
+    You say &quot;1&quot;
+    &gt; say testlock(*tester|*bob,*tester *bob *foo,,%b)
+    You say &quot;#123 #234&quot;
+  
+  See Also: lockencode(), lockdecode(), lockcheck(), lock(), elock(), @lock
+  
+</PRE>
+<A HREF="#terse">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#thing">[NEXT]</A>
 <BR>
 <HR><A NAME="thing"><H3>THING</H3></A><PRE>
@@ -35514,7 +44874,7 @@ Generated: Wed Jan 13 04:15:48 2016
   something that can both be carried and which can carry something.
   
 </PRE>
-<A HREF="#terse">[PREV]</A>
+<A HREF="#testlock()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#think">[NEXT]</A>
 <BR>
@@ -35588,7 +44948,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say time()
     You say &quot;Thu Dec 19 09:48:06 1991&quot;
   
-  See Also: convsecs(), convtime(), secs()
+  See Also: convsecs(), convtime(), secs(), msecs()
  
 </PRE>
 <A HREF="#time functions">[PREV]</A>
@@ -35755,7 +45115,7 @@ Generated: Wed Jan 13 04:15:48 2016
   'Y'    Year                     0..????
   'y'    Year (two digit)         0..99
   
-  See Also: timefmt examples, secs()
+  See Also: timefmt examples, secs(), msecs()
   
 </PRE>
 <A HREF="#timefmt codelist2">[PREV]</A>
@@ -35908,7 +45268,7 @@ Generated: Wed Jan 13 04:15:48 2016
   'P'    AM or PM                 AM/PM
   'p'    am or pm                 am/pm
   
-  See Also: timefmt examples, secs()
+  See Also: timefmt examples, secs(), msecs()
   
 </PRE>
 <A HREF="#timefmt syntax2">[PREV]</A>
@@ -36090,7 +45450,7 @@ Generated: Wed Jan 13 04:15:48 2016
   BNT    Brunei Darussalam Time              Asia             UTC + 8 hours
   BOT    Bolivia Time                        South America    UTC - 4 hours
   BRST   Brasilia Summer Time                South America    UTC - 2 hours
-  BRT    Brasília time                       South America    UTC - 3 hours
+  BRT    Brasilia time                       South America    UTC - 3 hours
   BST    Bangladesh Standard Time            Asia             UTC + 6 hours
   BST1   British Summer Time                 Europe           UTC + 1 hour
   BTT    Bhutan Time                         Asia             UTC + 6 hours
@@ -36195,17 +45555,17 @@ Generated: Wed Jan 13 04:15:48 2016
   GST    Gulf Standard Time                  Asia             UTC + 4 hours
   GYT    Guyana Time                         South America    UTC - 4 hours
   H      Hotel Time Zone                     Military         UTC + 8 hours
-  HAA    Heure Avancée de l'Atlantique       North America    UTC - 3 hours
-  HAA1   Heure Avancée de l'Atlantique       Atlantic         UTC - 3 hours
-  HAC    Heure Avancée du Centre             North America    UTC - 5 hours
+  HAA    Heure Avancee de l'Atlantique       North America    UTC - 3 hours
+  HAA1   Heure Avancee de l'Atlantique       Atlantic         UTC - 3 hours
+  HAC    Heure Avancee du Centre             North America    UTC - 5 hours
   HADT   Hawaii-Aleutian Daylight Time       North America    UTC - 9 hours
-  HAE    Heure Avancée de l'Est              North America    UTC - 4 hours
-  HAE1   Heure Avancée de l'Est              Caribbean        UTC - 4 hours
-  HAP    Heure Avancée du Pacifique          North America    UTC - 7 hours
-  HAR    Heure Avancée des Rocheuses         North America    UTC - 6 hours
+  HAE    Heure Avancee de l'Est              North America    UTC - 4 hours
+  HAE1   Heure Avancee de l'Est              Caribbean        UTC - 4 hours
+  HAP    Heure Avancee du Pacifique          North America    UTC - 7 hours
+  HAR    Heure Avancee des Rocheuses         North America    UTC - 6 hours
   HAST   Hawaii-Aleutian Standard Time       North America    UTC - 10 hours
-  HAT    Heure Avancée de Terre-Neuve        North America    UTC - 2:30 hours
-  HAY    Heure Avancée du Yukon              North America    UTC - 8 hours
+  HAT    Heure Avancee de Terre-Neuve        North America    UTC - 2:30 hours
+  HAY    Heure Avancee du Yukon              North America    UTC - 8 hours
   
 { timezone list6 to continue }    5 of 12
 
@@ -36331,7 +45691,7 @@ Generated: Wed Jan 13 04:15:48 2016
   PONT   Pohnpei Standard Time               Pacific          UTC + 11 hours
   PST    Pacific Standard Time               North America    UTC - 8 hours
   PST1   Pitcairn Standard Time              Pacific          UTC - 8 hours
-  PT     Tiempo del Pacífico                 North America    UTC - 8 hours
+  PT     Tiempo del Pacifico                 North America    UTC - 8 hours
   PWT    Palau Time                          Pacific          UTC + 9 hours
   PYST   Paraguay Summer Time                South America    UTC - 3 hours
   PYT    Paraguay Time                       South America    UTC - 4 hours
@@ -36513,26 +45873,28 @@ Generated: Wed Jan 13 04:15:48 2016
 <HR><A NAME="topics"><H3>topics</H3></A><PRE>
   Help available on the following Topics:
  
-  ALT INVENTORIES     ALTNAMES          ANSINAMES            ARBITRARY COMMANDS
-  ATTRIBUTE USELOCKS  ATTRIBUTE FLAGS   ATTRIBUTE OWNERSHIP  ATTRIBUTE TREES
-  BANG NOTATION       BEING KILLED      BOGUS COMMANDS       BOOLEAN VALUES    
-  CHANGES             CHANNEL           COLORS               COMMAND EVALUATION
-  CONTROL             COPYRIGHT         COSTS                CREDITS         
-  CLUSTERS            DROP-TO           ENACTOR              EXITS           
-  FAILURE             FLAG ALIAS        FLAG LIST            FLAGS           
-  FUNCTION ALIASES    FUNCTION LIST     FUNCTION TYPES       FUNCTIONS       
-  GENDER              GOALS             GUESTS               HERE              
-  HOMES               LINKING           LISTENING            LISTS            
-  LOOPING             MAIL              ME                   MONEY          
-  MOVING              OBJECT TYPES      PARENT OBJECTS       PUPPETS       
-  QUICKREFERENCE      REALITY LEVELS    REGEXPS              REGEXP SYNTAX    
-  REGEXP CLASSES      REGEXP EXAMPLES   ROBBERY              ROYALTY          
-  SEARCH CLASSES      SEMAPHORES        SENSES               SETQ_TEMPLATES   
-  SQL                 SQLESCAPE         SIDEEFFECTS          SINGLETHREADING  
-  SPOOFING            STACK             SUBSTITUTIONS        SUCCESS          
-  SWITCHES            TOGGLES           USEFUL               USER ATTRIBUTES  
-  VARIABLE EXITS      VATOVZ            VERBS                WANDERER         
-  ZATOZZ              ZONES             $-COMMANDS           #LAMBDA
+  ALT INVENTORIES     ALTNAMES           ANSINAMES           API
+  ARBITRARY COMMANDS  ATTRIB FORMATTING  ATTRIBUTE USELOCKS  ATTRIBUTE FLAGS 
+  ATTRIBUTE OWNERSHIP ATTRIBUTE TREES    BANG NOTATION       BEING KILLED    
+  BOGUS COMMANDS      BOOLEAN VALUES     CHANGES             CHANNEL         
+  CODING              COLORS             COMMAND EVALUATION  CONTROL         
+  COPYRIGHT           COSTS              CREDITS             CLUSTERS        
+  DROP-TO             ENACTOR            EXITS               FAILURE         
+  FLAG ALIAS          FLAG LIST          FLAGS               FUNCTION ALIASES
+  FUNCTION LIST       FUNCTION TYPES     FUNCTIONS           GENDER          
+  GOALS               GUESTS             HERE                HOMES           
+  LINKING             LISTENING          LISTS               LOOPING         
+  MAIL                MAX ARGS           ME                  MONEY           
+  MOVING              OBJECT TYPES       PARENT OBJECTS      PUPPETS         
+  QUICKREFERENCE      REALITY LEVELS     REGEXPS             REGEXP SYNTAX   
+  REGEXP CLASSES      REGEXP EXAMPLES    ROBBERY             ROYALTY         
+  SEARCH CLASSES      SEMAPHORES         SENSES              SETQ_TEMPLATES  
+  SIDEEFFECTS         SINGLETHREADING    SPECIAL CHARACTERS  SPOOFING        
+  SQL                 SQLESCAPE          STACK               SUBSTITUTIONS   
+  SUCCESS             SWITCHES           TOGGLES             USEFUL          
+  UNICODE SUPPORT     USER ATTRIBUTES    VARIABLE EXITS      VATOVZ         
+  VERBS               WANDERER           WILDCARDS           WIZARD ATTRIBUTES
+  ZATOZZ              ZONES               $-COMMANDS         #LAMBDA          
   
 </PRE>
 <A HREF="#tooct()">[PREV]</A>
@@ -36553,6 +45915,55 @@ Generated: Wed Jan 13 04:15:48 2016
   
 </PRE>
 <A HREF="#topics">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totems()">[NEXT]</A>
+<BR>
+<HR><A NAME="totems()"><H3>TOTEMS()</H3></A><PRE>
+  Function: totems(&lt;object&gt;)
+  
+  Totems returns a string consisting of the totem letters attached
+  to the object.  The string is, however, just one word.  All letters
+  in the 'second' tier of letters will be surrounded by []'s.  All 
+  letters in the 'third' tier of letters will be surrounded by {}'s.
+  
+  All default letters (?) defined to toggles will be skipped.  This
+  is intentional.
+  
+  Examples:
+    &gt; @list totems
+      Totems : FOO(f) BAR([b]) BAZ(z)
+    &gt; say ltotems(me)
+      You say &quot;FOO BAR BAZ&quot;
+    &gt; say totems(me)
+      You say &quot;fz[b]&quot;
+  
+  See Also: ltotems(), flags(), toggles(), lflags(), ltoggles(),
+            @totem
+
+</PRE>
+<A HREF="#totcmds()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totemset()">[NEXT]</A>
+<BR>
+<HR><A NAME="totemset()"><H3>TOTEMSET()</H3></A><PRE>
+  Function: totemset(&lt;target&gt;, &lt;TOTEM1 TOTEM2 ... TOTEMN !TOTEM1 ... !TOTEMN&gt;)
+  
+  This is a side-effect function that will set or unset totems on a target.
+  The totem must be a valid totem and the target must be valid and
+  controllable by the enactor.
+  
+  This requires the SIDEFX flag.  If you do not have access to the @totem
+  command you may not use this side-effect.  If this side-effect has been
+  disabled you will be unable to use this side-effect.
+  
+  Example:
+    &gt; say totemset(me,toteminit)
+    Set.
+  
+  See Also: @totem, set(), toggle(), SIDEFX
+
+</PRE>
+<A HREF="#totems()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#totmatch()">[NEXT]</A>
 <BR>
@@ -36577,7 +45988,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: match(), nummatch(), member(), nummember(), totmember()
   
 </PRE>
-<A HREF="#totcmds()">[PREV]</A>
+<A HREF="#totemset()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#totmember()">[NEXT]</A>
 <BR>
@@ -36685,7 +46096,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <BR>
 <HR><A NAME="tr()"><H3>TR()</H3></A><PRE>
   Function: tr(&lt;string&gt;, &lt;find&gt;, &lt;replace&gt; [,&lt;type&gt;])
-
+  
   This function translates every character in &lt;string&gt; that exists in
   &lt;find&gt; to the character at an identical position in &lt;replace&gt;. 
   
@@ -36693,7 +46104,7 @@ Generated: Wed Jan 13 04:15:48 2016
   ansi-aware and also process strings faster without the ansi overhead.
   The default value is '0' which allows tr() to be fully ansi-aware.
    
-  Ranges of characters seperated by -'s are accepted. &lt;find&gt; and &lt;replace&gt; 
+  Ranges of characters separated by -'s are accepted. &lt;find&gt; and &lt;replace&gt; 
   must be the same length after expansion of ranges. If a character exists 
   more than once in &lt;find&gt;, only the last instance will be counted. The example
   below is the common ROT-13 algorithm for lower case strings, demonstrated
@@ -36709,7 +46120,9 @@ Generated: Wed Jan 13 04:15:48 2016
       You say, &quot;uryyb&quot;
     &gt; say tr(uryyb, a-z, n-za-m)
       You say, &quot;hello&quot;
- 
+    &gt; say tr(This is a TEST,a-mn-zA-MN-Z,n-za-mN-ZA-M)  (rot13)
+      You ssay, &quot;Guvf vf n GRFG&quot;
+  
   See also: merge(), foreach(), garble(), creplace(), edit(), editansi()
 
 </PRE>
@@ -36770,6 +46183,9 @@ Generated: Wed Jan 13 04:15:48 2016
   However, if the TRACE flag was set on the object prior to execution, then
   you would see trace output for everything up to the trace(0) call.
   
+  You may specify a TRACETAB attribute that contains a number between 0-10
+  to indent related trace output.
+  
   See Also: %_, TRACE, VERBOSE, PUPPET, chktrace()
   
 </PRE>
@@ -36783,45 +46199,43 @@ Generated: Wed Jan 13 04:15:48 2016
   number of trace output lines that may be produced by an evaluation is limited
   to 200.  Bottom-up trace output is not limited.
   
-  See Also: VERBOSE, PUPPET, %_, trace(), chktrace()
+  You may set a TRACETAB attribute to a value between 0 and 10 to indent 
+  related trace output if you prefer that.
+   
+  You may use LABELS (help @label and help %_) for advanced tracing.
+   
+  See Also: VERBOSE, PUPPET, %_, trace(), chktrace(), TRACETAB
 
 </PRE>
 <A HREF="#trace()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
-<A HREF="#trace_grep">[NEXT]</A>
+<A HREF="#trace_color">[NEXT]</A>
 <BR>
-<HR><A NAME="trace_grep"><H3>TRACE_GREP</H3></A><PRE>
-  Topic: SUBSTITUTIONS
-  Syntax: %_&lt;label&gt;  -- enables debugging if &lt;label&gt; is in TRACE attribute.
-          %_&lt;-label&gt; -- disables debugging for &lt;label&gt;
-          %_&lt;off&gt;    -- disables all debugging
-  
-  The %_ substitution is a special substitution as it allows you to enbed
-  breakpoints into code to toggle on and off debugging on the fly dynamically.
-  This is handled by the enactors 'TRACE' attribute that houses the marker
-  that you specify for the substitutions.  The marker can be any string.
-  
-  You use - for the label to turn off debugging for that particular debug
-  marker.  For stacked debugging this will decrement the debug stack count.
-   
-  Using the &lt;label&gt; adds to the debug stack and using &lt;-label&gt; reduces one
-  from the debug stack.  This allows you to essentially nest debugging
-  breakpoints within code and only enable/disable them when you set
-  the specified label in your TRACE value.  For instance, &amp;TRACE me=123
-  
-  Note: This has absolutely no impact on the TRACE flag and uses another
-  method to keep track of how it's tracing information.  You can use
-  this in addition to the TRACE flag if you so wish.
+<HR><A NAME="trace_color"><H3>TRACE_COLOR</H3></A><PRE>
+  Topic: SUBSTITUTIONS (CONTINUED)
+  Syntax: %_&lt;label&gt;      -- enables debugging if &lt;label&gt; is in TRACE attribute.
+          %_&lt;-label&gt;     -- disables debugging for last named &lt;label&gt;
+          %_&lt;-&gt;          -- disables debugging for last defined label
+          %_&lt;off&gt;        -- disables all debugging
+          %_&lt;!list&gt;      -- List current stack, in-use stack, and all labels.
+          %_&lt;!shortlist&gt; -- List current stack and in-use stack.
   
   You may use the attribute TRACE_COLOR to set a standard color for your
-  labels.   For instance, &amp;TRACE_COLOR me=+purple.  You may specify colors
-  by label as &amp;TRACE_COLOR_&lt;label&gt; me=+orange.  Like &amp;TRACE_COLOR_123.
-  This will fall back on 'TRACE_COLOR' if the by label isn't found.
+  labels.   For instance, &amp;TRACE_COLOR object=+purple.  You may specify 
+  colors by label as &amp;TRACE_COLOR_&lt;label&gt; object=+orange.  Like 
+  &amp;TRACE_COLOR_123.  This will fall back on 'TRACE_COLOR' if the by 
+  label isn't found.
   
-  You may specify a TRACE_GREP attibute on yourself (&amp;TRACE_GREP me=&lt;string&gt;)
-  if you wish to have a specific piece of code in trace output which matches
-  the trace output return in red the match.  If the TRACE_GREP attribute
-  is attribute-set REGEXP, it will take the string as a regexp match.
+  You may specify a TRACE_GREP attibute on the enactor 
+  (&amp;TRACE_GREP object=&lt;string&gt;) if you wish to have a specific piece 
+  of code in trace output which matches the trace output return in red 
+  the match.  If the TRACE_GREP attribute is attribute-set REGEXP, 
+  it will take the string as a regexp match.
+  
+  Keep in mind, the various &amp;TRACE attributes need to be on the executor,
+  not the object enacting the command.  It will behave like the TRACE flag.
+  So all attributes (like &amp;TRACE) need to be on the target that you 
+  have the labels on.
    
   Examples:
     &gt; &amp;TRACE me=123
@@ -36835,20 +46249,124 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say Debugging: [add(1,1)]%_&lt;123&gt;[add(2,2)]%_&lt;off&gt;[add(3,3)]
     YourPlayerName(#12345) [123]} 'add(2,2)' -&gt; '4'
     You say &quot;Debugging: 246&quot;
+    &gt; say Debugging: [add(1,1)]%_&lt;123&gt;[add(2,2)]%_&lt;-&gt;[add(3,3)]
+    YourPlayerName(#12345) [123]} 'add(2,2)' -&gt; '4'
+    You say &quot;Debugging: 246&quot;
   
-  In the last exampole, the 123 inside the []'s would have been orange.
+  In the last two examples, the 123 inside the []'s would have been orange.
   
-  See Also: SUBSTITUTIONS, TRACE, trace()
+  See 'help %_vars' for variables used with trace label debugging.
+  
+  See Also: SUBSTITUTIONS, TRACE, trace(), @label, ruler()
   
 </PRE>
 <A HREF="#trace2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#trace_grep">[NEXT]</A>
+<BR>
+<HR><A NAME="trace_grep"><H3>TRACE_GREP</H3></A><PRE>
+  Topic: SUBSTITUTIONS (CONTINUED)
+  Syntax: %_&lt;label&gt;      -- enables debugging if &lt;label&gt; is in TRACE attribute.
+          %_&lt;-label&gt;     -- disables debugging for last named &lt;label&gt;
+          %_&lt;-&gt;          -- disables debugging for last defined label
+          %_&lt;off&gt;        -- disables all debugging
+          %_&lt;!list&gt;      -- List current stack, in-use stack, and all labels.
+          %_&lt;!shortlist&gt; -- List current stack and in-use stack.
+  
+  You may use the attribute TRACE_COLOR to set a standard color for your
+  labels.   For instance, &amp;TRACE_COLOR object=+purple.  You may specify 
+  colors by label as &amp;TRACE_COLOR_&lt;label&gt; object=+orange.  Like 
+  &amp;TRACE_COLOR_123.  This will fall back on 'TRACE_COLOR' if the by 
+  label isn't found.
+  
+  You may specify a TRACE_GREP attibute on the enactor 
+  (&amp;TRACE_GREP object=&lt;string&gt;) if you wish to have a specific piece 
+  of code in trace output which matches the trace output return in red 
+  the match.  If the TRACE_GREP attribute is attribute-set REGEXP, 
+  it will take the string as a regexp match.
+  
+  Keep in mind, the various &amp;TRACE attributes need to be on the executor,
+  not the object enacting the command.  It will behave like the TRACE flag.
+  So all attributes (like &amp;TRACE) need to be on the target that you 
+  have the labels on.
+   
+  Examples:
+    &gt; &amp;TRACE me=123
+    &gt; say Debugging: [add(1,1)]%_&lt;123&gt;[add(2,2)]%_&lt;-123&gt;[add(3,3)]
+    YourPlayerName(#12345) [123]} 'add(2,2)' -&gt; '4'
+    You say &quot;Debugging: 246&quot;
+    &gt; say Debugging: [add(1,1)]%_&lt;123&gt;[add(2,2)]%_&lt;off&gt;[add(3,3)]
+    YourPlayerName(#12345) [123]} 'add(2,2)' -&gt; '4'
+    You say &quot;Debugging: 246&quot;
+    &gt; &amp;TRACE_COLOR me=+orange
+    &gt; say Debugging: [add(1,1)]%_&lt;123&gt;[add(2,2)]%_&lt;off&gt;[add(3,3)]
+    YourPlayerName(#12345) [123]} 'add(2,2)' -&gt; '4'
+    You say &quot;Debugging: 246&quot;
+    &gt; say Debugging: [add(1,1)]%_&lt;123&gt;[add(2,2)]%_&lt;-&gt;[add(3,3)]
+    YourPlayerName(#12345) [123]} 'add(2,2)' -&gt; '4'
+    You say &quot;Debugging: 246&quot;
+  
+  In the last two examples, the 123 inside the []'s would have been orange.
+  
+  See 'help %_vars' for variables used with trace label debugging.
+  
+  See Also: SUBSTITUTIONS, TRACE, trace(), @label, ruler()
+  
+</PRE>
+<A HREF="#trace_color">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#tracetab">[NEXT]</A>
+<BR>
+<HR><A NAME="tracetab"><H3>TRACETAB</H3></A><PRE>
+  Topic: SUBSTITUTIONS (CONTINUED)
+  Syntax: %_&lt;label&gt;      -- enables debugging if &lt;label&gt; is in TRACE attribute.
+          %_&lt;-label&gt;     -- disables debugging for last named &lt;label&gt;
+          %_&lt;-&gt;          -- disables debugging for last defined label
+          %_&lt;off&gt;        -- disables all debugging
+          %_&lt;!list&gt;      -- List current stack, in-use stack, and all labels.
+          %_&lt;!shortlist&gt; -- List current stack and in-use stack.
+  
+  The following special variables are used for %_ label debugging.
+  
+  TRACE            -- This is the main controller for labels.  When the
+                      object running code has a label matching one
+                      in this attribute, it will run debugging code
+                      for that label until turned off.   This should always
+                      have labels in lower case.
+  
+  TRACE_GREP       -- * Without the REGEXP attribute flag, it will use
+                        standard direct string matching and hilight red
+                        any match in your trace output.  Again, this must
+                        be set on the object running code.
+                      * With the REGEXP attribute flag, it uses enhanced
+                        regular expression matching to hilite red any
+                        matching pattern.
+  
+  TRACE_COLOR      -- This is the global generic color code that you wish
+                      any label to have.  If there's not a label specific
+                      color, this is what it will choose.  If no color
+                      is selected, it just hilights it.  Again, this must
+                      be set on the object running code.
+  
+  TRACE_COLOR_&lt;L&gt;  -- Where '&lt;L&gt;' is the name of the label.  For example
+                      if your label was 'bob' the attribute name would be
+                      'TRACE_COLOR_BOB'.  This will set a specific color
+                      for the given label to use.  This will have priority
+                      over the global TRACE_COLOR definition.
+  
+  TRACETAB         -- Specify how many spaces to indent on each parse
+  
+  See Also: SUBSTITUTIONS, TRACE, trace(), @label, ruler()
+  
+</PRE>
+<A HREF="#trace_grep">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#train">[NEXT]</A>
 <BR>
 <HR><A NAME="train"><H3>train</H3></A><PRE>
   Command: train
   The train command is used to output to the player what exactly you have 
-  typed.  The output is not parsed and is taken verbatum and displayed as
+  typed.  The output is not parsed and is taken verbatim and displayed as
   is. 
   
   Example:
@@ -36859,7 +46377,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: @emit, pose, @pemit, think, ]
   
 </PRE>
-<A HREF="#trace_grep">[PREV]</A>
+<A HREF="#tracetab">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#translate()">[NEXT]</A>
 <BR>
@@ -36883,7 +46401,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say translate(v(va),s)
     You say &quot;this  is atest&quot;
   
-  See Also: strip(), edit(), editansi(), s(), eval(), regedit()
+  See Also: strip(), edit(), editansi(), s(), eval(), regedit(), subeval()
   
 </PRE>
 <A HREF="#train">[PREV]</A>
@@ -36979,14 +46497,42 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#trigonometry functions">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#trreverse()">[NEXT]</A>
+<BR>
+<HR><A NAME="trreverse()"><H3>TRREVERSE()</H3></A><PRE>
+  Function: reverse(&lt;string&gt;)
+            trreverse(&lt;string&gt;)
+ 
+  Reverses the order of the characters of &lt;string&gt;.
+  
+  trreverse() works like reverse() except it transposes characters that 
+  are reverseable.  Ergo, &gt; to &lt;, ] to [, } to { and so forth.
+   
+  Examples:
+    &gt; say reverse(This is a test)
+    You say &quot;tset a si sihT&quot;
+    &gt; say reverse(This is a test, Really...)
+    You say &quot;...yllaeR ,tset a si sihT&quot;
+    &gt; say reverse(A man, a plan, a canal -- Panama!)
+    You say &quot;!amanaP -- lanac a ,nalp a ,nam A&quot;
+    &gt; say reverse(&gt;&gt;test&lt;&lt;)
+    You say &quot;&lt;&lt;tset&gt;&gt;&quot;
+    &gt; say trreverse(&gt;&gt;test&lt;&lt;)
+    You say &quot;&gt;&gt;tset&lt;&lt;&quot;
+  
+  See Also: revwords()
+  
+</PRE>
+<A HREF="#trim()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#trunc()">[NEXT]</A>
 <BR>
 <HR><A NAME="trunc()"><H3>TRUNC()</H3></A><PRE>
   Function: trunc(&lt;number&gt;)
- 
+   
   Returns the value of &lt;number&gt; after truncating off any fractional value.
   &lt;number&gt; may be a floating point number, and an integer result is returned.
- 
+   
   Examples:
     &gt; say trunc(5)
     You say &quot;5&quot;
@@ -37002,7 +46548,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: div(), floor(), mod(), round()
   
 </PRE>
-<A HREF="#trim()">[PREV]</A>
+<A HREF="#trreverse()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#txlevel()">[NEXT]</A>
 <BR>
@@ -37027,6 +46573,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;&quot;
   
   See Also: hasrxlevel(), hastxlevel(), rxlevel(), listrlevels(), chkreality()
+            rxdesc()
   
 </PRE>
 <A HREF="#trunc()">[PREV]</A>
@@ -37076,7 +46623,7 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;Word is u, arg2 is Foobar.&quot;
   
   See Also: s(), v(), get(), get_eval(), map(), ueval(), streval(),
-            objeval(), @lfunction
+            objeval(), @lfunction, sandbox(), subeval()
   
 </PRE>
 <A HREF="#type()">[PREV]</A>
@@ -37270,19 +46817,23 @@ Generated: Wed Jan 13 04:15:48 2016
   attribute.  For more detail on functionality, look at U().
  
   The available permission levels are CIT[IZEN], GUILD[MASTER], ARCH[ITECT],
-  COUN[CILOR], ROY[ALTY], IMM[ORTAL].  You must have the permissions of the
-  given level in order to use it else it defaults to your permission level.
+  COUN[CILOR], ROY[ALTY], IMM[ORTAL], SUB[EVAL].  You must have the permissions 
+  of the given level in order to use it else it defaults to your permission level.
   The permission must be included for the function to work.
+  
+  The special permission SUB[EVAL] will work like subeval() in that it will
+  only evaluate substitutions on the target and not evaluate functions.
   
   Examples:
     &gt; @set me=royalty (let's assume you're a wizard)
-    &gt; @va me=[num(*Miriar)] (the ghod character - #1)
+    &gt; @va me=[num(*Miriar)] (the ghod player - #1)
     &gt; say ueval(va/royalty)
     You say &quot;#1&quot;
     &gt; say ueval(va/citizen)
     You say &quot;#-1&quot;
   
-  See Also: u(), u2(), objeval(), ulocal(), u2local(), streval()
+  See Also: u(), u2(), objeval(), ulocal(), u2local(), streval(), subeval(),
+            sandbox()
   
 </PRE>
 <A HREF="#udefault()">[PREV]</A>
@@ -37407,6 +46958,35 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#unesclist()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#unicode support">[NEXT]</A>
+<BR>
+<HR><A NAME="unicode support"><H3>UNICODE SUPPORT</H3></A><PRE>
+  Topic: UNICODE SUPPORT
+  
+  RhostMUSH servers can now support unicode characters. Currently this only
+  supports UTF8 encoding of these characters. In order to make use of this
+  feature RhostMUSH must be compiled with ZHENTY ANSI support. This works
+  alongside ACCENTS support but is independent of it.
+  
+  For a player to see unicode characters they must enable the UTF8 toggle.
+  This toggle is mutually exclusive from the ACCENTS toggle but also works
+  alongside it, allowing accents sent by players with one toggle to be 
+  correctly seen by the other. However, those with neither toggle will have
+  these extended characters removed as normal. Similarly, unicode characters
+  beyond the supported range for ACCENTS will be removed for players with
+  that toggle.
+  
+  Unicode characters are encoded by the parser in the format %&lt;u####&gt; where
+  the ####s represent the unicode code point for the character. 
+  
+  A complete list of unicode characters can be found here: 
+  http://unicode.org/charts/
+  
+  See Also: UTF8 TOGGLE
+  
+</PRE>
+<A HREF="#unfindable">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#unpack()">[NEXT]</A>
 <BR>
 <HR><A NAME="unpack()"><H3>UNPACK()</H3></A><PRE>
@@ -37426,10 +47006,11 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt;think unpack(1111,2)
     15
    
-  See Also: pack(), crc32(), mask(), tobin(), tohex(), tooct(), todec()
+  See Also: pack(), crc32(), mask(), tobin(), tohex(), tooct(), todec(),
+            packmath()
   
 </PRE>
-<A HREF="#unfindable">[PREV]</A>
+<A HREF="#unicode support">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#use">[NEXT]</A>
 <BR>
@@ -37447,6 +47028,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#useful">[NEXT]</A>
 <BR>
 <HR><A NAME="useful"><H3>USEFUL</H3></A><PRE>
+  Topic: USEFUL
+  
   The following topics should be of greater import to learn for new users.
   
   news cmdlist          - lists all commands with the news system
@@ -37454,6 +47037,14 @@ Generated: Wed Jan 13 04:15:48 2016
   mail write cmdlist    - lists all commands with the mail line-editor
   folder cmdlist        - lists all commands with the mail folder system
   page                  - lists differences in the page system
+  goto                  - for movement (or just type the exit name)
+  look                  - to look at something.  Specify optional target.
+  drop                  - to drop something
+  get                   - to get something
+  inventory             - to see your inventory
+  say                   - to say something (use &quot; as shorthand)
+  pose                  - to pose/emote something (use : as shorthand)
+  @emit                 - to emit something (use \\ as shorthand)
   WHO                   - needs to be capitalized to who (unless changed)
   QUIT                  - needs to be capitalized to quit (unless changed)
   LOGOUT                - needs to be capitalized to logout (unless changed)
@@ -37471,6 +47062,8 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#user attributes">[NEXT]</A>
 <BR>
 <HR><A NAME="user attributes"><H3>USER ATTRIBUTES</H3></A><PRE>
+  Topic: USER ATTRIBUTES
+  
   User attributes are defined as personally designed or created attribute
   names by the user.  These can be mostly anything you want, up to the
   length of the current SBUF (32 or 64 characters) and starting with
@@ -37488,7 +47081,7 @@ Generated: Wed Jan 13 04:15:48 2016
   permissions prefixes that may be established.
   
   See Also: &amp;, &gt;, @set, set(), @cpattr, @mvattr
-  
+
 </PRE>
 <A HREF="#useful">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -37517,6 +47110,52 @@ Generated: Wed Jan 13 04:15:48 2016
 
 </PRE>
 <A HREF="#user attributes">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#utf8 support">[NEXT]</A>
+<BR>
+<HR><A NAME="utf8 support"><H3>UTF8 SUPPORT</H3></A><PRE>
+  Topic: UNICODE SUPPORT
+  
+  RhostMUSH servers can now support unicode characters. Currently this only
+  supports UTF8 encoding of these characters. In order to make use of this
+  feature RhostMUSH must be compiled with ZHENTY ANSI support. This works
+  alongside ACCENTS support but is independent of it.
+  
+  For a player to see unicode characters they must enable the UTF8 toggle.
+  This toggle is mutually exclusive from the ACCENTS toggle but also works
+  alongside it, allowing accents sent by players with one toggle to be 
+  correctly seen by the other. However, those with neither toggle will have
+  these extended characters removed as normal. Similarly, unicode characters
+  beyond the supported range for ACCENTS will be removed for players with
+  that toggle.
+  
+  Unicode characters are encoded by the parser in the format %&lt;u####&gt; where
+  the ####s represent the unicode code point for the character. 
+  
+  A complete list of unicode characters can be found here: 
+  http://unicode.org/charts/
+  
+  See Also: UTF8 TOGGLE
+  
+</PRE>
+<A HREF="#userlocks">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#utf8 toggle">[NEXT]</A>
+<BR>
+<HR><A NAME="utf8 toggle"><H3>UTF8 TOGGLE</H3></A><PRE>
+  Toggle: UTF8
+  
+  When set on a player, and as long as ZENTY_ANSI has been compiled
+  into the RhostMUSH in question, this allows the player to see
+  strings including extended character sets using UTF8 encoding.
+  
+  You can not have the UTF8 toggle with the ACCENT toggle enabled.
+  Attempting to do so will give you an error message.
+   
+  See Also: UNICODE SUPPORT, ACCENT TOGGLE
+  
+</PRE>
+<A HREF="#utf8 support">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#v()">[NEXT]</A>
 <BR>
@@ -37560,17 +47199,17 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: GENDER, SUBSTITUTION, PARENT OBJECTS, SHIFT()
   
 </PRE>
-<A HREF="#userlocks">[PREV]</A>
+<A HREF="#utf8 toggle">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#vadd()">[NEXT]</A>
 <BR>
 <HR><A NAME="vadd()"><H3>VADD()</H3></A><PRE>
-  Function: vadd(&lt;vector&gt;,&lt;vector&gt;[[,&lt;delimiter&gt;],&lt;seperator&gt;])
+  Function: vadd(&lt;vector&gt;,&lt;vector&gt;[[,&lt;delimiter&gt;],&lt;separator&gt;])
    
   Returns the sum of two vectors.  A vector is a list of numbers
   separated by spaces or a delimiter.  The vector lists must contain
   the same number of items or it will return an error.  You may
-  specify an optional output seperator.
+  specify an optional output separator.
    
   Examples:
     &gt; think vadd(1 2 3,4 5 6)
@@ -37621,7 +47260,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; say valid(playername,me)
     You say &quot;0&quot;
   
-  See Also: isdbref(), name()
+  See Also: isobjid(), isdbref(), istag(), name()
   
 </PRE>
 <A HREF="#vadd()">[PREV]</A>
@@ -37661,7 +47300,9 @@ Generated: Wed Jan 13 04:15:48 2016
   
   Specifies that the target exit is a 'variable' exit and that it will
   parse the @exitto attribute for it's destination location and not where
-  it is currently linked to.
+  it is currently linked to.  If the exit is @powered FULLTEL then that
+  exit will be assumed to have full 'link' privialages to any valid
+  location returned from @exitto.
   
   If a player sets the VARIABLE toggle on himself, then all ansi via
   Cname()/%k will show up when that player @walls, poses, or uses say.
@@ -37722,10 +47363,10 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#vcross()">[NEXT]</A>
 <BR>
 <HR><A NAME="vcross()"><H3>VCROSS()</H3></A><PRE>
-  Function: vcross(&lt;vector&gt;,&lt;vector&gt;[,&lt;delimiter&gt;],&lt;seperator&gt;])
+  Function: vcross(&lt;vector&gt;,&lt;vector&gt;[,&lt;delimiter&gt;],&lt;separator&gt;])
    
   Returns the cross product of two vectors. The cross product of two
-  vectors is a vector.  This function may take an optional seperator.
+  vectors is a vector.  This function may take an optional separator.
   
                           | a b c |
   (a,b,c) X (d,e,f) = det | d e f | = i(bf-ce) + j(cd-af) + k(ae-bd)
@@ -37937,11 +47578,11 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#vmul()">[NEXT]</A>
 <BR>
 <HR><A NAME="vmul()"><H3>VMUL()</H3></A><PRE>
-  Function: vmul(&lt;vector|number&gt;,&lt;vector|number&gt;[[,&lt;delimiter&gt;],&lt;seperator&gt;])
+  Function: vmul(&lt;vector|number&gt;,&lt;vector|number&gt;[[,&lt;delimiter&gt;],&lt;separator&gt;])
    
   Returns the result of either multiplying a vector by a number,
   or the elementwise product of two vectors.  This function may take an 
-  optional output seperator.
+  optional output separator.
   
   Examples: 
     &gt; think vmul(1 2 3,2)      (this is a vector by number)
@@ -37972,11 +47613,11 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#vsub()">[NEXT]</A>
 <BR>
 <HR><A NAME="vsub()"><H3>VSUB()</H3></A><PRE>
-  Function: vsub(&lt;vector&gt;,&lt;vector&gt;[[,&lt;delimiter&gt;],&lt;seperator&gt;])
+  Function: vsub(&lt;vector&gt;,&lt;vector&gt;[[,&lt;delimiter&gt;],&lt;separator&gt;])
    
   Returns the difference between two vectors.  The vectors must be
   the same length.  This function may take an optional output
-  seperator.
+  separator.
    
   Example:
     &gt; think vsub(3 4 5,3 2 1)
@@ -37992,11 +47633,11 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#vunit()">[NEXT]</A>
 <BR>
 <HR><A NAME="vunit()"><H3>VUNIT()</H3></A><PRE>
-  Function: vunit(&lt;vector&gt;[[,&lt;delimiter&gt;],&lt;seperator&gt;])
+  Function: vunit(&lt;vector&gt;[[,&lt;delimiter&gt;],&lt;separator&gt;])
    
   Returns the unit vector (a vector of magnitude 1), which points
   in the same direction as the given vector.  This function may take
-  an optional output seperator.
+  an optional output separator.
    
   Examples:
     &gt; think vunit(2 0 0)
@@ -38105,7 +47746,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
   This function provided for TinyMUSH 3.0 compatibility.
   
-  See Also: map(), step(), foreach(), iter()
+  See Also: map(), step(), foreach(), iter(), inf()
   
 </PRE>
 <A HREF="#while()">[PREV]</A>
@@ -38165,6 +47806,77 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#who">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#wildcards">[NEXT]</A>
+<BR>
+<HR><A NAME="wildcards"><H3>WILDCARDS</H3></A><PRE>
+  Topic:  WILDCARDS [* and ?]  (also referred to as GLOBBING)
+  
+  Note: RhostMUSH also supports regular expressions.  Please refer to 
+        'help REGEXPS'
+  
+  Wildcards are the standard globbing mechanism for the mush engine.  With the
+  wildcards, the '*' character is considered 0 or more characters and the '?'
+  character is considered a single character.  These are used primarilly in
+  commands and functions that allow mulit-matching based on wild card support.
+  
+  Example:
+    &gt; say match(this is a test,?es*)
+    You say &quot;4&quot;
+  
+  Wildcards, however, are most useful for $command substitution matching.
+  When you create your own softcoded command, any argument you want
+  substituted you would place a '*' or a '?' for that argument.  Each argument
+  is then matched up with a numerical argument for each wildcard used.  The
+  first argument being %0, second being %1, and so forth.
+  
+  Example:
+    &gt; &amp;TEST1 me=$test1*:@emit Your First Test:%0
+    &gt; &amp;TEST2 me=$test2?:@emit Your Second Test:%0
+    &gt; &amp;TEST3 me=$test3 *:@emit Your Third Test:%0
+    &gt; test1
+    Your First Test:
+    &gt; test1 abc
+    Your First Test: abc  [notice the space between ':' and 'a']
+    &gt; test2
+    Huh? (Type 'help' for help)  [Because ? requires 1 character exactly]
+    &gt; test2X
+    Your Second Test:X
+    &gt; test2abc
+    Huh? (Type 'help' for help)  [Because ? required 1 character exactly]
+    &gt; test3
+    Huh? (Type 'help' for help)  [because you have a space in the command]
+    &gt; test3 abc
+    Your Third Test:abc  [notice no space between ':' and 'a']
+    
+  { See 'help wildcards2' for clarification and extended explainations }
+ 
+</PRE>
+<A HREF="#wielded">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#wildcards2">[NEXT]</A>
+<BR>
+<HR><A NAME="wildcards2"><H3>WILDCARDS2</H3></A><PRE>
+  Clarification:
+    The difference between Test1 and Test3 is the fact there is a space in
+    the command between the command (test1 and test3 respectively) and the
+    wildcard.  For test1, when you did 'test1 abc' the space in ' abc' was
+    part of the argument you passed to the command, thus it included the
+    space.  In test3, you had a space as part of the requirement argument
+    so it required the space then saw 'abc' as the argument.   
+  
+    Test2 required a single character after it.  Anything less or more than
+    1 character exactly returned an error message.
+  
+  Additional matching:
+    You may use regular expressions instead of globbing if you set the 
+    attribute in question REGEXP (help attribute flag).  To use 
+    regular expressions instead, please check 'help REGEXPS'.
+  
+  See Also: ATTRIBUTE FLAG, REGEXP, $-command, ^-listens
+
+</PRE>
+<A HREF="#wildcards">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#wildmatch()">[NEXT]</A>
 <BR>
 <HR><A NAME="wildmatch()"><H3>wildmatch()</H3></A><PRE>
@@ -38195,12 +47907,13 @@ Generated: Wed Jan 13 04:15:48 2016
             totwildmatch(), match()
   
 </PRE>
-<A HREF="#wielded">[PREV]</A>
+<A HREF="#wildcards2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#wipe()">[NEXT]</A>
 <BR>
 <HR><A NAME="wipe()"><H3>WIPE()</H3></A><PRE>
-  Function: wipe(&lt;obj&gt;[/wildattr] [,&lt;regexp&gt;])
+  Function: wipe(&lt;obj&gt;[/wildattr] [[,&lt;regexp&gt;] [,&lt;ownerkey&gt;] [,&lt;preserve&gt;]])
+            wipe(&lt;owner&gt;/&lt;obj&gt;[/wildattr], [,&lt;regexp&gt;], 1, [,&lt;preserve&gt;])
   
   The wipe() function will remove all matching attributes specified by
   a wildcard, or, if no attribute is specified, remove all attributes of
@@ -38210,10 +47923,18 @@ Generated: Wed Jan 13 04:15:48 2016
   If &lt;regexp&gt; is specified as '1', then &lt;wildattr&gt; is evaluated as a
   regular expresion instead of the default expresion.
   
+  If &lt;ownerkey&gt; is specified as '1', then, as the second syntax example above,
+  it takes the additional &lt;owner&gt; argument as the owner to compare against.
+  
+  If &lt;preserve&gt; is specified as '1', it takes the reverse of the wipe and
+  keeps the specified wildcard pattern and wipes everything else.
+   
   Check @list options to see if this side-effect is enabled.
   Anything using this side-effect must have the SIDEFX flag set.
   
   Examples:
+    &gt; say wipe(Corum/#123/*foo,,1)   (this wipes attribs owned by Corum only)
+    You say &quot;Wipe: 1 attributes wiped.&quot;
     &gt; say wipe(#123/*foo*)
     You say &quot;Wipe: 8 attributes wiped.&quot;
     &gt; say wipe(#123/^.*ab$,1)
@@ -38225,6 +47946,28 @@ Generated: Wed Jan 13 04:15:48 2016
   
 </PRE>
 <A HREF="#wildmatch()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#wizard attributes">[NEXT]</A>
+<BR>
+<HR><A NAME="wizard attributes"><H3>WIZARD ATTRIBUTES</H3></A><PRE>
+  Topic: WIZARD ATTRIBUTES
+  
+  This is a backward compatible ability to set attributes that are
+  wizard settable and seeable.  This is obsoleted now with the addition
+  of the wizard command '@aflags'.
+  
+  Examples: 
+    &gt; &amp;_foo me=Only a wiz can see or set this.
+    Set.
+    &gt; @aflags _foo
+    (Attribute 231028) Flags are: private [hidden wizard] 
+  
+  Wizard help: @aflags, _
+  
+  See Also: &amp;, @set
+
+</PRE>
+<A HREF="#wipe()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#wizards">[NEXT]</A>
 <BR>
@@ -38248,7 +47991,7 @@ Generated: Wed Jan 13 04:15:48 2016
   See Also: IMMORTAL, ROYALTY, COUNCILOR, ARCHITECT, GUILDMASTER
   
 </PRE>
-<A HREF="#wipe()">[PREV]</A>
+<A HREF="#wizard attributes">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#wordpos()">[NEXT]</A>
 <BR>
@@ -38372,7 +48115,7 @@ Generated: Wed Jan 13 04:15:48 2016
   The width can not be above 4000 characters.
   
   See Also: ljust(), rjust(), center(), columns(), wrapcolumns(), printf(),
-            array()
+            array(), template()
   
 </PRE>
 <A HREF="#wrap()">[PREV]</A>
@@ -38398,7 +48141,7 @@ Generated: Wed Jan 13 04:15:48 2016
   * &lt;cut&gt;    - Specifies that the word be cut off if over maximum columns size.
                Arguments: 1 to cut, 0 for no cutting (default).
   * &lt;lbd&gt;    - What text you want displayed as the left border of the line.
-  * &lt;mbd&gt;    - What text you want as the seperator between columns on the line.
+  * &lt;mbd&gt;    - What text you want as the separator between columns on the line.
   * &lt;rbd&gt;    - What text you want displayed as the right border of the line.
   * &lt;dsp&gt;    - What display type you want.  Down then over or over then down.
                Arguments: 1 for over then down, 0 for down then over (default)
@@ -38466,7 +48209,7 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; @emit wrapcolumns(this is a test of wrapcolumns,10,3,R,0,1,&lt;*,|,*&gt;,1)
       &lt;* this is a|   test of|wrapcolumn*&gt;
   
-  See Also: columns(), wrap(), printf(), array()
+  See Also: columns(), wrap(), printf(), array(), template()
   
 </PRE>
 <A HREF="#wrapcolumns2">[PREV]</A>
@@ -38481,8 +48224,14 @@ Generated: Wed Jan 13 04:15:48 2016
   
   If &lt;player&gt; or &lt;target&gt; does not exist, it will return a failure (0).
   
-  If &lt;attrib&gt; does not exist, it will return a success, but only if the first
-  two conditions wouldn't cause a failure.
+  If &lt;attrib&gt; is an invalid attribute, it will return '0'.
+  
+  If &lt;attrib&gt; exists on &lt;target&gt;, it will check permissions and return '1' if
+  &lt;player&gt; can set the attribute, '0' if it can not.
+  
+  If &lt;attrib&gt; does not exist, it will check the hash table for matching 
+  permissions and return a '1' if the attribute would be settable on
+  the &lt;target&gt; by the &lt;player&gt;, or a '0' if would not.
   
   Example:
     &gt; say writable(bob, fred/desc)
@@ -38496,21 +48245,26 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#xcon()">[NEXT]</A>
 <BR>
 <HR><A NAME="xcon()"><H3>XCON()</H3></A><PRE>
-  Function: xcon(&lt;object&gt;[/switch],&lt;start&gt;,&lt;count&gt; [,&lt;switch&gt;])
+  Function: xcon(&lt;object&gt;[/switch],&lt;start&gt;,&lt;count&gt; [,&lt;switch&gt;] [,&lt;objid&gt;])
   
-  This function is similiar to lcon() except it returns a space-seperated list
+  This function is similiar to lcon() except it returns a space-separated list
   of the contents of &lt;object&gt; starting at point &lt;start&gt; and returning &lt;count&gt;
   number of contents.  It takes a specific switch as an option:
-      /PLAYER  -- lists all TYPE players in the contents.
-      /OBJECT  -- lists all TYPE objects in the contents.
-      /CONNECT -- lists all connected players in the contents.
-      /PUPPET  -- lists all flag type 'PUPPET' in the contents.
-      /LISTEN  -- lists all listening things in the contents.
+      /PLAYER    -- lists all TYPE players in the contents.
+      /OBJECT    -- lists all TYPE objects in the contents.
+      /CONNECT   -- lists all connected players in the contents.
+      /PUPPET    -- lists all flag type 'PUPPET' in the contents.
+      /LISTEN    -- lists all listening things in the contents.
+      /CMDLISTEN -- lists all listening/command things in the contents.
+      /VISIBLE   -- lists only things visible (not-dark) as if looking.
   
   You may optionally specify the switch as the second argument, without 
   the '/' before it, to do the same thing.  This will cause any /switch
   you have in the first argument to assume it's part of the object name.
   
+  You may optionally specify &lt;objid&gt; as '1' to have it list objid's instead
+  of the default dbref#'s.
+   
 { type 'help xcon2' for examples }
   
 </PRE>
@@ -38539,6 +48293,8 @@ Generated: Wed Jan 13 04:15:48 2016
     You say &quot;#2672&quot;
     &gt; say xcon(me,2,1,puppet)   
     You say &quot;#2672&quot;
+    &gt; say xcon(me,2,1,puppet,1)   
+    You say &quot;#2672:8281828218&quot;
   
   See Also: lexits(), lcon()
   
@@ -38548,16 +48304,27 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#xdec()">[NEXT]</A>
 <BR>
 <HR><A NAME="xdec()"><H3>XDEC()</H3></A><PRE>
-  Function: xdec(&lt;number&gt;)
+  Function: xdec(&lt;number&gt; [,&lt;key&gt;])
+  
+  DEC() and XDEC() may be reversed.  to check if they are, Please reference:  
+                           @list options system  
   
   The xdec() function is used to decrement the number passed into it.
   Any number passed into it is automatically decremented by one.
   
+  If &lt;key&gt; is 1, it does advanced increments.  It then will take the number
+  at the end of the string and increment, or if the string is a hexidicimal
+  code starting with '0x' or '0X' it will increment the hex number. 
+  
   Example:
-    &gt; say dec(5)
+    &gt; say xdec(5)
     You say &quot;4&quot;
-    &gt; say dec(-5)
+    &gt; say xdec(-5)
     You say &quot;-6&quot;
+    &gt; say xdec(test123,1)
+    You say &quot;test122&quot;
+    &gt; say xdec(0xfa,1)
+    You say &quot;0xf9&quot;
   
   See Also: xinc(), inc(), dec(), add(), sub()
   
@@ -38592,16 +48359,27 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#xinc()">[NEXT]</A>
 <BR>
 <HR><A NAME="xinc()"><H3>XINC()</H3></A><PRE>
-  Function: xinc(&lt;number&gt;)
+  Function: xinc(&lt;number&gt; [,&lt;key&gt;])
+  
+  INC() and XINC() may be reversed.  to check if they are, Please reference:  
+                           @list options system  
   
   The xinc() function is used to increment the number passed into it.
   Any number passed into it is automatically incremented by one.
   
+  If &lt;key&gt; is 1, it does advanced increments.  It then will take the number
+  at the end of the string and increment, or if the string is a hexidicimal
+  code starting with '0x' or '0X' it will increment the hex number. 
+  
   Example:
-    &gt; say inc(5)
+    &gt; say xinc(5)
     You say &quot;6&quot;
-    &gt; say inc(-5)
+    &gt; say xinc(-5)
     You say &quot;-4&quot;
+    &gt; say xinc(test123,1)
+    You say &quot;test124&quot;
+    &gt; say xinc(0xfa,1)
+    You say &quot;0xfb&quot;
   
   See Also: xdec(), inc(), dec(), add(), sub()
   
@@ -38867,16 +48645,22 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#zemit()">[NEXT]</A>
 <BR>
 <HR><A NAME="zemit()"><H3>ZEMIT()</H3></A><PRE>
-  Function: zemit(&lt;list of zones&gt;,&lt;text&gt;)
+  Function: zemit(&lt;list of zones&gt;, &lt;text&gt; [,&lt;key&gt;])
   
   The zemit() function returns 'text' to every room of every zone in
   the specified list.  If the target zone is not a zonemaster, but still
   is contained in a zone, then it will just return the text to that room.
+  This function by default evaluates '##' for each zone in the list and
+  evaluates separately for every zone member.
   
   This works similiarilly to @pemit/zone/list
   
   Check @list options to see if this side-effect is enabled.  
   Anything using this side-effect must have the SIDEFX flag set.
+  
+  Following &lt;key&gt; values exist:
+    1 - disable ## substitution.
+    2 - evaluate only once for every zone in list (disables ## automatically)
   
   Examples:
     &gt; @zone here=#0
@@ -39101,19 +48885,23 @@ Generated: Wed Jan 13 04:15:48 2016
   supplied the attribute.  For more detail on functionality, look at ZFUN().
  
   The available permission levels are CIT[IZEN], GUILD[MASTER], ARCH[ITECT],
-  COUN[CILOR], ROY[ALTY], IMM[ORTAL].  You must have the permissions of the
-  given level in order to use it else it defaults to your permission level.
-  The permission must be included for the function to work.
+  COUN[CILOR], ROY[ALTY], IMM[ORTAL], SUB[EVAL].  You must have the permissions
+  of the given level in order to use it else it defaults to your permission 
+  level.  The permission must be included for the function to work.
+  
+  The special permission SUB[EVAL] will work like subeval() in that it will
+  only evaluate substitutions on the target and not evaluate functions.
   
   Examples:
     &gt; @set me=royalty (let's assume you're a wizard)
-    &gt; @va #2=[num(*Miriar)] (the ghod character - #1) (#2 a zone you control)
+    &gt; @va #2=[num(*Miriar)] (the ghod player - #1) (#2 a zone you control)
     &gt; say zfuneval(va/royalty)
     You say &quot;#1&quot;
     &gt; say zfuneval(va/citizen)
     You say &quot;#-1&quot;
   
-  See Also: zfun(), zfun2(), objeval(), zfunlocal(), zfun2local()
+  See Also: zfun(), zfun2(), objeval(), zfunlocal(), zfun2local(), sandbox(),
+            subeval()
   
 </PRE>
 <A HREF="#zfundefault()">[PREV]</A>
@@ -39216,6 +49004,8 @@ Generated: Wed Jan 13 04:15:48 2016
   zfunlocal()    - Like ulocal(), but from the perspective of a zone object.
   zfun2local()   - Like u2local(), but from the perspective of a zone object.
   zwho()         - Returns the players in a specified zone master.
+  zonecmd()      - Adds/Deletes/Purges zones from targets.
+  lzone()        - Lists targets of a zone or zones of a target.
 
 </PRE>
 <A HREF="#zfunlocal2">[PREV]</A>
@@ -39253,6 +49043,92 @@ Generated: Wed Jan 13 04:15:48 2016
 </PRE>
 <A HREF="#zone_autoadd toggle">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#zonecmd()">[NEXT]</A>
+<BR>
+<HR><A NAME="zonecmd()"><H3>ZONECMD()</H3></A><PRE>
+  Function: zonecmd(&lt;command&gt;, &lt;target&gt; [,&lt;zone string&gt;])
+  
+  Note: This function requires the SIDEFX flag.
+  
+  The &lt;zone string&gt; in most cases will be the zone or target.  The exception 
+  is the replace command which requires the string of &lt;oldzone&gt;/&lt;newzone&gt;.
+  
+  This function duplicates the features of @zone, minus the list 
+  ability which can be found with lzone().  The following &lt;commands&gt;
+  are currently available with this function:
+    list    -- (shorthand with 'l') List zones on target zonemaster or all the 
+               zonemasters on the target zone.  You may specify &lt;boolean&gt; to
+               '1' (true) if you wish to show the list as objid's.
+               Syntax: zonecmd(list, target [,&lt;boolean&gt;])
+  
+    add     -- (shorthand with 'a') allows you to add a &lt;target&gt; to the the 
+               specified &lt;zone&gt;.  It does sanity check and like @zone you can 
+               not add a zonemaster to another zone.  
+               Syntax: zonecmd(add, target, zone)
+   
+    delete  -- (shorthand with 'd') allows you to delete the &lt;target&gt;
+               from the zone.  You can swap &lt;target&gt; and &lt;zone&gt; for
+               the same effect.
+               Syntax: zonecmd(del, target, zone)
+                       zonecmd(del, zone, target)
+  
+    replace -- (shorthand with 'r') allows you to replace the zonemaster from
+               the target with the new zonemaster.
+               Syntax: zonecmd(replace, target, oldzone/newzone)
+  
+    purge   -- (shorthand with 'p') allows you to purge all zones
+               from &lt;target&gt;.  If a non-zonemaster is specified, it
+               will purge all zones from the target.  If a zonemaster
+               is specified, it will purge all members from that zone.
+               Syntax: zonecmd(purge, target)
+ 
+{ see 'help zonecmd2' for examples}
+  
+</PRE>
+<A HREF="#zone_autoaddall toggle">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#zonecmd2 ">[NEXT]</A>
+<BR>
+<HR><A NAME="zonecmd2 "><H3>ZONECMD2 </H3></A><PRE>
+ (CONTINUED)
+  Function: zonecmd(&lt;command&gt;, &lt;target&gt; [,&lt;zone string&gt;])
+  
+  A successful execution of this function returns no output, otherwise
+  any error will start with #-1 for coding checks.
+  
+  You can belong to multiple zones at the same time.
+    
+  Examples:
+    &gt; @set #123=zonemaster
+    Set.
+    &gt; @set #789=zonemaster
+    Set.
+    &gt; @set #12345=zonemaster
+    Set.
+    &gt; say zonecmd(add,me,#789)
+    You say &quot;&quot;
+    &gt; say zonecmd(add,me,#12345)
+    You say &quot;&quot;
+    &gt; say zonecmd(list,me)
+    You say &quot;#789 #12345&quot;
+    &gt; say zonecmd(replace,me,#789/#123)
+    You say &quot;&quot;
+    &gt; say zonecmd(list,me)
+    You say &quot;#123 #12345&quot;
+    &gt; say zonecmd(add,me,#123)
+    You say &quot;#-1 ALREADY IN ZONE&quot;
+    &gt; say zonecmd(del,me,#123)
+    You say &quot;&quot;
+    &gt; say zonecmd(del,me,#123)
+    You say &quot;#-1 NOT IN ZONE&quot;
+    &gt; say zonecmd(list,me)
+    You say &quot;#12345&quot;
+  
+  See Also: @zone, ZONES, lzone(), inzone(), zwho()
+  
+</PRE>
+<A HREF="#zonecmd()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#zonecmdchk">[NEXT]</A>
 <BR>
 <HR><A NAME="zonecmdchk"><H3>ZONECMDCHK</H3></A><PRE>
@@ -39265,7 +49141,7 @@ Generated: Wed Jan 13 04:15:48 2016
   
 
 </PRE>
-<A HREF="#zone_autoaddall toggle">[PREV]</A>
+<A HREF="#zonecmd2 ">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#zonecontents">[NEXT]</A>
 <BR>
@@ -39385,7 +49261,7 @@ Generated: Wed Jan 13 04:15:48 2016
 <A HREF="#zwho()">[NEXT]</A>
 <BR>
 <HR><A NAME="zwho()"><H3>ZWHO()</H3></A><PRE>
-  Function: zwho(&lt;zone&gt; [,&lt;type&gt;])
+  Function: zwho(&lt;zone&gt; [,&lt;type&gt;] [,&lt;objid&gt;])
   Returns the players in the specified zonemaster.  If the target is not
   a zonemaster, or if the object is not a valid zone, it returns an
   empty list.  This is _not_ database intensive.  This is the default 
@@ -39395,6 +49271,9 @@ Generated: Wed Jan 13 04:15:48 2016
   inside every single location belonging to that zone.  Also not overly
   cost intensive.
   
+  You may optionally specify the &lt;objid&gt; to '1' to show the listings as
+  objid's instead of the default of dbref#'s.
+   
   Example:
     &gt; @set here=zonemaster
     &gt; @zone here=#0   (a room)
@@ -39404,12 +49283,16 @@ Generated: Wed Jan 13 04:15:48 2016
     &gt; @zone here=#987 (a player)
     &gt; say lzone(here)
     You say &quot;#0 #534 #987&quot;
+    &gt; say lzone(here,,1)
+    You say &quot;#0:8294929292 #534:8285029852 #987:8572572727&quot;
     &gt; say zwho(here)
     You say &quot;#987&quot;
     &gt; say zwho(here,1)
     You say &quot;#1 #3 #5&quot;
+    &gt; say zwho(here,1,1)
+    You say &quot;#1:8258757272 #3:8572757272 #5:8572572727&quot;
   
-  See Also: @zone, ZONES, lzone(), inzone()
+  See Also: @zone, ZONES, lzone(), inzone(), zonecmd()
   
 </PRE>
 <A HREF="#zones2">[PREV]</A>

--- a/Server/readme/wizhelp.html
+++ b/Server/readme/wizhelp.html
@@ -1,15 +1,16 @@
 <HTML><HEAD><TITLE>RhostMUSH Help File [HTML Version]</TITLE></HEAD><BODY>
 <H1>RhostMUSH Help File [HTML Version]</H1>
-Generated: Wed Jan 13 04:15:57 2016
+Generated: Mon Mar 15 08:30:56 2021
 <HR><A NAME="topic index"><H2>Topic Index</H2></A><PRE>
 <A HREF="##1">#1</A>                        <A HREF="#PLUSplayers">+players</A>                  <A HREF="#@adesc2">@adesc2</A>
 <A HREF="#@admin">@admin</A>                    <A HREF="#@aflags">@aflags</A>                   <A HREF="#@aflags add">@aflags add</A>
 <A HREF="#@aflags args">@aflags args</A>              <A HREF="#@aflags bits">@aflags bits</A>              <A HREF="#@aflags del">@aflags del</A>
 <A HREF="#@aflags mod">@aflags mod</A>               <A HREF="#@aflags perm">@aflags perm</A>              <A HREF="#@aflags2 ">@aflags2 </A>
-<A HREF="#@allowance">@allowance</A>                <A HREF="#@altname">@altname</A>                  <A HREF="#@apply_marked">@apply_marked</A>
-<A HREF="#@areg">@areg</A>                     <A HREF="#@areg2">@areg2</A>                    <A HREF="#@attribute">@attribute</A>
-<A HREF="#@badsite">@badsite</A>                  <A HREF="#@blacklist">@blacklist</A>                <A HREF="#@boot">@boot</A>
-<A HREF="#@chown">@chown</A>                    <A HREF="#@chownall">@chownall</A>                 <A HREF="#@clone">@clone</A>
+<A HREF="#@allowance">@allowance</A>                <A HREF="#@altname">@altname</A>                  <A HREF="#@api">@api</A>
+<A HREF="#@apply_marked">@apply_marked</A>             <A HREF="#@areg">@areg</A>                     <A HREF="#@areg2">@areg2</A>
+<A HREF="#@attribute">@attribute</A>                <A HREF="#@badsite">@badsite</A>                  <A HREF="#@blacklist">@blacklist</A>
+<A HREF="#@blacklist2">@blacklist2</A>               <A HREF="#@boot">@boot</A>                     <A HREF="#@chown">@chown</A>
+<A HREF="#@chownall">@chownall</A>                 <A HREF="#@clone">@clone</A>                    <A HREF="#@cmdquota">@cmdquota</A>
 <A HREF="#@comment">@comment</A>                  <A HREF="#@conncheck">@conncheck</A>                <A HREF="#@convert">@convert</A>
 <A HREF="#@create">@create</A>                   <A HREF="#@createdstamp">@createdstamp</A>             <A HREF="#@cut">@cut</A>
 <A HREF="#@darkexitformat">@darkexitformat</A>           <A HREF="#@dbck">@dbck</A>                     <A HREF="#@dbclean">@dbclean</A>
@@ -22,21 +23,26 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@halt">@halt</A>                     <A HREF="#@hide">@hide</A>                     <A HREF="#@hook">@hook</A>
 <A HREF="#@hook2">@hook2</A>                    <A HREF="#@icmd">@icmd</A>                     <A HREF="#@icmd eval">@icmd eval</A>
 <A HREF="#@icmd2">@icmd2</A>                    <A HREF="#@icmd3">@icmd3</A>                    <A HREF="#@icmd4">@icmd4</A>
-<A HREF="#@invtype">@invtype</A>                  <A HREF="#@kick">@kick</A>                     <A HREF="#@limit">@limit</A>
-<A HREF="#@list">@list</A>                     <A HREF="#@list allocations">@list allocations</A>         <A HREF="#@list attr_permissions">@list attr_permissions</A>
+<A HREF="#@invtype">@invtype</A>                  <A HREF="#@kick">@kick</A>                     <A HREF="#@leveldefault">@leveldefault</A>
+<A HREF="#@lfunction">@lfunction</A>                <A HREF="#@limit">@limit</A>                    <A HREF="#@list">@list</A>
+<A HREF="#@list advbuffers">@list advbuffers</A>          <A HREF="#@list allocations">@list allocations</A>         <A HREF="#@list attr_permissions">@list attr_permissions</A>
 <A HREF="#@list attributes">@list attributes</A>          <A HREF="#@list bad_names">@list bad_names</A>           <A HREF="#@list buffers">@list buffers</A>
-<A HREF="#@list cmdslogged">@list cmdslogged</A>          <A HREF="#@list commands">@list commands</A>            <A HREF="#@list costs">@list costs</A>
-<A HREF="#@list db_stats">@list db_stats</A>            <A HREF="#@list default_flags">@list default_flags</A>       <A HREF="#@list depowers">@list depowers</A>
-<A HREF="#@list depowers2">@list depowers2</A>           <A HREF="#@list flags">@list flags</A>               <A HREF="#@list functions">@list functions</A>
-<A HREF="#@list funperms">@list funperms</A>            <A HREF="#@list globals">@list globals</A>             <A HREF="#@list globals2">@list globals2</A>
-<A HREF="#@list guest_names">@list guest_names</A>         <A HREF="#@list hashstats">@list hashstats</A>           <A HREF="#@list hashstats2">@list hashstats2</A>
-<A HREF="#@list logging">@list logging</A>             <A HREF="#@list logging2">@list logging2</A>            <A HREF="#@list mail_globals">@list mail_globals</A>
-<A HREF="#@list options">@list options</A>             <A HREF="#@list permissions">@list permissions</A>         <A HREF="#@list powers">@list powers</A>
+<A HREF="#@list cmdslogged">@list cmdslogged</A>          <A HREF="#@list commands">@list commands</A>            <A HREF="#@list config_permissions">@list config_permissions</A>
+<A HREF="#@list costs">@list costs</A>               <A HREF="#@list db_stats">@list db_stats</A>            <A HREF="#@list default_flags">@list default_flags</A>
+<A HREF="#@list depowers">@list depowers</A>            <A HREF="#@list depowers2">@list depowers2</A>           <A HREF="#@list flags">@list flags</A>
+<A HREF="#@list functions">@list functions</A>           <A HREF="#@list funperms">@list funperms</A>            <A HREF="#@list globals">@list globals</A>
+<A HREF="#@list globals2">@list globals2</A>            <A HREF="#@list guest_names">@list guest_names</A>         <A HREF="#@list hashstats">@list hashstats</A>
+<A HREF="#@list hashstats2">@list hashstats2</A>          <A HREF="#@list logging">@list logging</A>             <A HREF="#@list logging2">@list logging2</A>
+<A HREF="#@list mail_globals">@list mail_globals</A>        <A HREF="#@list options">@list options</A>             <A HREF="#@list options boolean">@list options boolean</A>
+<A HREF="#@list options config">@list options config</A>      <A HREF="#@list options convtime">@list options convtime</A>    <A HREF="#@list options display">@list options display</A>
+<A HREF="#@list options mail">@list options mail</A>        <A HREF="#@list options mysql">@list options mysql</A>       <A HREF="#@list options system">@list options system</A>
+<A HREF="#@list options values">@list options values</A>      <A HREF="#@list permissions">@list permissions</A>         <A HREF="#@list powers">@list powers</A>
 <A HREF="#@list powers2">@list powers2</A>             <A HREF="#@list process">@list process</A>             <A HREF="#@list rlevels">@list rlevels</A>
 <A HREF="#@list site_information">@list site_information</A>    <A HREF="#@list site_information2">@list site_information2</A>   <A HREF="#@list stacks">@list stacks</A>
 <A HREF="#@list switches">@list switches</A>            <A HREF="#@list toggles">@list toggles</A>             <A HREF="#@list user_attributes">@list user_attributes</A>
-<A HREF="#@list_file">@list_file</A>                <A HREF="#@list_file2">@list_file2</A>               <A HREF="#@listmotd">@listmotd</A>
-<A HREF="#@lock">@lock</A>                     <A HREF="#@log">@log</A>                      <A HREF="#@logrotate">@logrotate</A>
+<A HREF="#@list vattrcmds">@list vattrcmds</A>           <A HREF="#@list_file">@list_file</A>                <A HREF="#@list_file2">@list_file2</A>
+<A HREF="#@listmotd">@listmotd</A>                 <A HREF="#@lock">@lock</A>                     <A HREF="#@lock type altname">@lock type altname</A>
+<A HREF="#@lock/altname">@lock/altname</A>             <A HREF="#@log">@log</A>                      <A HREF="#@logrotate">@logrotate</A>
 <A HREF="#@mailscur">@mailscur</A>                 <A HREF="#@mailsmax">@mailsmax</A>                 <A HREF="#@mailtime">@mailtime</A>
 <A HREF="#@mark">@mark</A>                     <A HREF="#@mark_all">@mark_all</A>                 <A HREF="#@modifiedstamp">@modifiedstamp</A>
 <A HREF="#@money">@money</A>                    <A HREF="#@motd">@motd</A>                     <A HREF="#@newpassword">@newpassword</A>
@@ -49,25 +55,49 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@reclist">@reclist</A>                  <A HREF="#@recover">@recover</A>                  <A HREF="#@remote">@remote</A>
 <A HREF="#@rsrvdesc2">@rsrvdesc2</A>                <A HREF="#@rwho">@rwho</A>                     <A HREF="#@rxlevel">@rxlevel</A>
 <A HREF="#@shutdown">@shutdown</A>                 <A HREF="#@site">@site</A>                     <A HREF="#@snapshot">@snapshot</A>
-<A HREF="#@thaw">@thaw</A>                     <A HREF="#@timeout">@timeout</A>                  <A HREF="#@timewarp">@timewarp</A>
-<A HREF="#@toad">@toad</A>                     <A HREF="#@toggledef">@toggledef</A>                <A HREF="#@toggledef2">@toggledef2</A>
-<A HREF="#@toggledef3">@toggledef3</A>               <A HREF="#@toggledef4">@toggledef4</A>               <A HREF="#@tor">@tor</A>
+<A HREF="#@snoop">@snoop</A>                    <A HREF="#@tag">@tag</A>                      <A HREF="#@thaw">@thaw</A>
+<A HREF="#@timeout">@timeout</A>                  <A HREF="#@timewarp">@timewarp</A>                 <A HREF="#@toad">@toad</A>
+<A HREF="#@toggledef">@toggledef</A>                <A HREF="#@toggledef2">@toggledef2</A>               <A HREF="#@toggledef3">@toggledef3</A>
+<A HREF="#@toggledef4">@toggledef4</A>               <A HREF="#@tor">@tor</A>                      <A HREF="#@totem">@totem</A>
+<A HREF="#@totem add">@totem add</A>                <A HREF="#@totem alias">@totem alias</A>              <A HREF="#@totem clean">@totem clean</A>
+<A HREF="#@totem display">@totem display</A>            <A HREF="#@totem fulllist">@totem fulllist</A>           <A HREF="#@totem info">@totem info</A>
+<A HREF="#@totem letter">@totem letter</A>             <A HREF="#@totem remove">@totem remove</A>             <A HREF="#@totem rename">@totem rename</A>
+<A HREF="#@totem see">@totem see</A>                <A HREF="#@totem set">@totem set</A>                <A HREF="#@totem slots">@totem slots</A>
+<A HREF="#@totem type">@totem type</A>               <A HREF="#@totem unalias">@totem unalias</A>            <A HREF="#@totem unset">@totem unset</A>
+<A HREF="#@totem validate">@totem validate</A>           <A HREF="#@totem/add">@totem/add</A>                <A HREF="#@totem/alias">@totem/alias</A>
+<A HREF="#@totem/clean">@totem/clean</A>              <A HREF="#@totem/display">@totem/display</A>            <A HREF="#@totem/fulllist">@totem/fulllist</A>
+<A HREF="#@totem/info">@totem/info</A>               <A HREF="#@totem/letter">@totem/letter</A>             <A HREF="#@totem/remove">@totem/remove</A>
+<A HREF="#@totem/rename">@totem/rename</A>             <A HREF="#@totem/see">@totem/see</A>                <A HREF="#@totem/set">@totem/set</A>
+<A HREF="#@totem/slots">@totem/slots</A>              <A HREF="#@totem/type">@totem/type</A>               <A HREF="#@totem/unalias">@totem/unalias</A>
+<A HREF="#@totem/unset">@totem/unset</A>              <A HREF="#@totem/validate">@totem/validate</A>           <A HREF="#@totemdef">@totemdef</A>
+<A HREF="#@totemdef2">@totemdef2</A>                <A HREF="#@totemdef3">@totemdef3</A>                <A HREF="#@totemdef4">@totemdef4</A>
 <A HREF="#@turtle">@turtle</A>                   <A HREF="#@txlevel">@txlevel</A>                  <A HREF="#@wall">@wall</A>
+<A HREF="#_">_</A>                         <A HREF="#_noconnect_msg">_NOCONNECT_MSG</A>            <A HREF="#_nopossess_msg">_NOPOSSESS_MSG</A>
 <A HREF="#abort_on_bug">abort_on_bug</A>              <A HREF="#accent_extend">accent_extend</A>             <A HREF="#access">access</A>
+<A HREF="#account membership">ACCOUNT MEMBERSHIP</A>        <A HREF="#account_login()">ACCOUNT_LOGIN()</A>           <A HREF="#account_login2">ACCOUNT_LOGIN2</A>
+<A HREF="#account_owner()">ACCOUNT_OWNER()</A>           <A HREF="#account_su()">ACCOUNT_SU()</A>              <A HREF="#account_who()">ACCOUNT_WHO()</A>
 <A HREF="#admin_object">admin_object</A>              <A HREF="#aflags()">AFLAGS()</A>                  <A HREF="#ahear_maxcount">ahear_maxcount</A>
 <A HREF="#ahear_maxtime">ahear_maxtime</A>             <A HREF="#alias">alias</A>                     <A HREF="#allow_ansinames">allow_ansinames</A>
 <A HREF="#allow_whodark">allow_whodark</A>             <A HREF="#alt inventories">ALT INVENTORIES</A>           <A HREF="#alt inventories2">ALT INVENTORIES2</A>
 <A HREF="#alt_inventories">alt_inventories</A>           <A HREF="#altover_inv">altover_inv</A>               <A HREF="#always_blind">always_blind</A>
-<A HREF="#anonymous">ANONYMOUS</A>                 <A HREF="#ansi_default">ansi_default</A>              <A HREF="#ansi_txtfiles">ansi_txtfiles</A>
-<A HREF="#architect">ARCHITECT</A>                 <A HREF="#areg_file">areg_file</A>                 <A HREF="#areg_lim">areg_lim</A>
-<A HREF="#aregh_file">aregh_file</A>                <A HREF="#atrlock">ATRLOCK</A>                   <A HREF="#atrperms">atrperms</A>
-<A HREF="#atrperms2">atrperms2</A>                 <A HREF="#atrperms_max">atrperms_max</A>              <A HREF="#atruse toggle">ATRUSE TOGGLE</A>
+<A HREF="#ancestor exit">ancestor exit</A>             <A HREF="#ancestor obj">ancestor obj</A>              <A HREF="#ancestor player">ancestor player</A>
+<A HREF="#ancestor room">ancestor room</A>             <A HREF="#ancestor thing">ancestor thing</A>            <A HREF="#ancestor_exit">ancestor_exit</A>
+<A HREF="#ancestor_obj">ancestor_obj</A>              <A HREF="#ancestor_player">ancestor_player</A>           <A HREF="#ancestor_room">ancestor_room</A>
+<A HREF="#ancestor_thing">ancestor_thing</A>            <A HREF="#ancestors">ancestors</A>                 <A HREF="#anonymous">ANONYMOUS</A>
+<A HREF="#ansi_default">ansi_default</A>              <A HREF="#ansi_txtfiles">ansi_txtfiles</A>             <A HREF="#api">API</A>
+<A HREF="#api processing">API PROCESSING</A>            <A HREF="#api return">API RETURN</A>                <A HREF="#api setup">API SETUP</A>
+<A HREF="#api_nodns">api_nodns</A>                 <A HREF="#api_port">api_port</A>                  <A HREF="#architect">ARCHITECT</A>
+<A HREF="#areg_file">areg_file</A>                 <A HREF="#areg_lim">areg_lim</A>                  <A HREF="#aregh_file">aregh_file</A>
+<A HREF="#atrlock">ATRLOCK</A>                   <A HREF="#atrperms">atrperms</A>                  <A HREF="#atrperms2">atrperms2</A>
+<A HREF="#atrperms_checkall">atrperms_checkall</A>         <A HREF="#atrperms_max">atrperms_max</A>              <A HREF="#atruse toggle">ATRUSE TOGGLE</A>
 <A HREF="#attr_access">attr_access</A>               <A HREF="#attr_access2">attr_access2</A>              <A HREF="#attr_alias">attr_alias</A>
 <A HREF="#attr_cmd_access">attr_cmd_access</A>           <A HREF="#attrib contlocks">attrib contlocks</A>          <A HREF="#attrib formatting">attrib formatting</A>
-<A HREF="#authenticate">authenticate</A>              <A HREF="#autoreg db">AUTOREG DB</A>                <A HREF="#autoreg files">AUTOREG FILES</A>
-<A HREF="#autoreg monitor">AUTOREG MONITOR</A>           <A HREF="#autoreg params">AUTOREG PARAMS</A>            <A HREF="#autoregistration">AUTOREGISTRATION</A>
-<A HREF="#backstage">BACKSTAGE</A>                 <A HREF="#bad_name">bad_name</A>                  <A HREF="#badsite_file">badsite_file</A>
-<A HREF="#bcc_hidden">bcc_hidden</A>                <A HREF="#beep()">BEEP()</A>                    <A HREF="#blacklist.txt">blacklist.txt</A>
+<A HREF="#attribute contlocks">attribute contlocks</A>       <A HREF="#attribute formatting">attribute formatting</A>      <A HREF="#authenticate">authenticate</A>
+<A HREF="#autoreg db">AUTOREG DB</A>                <A HREF="#autoreg files">AUTOREG FILES</A>             <A HREF="#autoreg monitor">AUTOREG MONITOR</A>
+<A HREF="#autoreg params">AUTOREG PARAMS</A>            <A HREF="#autoregistration">AUTOREGISTRATION</A>          <A HREF="#backstage">BACKSTAGE</A>
+<A HREF="#bad_name">bad_name</A>                  <A HREF="#badsite_file">badsite_file</A>              <A HREF="#bcc_hidden">bcc_hidden</A>
+<A HREF="#beep()">BEEP()</A>                    <A HREF="#blacklist file">blacklist file</A>            <A HREF="#blacklist.txt">blacklist.txt</A>
+<A HREF="#blacklist_max">blacklist_max</A>             <A HREF="#blacklist_nodns file">blacklist_nodns file</A>      <A HREF="#blacklist_nodns.txt">blacklist_nodns.txt</A>
 <A HREF="#blind_snuffs_cons">blind_snuffs_cons</A>         <A HREF="#brace_compatibility">brace_compatibility</A>       <A HREF="#break_compatibility">break_compatibility</A>
 <A HREF="#bypass()">BYPASS()</A>                  <A HREF="#cache_depth">cache_depth</A>               <A HREF="#cache_names">cache_names</A>
 <A HREF="#cache_steal_dirty">cache_steal_dirty</A>         <A HREF="#cache_trim">cache_trim</A>                <A HREF="#cache_width">cache_width</A>
@@ -82,16 +112,18 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#commands">commands</A>                  <A HREF="#compress_program">compress_program</A>          <A HREF="#compression">compression</A>
 <A HREF="#config parameters">CONFIG PARAMETERS</A>         <A HREF="#config parameters mysql">CONFIG PARAMETERS MYSQL</A>   <A HREF="#config parameters reality">CONFIG PARAMETERS REALITY</A>
 <A HREF="#config parameters2">CONFIG PARAMETERS2</A>        <A HREF="#config parameters3">CONFIG PARAMETERS3</A>        <A HREF="#config parameters4">CONFIG PARAMETERS4</A>
-<A HREF="#config parameters5">config parameters5</A>        <A HREF="#config parameters6">config parameters6</A>        <A HREF="#config_access">config_access</A>
-<A HREF="#conn_timeout">conn_timeout</A>              <A HREF="#connect_file">connect_file</A>              <A HREF="#connect_reg_file">connect_reg_file</A>
+<A HREF="#config parameters5">config parameters5</A>        <A HREF="#config parameters6">config parameters6</A>        <A HREF="#config()">CONFIG()</A>
+<A HREF="#config_access">config_access</A>             <A HREF="#conn_timeout">conn_timeout</A>              <A HREF="#connect_file">connect_file</A>
+<A HREF="#connect_methods">connect_methods</A>           <A HREF="#connect_perm">connect_perm</A>              <A HREF="#connect_reg_file">connect_reg_file</A>
 <A HREF="#contact info">CONTACT INFO</A>              <A HREF="#control">CONTROL</A>                   <A HREF="#control flow">CONTROL FLOW</A>
 <A HREF="#control2">CONTROL2</A>                  <A HREF="#councilor">COUNCILOR</A>                 <A HREF="#cpu">CPU</A>
 <A HREF="#cpu_secure_lvl">cpu_secure_lvl</A>            <A HREF="#cpuintervalchk">cpuintervalchk</A>            <A HREF="#cputimechk">cputimechk</A>
 <A HREF="#crash_database">crash_database</A>            <A HREF="#create_max_cost">create_max_cost</A>           <A HREF="#create_min_cost">create_min_cost</A>
-<A HREF="#dark_sleepers">dark_sleepers</A>             <A HREF="#debug features">DEBUG FEATURES</A>            <A HREF="#def_exit_rx">def_exit_rx</A>
-<A HREF="#def_exit_tx">def_exit_tx</A>               <A HREF="#def_player_rx">def_player_rx</A>             <A HREF="#def_player_tx">def_player_tx</A>
-<A HREF="#def_room_rx">def_room_rx</A>               <A HREF="#def_room_tx">def_room_tx</A>               <A HREF="#def_thing_rx">def_thing_rx</A>
-<A HREF="#def_thing_tx">def_thing_tx</A>              <A HREF="#default_home">default_home</A>              <A HREF="#depower abuse">DEPOWER ABUSE</A>
+<A HREF="#customized connect">CUSTOMIZED CONNECT</A>        <A HREF="#customized connect2">CUSTOMIZED CONNECT2</A>       <A HREF="#dark_sleepers">dark_sleepers</A>
+<A HREF="#debug features">DEBUG FEATURES</A>            <A HREF="#def_exit_rx">def_exit_rx</A>               <A HREF="#def_exit_tx">def_exit_tx</A>
+<A HREF="#def_player_rx">def_player_rx</A>             <A HREF="#def_player_tx">def_player_tx</A>             <A HREF="#def_room_rx">def_room_rx</A>
+<A HREF="#def_room_tx">def_room_tx</A>               <A HREF="#def_thing_rx">def_thing_rx</A>              <A HREF="#def_thing_tx">def_thing_tx</A>
+<A HREF="#default_home">default_home</A>              <A HREF="#delim_null">delim_null</A>                <A HREF="#depower abuse">DEPOWER ABUSE</A>
 <A HREF="#depower boot">DEPOWER BOOT</A>              <A HREF="#depower chown_me">DEPOWER CHOWN_ME</A>          <A HREF="#depower chown_other">DEPOWER CHOWN_OTHER</A>
 <A HREF="#depower cloak">DEPOWER CLOAK</A>             <A HREF="#depower com">DEPOWER COM</A>               <A HREF="#depower command">DEPOWER COMMAND</A>
 <A HREF="#depower create">DEPOWER CREATE</A>            <A HREF="#depower dark">DEPOWER DARK</A>              <A HREF="#depower examine">DEPOWER EXAMINE</A>
@@ -113,54 +145,61 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#enable_tstamps">enable_tstamps</A>            <A HREF="#enforce_unfindable">enforce_unfindable</A>        <A HREF="#enhanced_convtime">enhanced_convtime</A>
 <A HREF="#error_file">error_file</A>                <A HREF="#error_index">error_index</A>               <A HREF="#examine">examine</A>
 <A HREF="#examine_flags">examine_flags</A>             <A HREF="#examine_public_attrs">examine_public_attrs</A>      <A HREF="#examine_restrictive">examine_restrictive</A>
-<A HREF="#execscript()">EXECSCRIPT()</A>              <A HREF="#exfullwizattr toggle">EXFULLWIZATTR TOGGLE</A>      <A HREF="#exit_attr_default">exit_attr_default</A>
+<A HREF="#exec_secure">exec_secure</A>               <A HREF="#execscript()">EXECSCRIPT()</A>              <A HREF="#execscript2">EXECSCRIPT2</A>
+<A HREF="#execscriptpath">execscriptpath</A>            <A HREF="#exfullwizattr toggle">EXFULLWIZATTR TOGGLE</A>      <A HREF="#exit_attr_default">exit_attr_default</A>
 <A HREF="#exit_flags">exit_flags</A>                <A HREF="#exit_parent">exit_parent</A>               <A HREF="#exit_quota">exit_quota</A>
-<A HREF="#exit_toggles">exit_toggles</A>              <A HREF="#exits_connect_rooms">exits_connect_rooms</A>       <A HREF="#expand_goto">expand_goto</A>
-<A HREF="#fascist_teleport">fascist_teleport</A>          <A HREF="#file_object">file_object</A>               <A HREF="#files">FILES</A>
+<A HREF="#exit_separator">exit_separator</A>            <A HREF="#exit_toggles">exit_toggles</A>              <A HREF="#exits_connect_rooms">exits_connect_rooms</A>
+<A HREF="#expand_goto">expand_goto</A>               <A HREF="#fascist_teleport">fascist_teleport</A>          <A HREF="#file_object">file_object</A>
+<A HREF="#file_object2">file_object2</A>              <A HREF="#file_object3">file_object3</A>              <A HREF="#files">FILES</A>
 <A HREF="#files2">files2</A>                    <A HREF="#files3">files3</A>                    <A HREF="#files4">files4</A>
 <A HREF="#files5">files5</A>                    <A HREF="#find_money_chance">find_money_chance</A>         <A HREF="#flag alias">flag alias</A>
 <A HREF="#flag_access_see">flag_access_see</A>           <A HREF="#flag_access_set">flag_access_set</A>           <A HREF="#flag_access_type">flag_access_type</A>
 <A HREF="#flag_access_unset">flag_access_unset</A>         <A HREF="#flag_alias">flag_alias</A>                <A HREF="#flag_name">flag_name</A>
-<A HREF="#flags">flags</A>                     <A HREF="#float_precision">float_precision</A>           <A HREF="#folder">folder</A>
-<A HREF="#forbid_host">forbid_host</A>               <A HREF="#forbid_site">forbid_site</A>               <A HREF="#forcehalted toggle">FORCEHALTED TOGGLE</A>
+<A HREF="#flags">flags</A>                     <A HREF="#float_precision">float_precision</A>           <A HREF="#float_switches">float_switches</A>
+<A HREF="#folder">folder</A>                    <A HREF="#forbid_host">forbid_host</A>               <A HREF="#forbid_site">forbid_site</A>
+<A HREF="#forbidapi_host">forbidapi_host</A>            <A HREF="#forbidapi_site">forbidapi_site</A>            <A HREF="#forcehalted toggle">FORCEHALTED TOGGLE</A>
 <A HREF="#fork_dump">fork_dump</A>                 <A HREF="#fork_vfork">fork_vfork</A>                <A HREF="#format_compatibility">format_compatibility</A>
 <A HREF="#format_contents">format_contents</A>           <A HREF="#format_exits">format_exits</A>              <A HREF="#format_name">format_name</A>
 <A HREF="#formats_are_local">formats_are_local</A>         <A HREF="#fubar">FUBAR</A>                     <A HREF="#full_file">full_file</A>
 <A HREF="#full_motd_message">full_motd_message</A>         <A HREF="#function list">function list</A>             <A HREF="#function overloading">FUNCTION OVERLOADING</A>
 <A HREF="#function_access">function_access</A>           <A HREF="#function_alias">function_alias</A>            <A HREF="#function_invocation_limit">function_invocation_limit</A>
-<A HREF="#function_recursion_limit">function_recursion_limit</A>  <A HREF="#functions">functions</A>                 <A HREF="#gconf_file">gconf_file</A>
-<A HREF="#gdbm_cache_size">gdbm_cache_size</A>           <A HREF="#gdbm_database">gdbm_database</A>             <A HREF="#ghod">GHOD</A>
-<A HREF="#give">give</A>                      <A HREF="#global attributes">global attributes</A>         <A HREF="#global formatting">global formatting</A>
-<A HREF="#global inheritance">global inheritance</A>        <A HREF="#global parenting">global parenting</A>          <A HREF="#global_aconnect">global_aconnect</A>
-<A HREF="#global_adisconnect">global_adisconnect</A>        <A HREF="#global_ansimask">global_ansimask</A>           <A HREF="#global_attrdefault">global_attrdefault</A>
-<A HREF="#global_clone_exit">global_clone_exit</A>         <A HREF="#global_clone_obj">global_clone_obj</A>          <A HREF="#global_clone_player">global_clone_player</A>
-<A HREF="#global_clone_room">global_clone_room</A>         <A HREF="#global_clone_thing">global_clone_thing</A>        <A HREF="#global_error_obj">global_error_obj</A>
+<A HREF="#function_max">function_max</A>              <A HREF="#function_recursion_limit">function_recursion_limit</A>  <A HREF="#functions">functions</A>
+<A HREF="#gconf_file">gconf_file</A>                <A HREF="#gdbm_cache_size">gdbm_cache_size</A>           <A HREF="#gdbm_database">gdbm_database</A>
+<A HREF="#ghod">GHOD</A>                      <A HREF="#give">give</A>                      <A HREF="#global attributes">global attributes</A>
+<A HREF="#global formatting">global formatting</A>         <A HREF="#global inheritance">global inheritance</A>        <A HREF="#global inheritance">global inheritance</A>
+<A HREF="#global parenting">global parenting</A>          <A HREF="#global_aconnect">global_aconnect</A>           <A HREF="#global_adisconnect">global_adisconnect</A>
+<A HREF="#global_ansimask">global_ansimask</A>           <A HREF="#global_attrdefault">global_attrdefault</A>        <A HREF="#global_clone_exit">global_clone_exit</A>
+<A HREF="#global_clone_obj">global_clone_obj</A>          <A HREF="#global_clone_player">global_clone_player</A>       <A HREF="#global_clone_room">global_clone_room</A>
+<A HREF="#global_clone_thing">global_clone_thing</A>        <A HREF="#global_error_cmd">global_error_cmd</A>          <A HREF="#global_error_obj">global_error_obj</A>
 <A HREF="#global_parent_exit">global_parent_exit</A>        <A HREF="#global_parent_obj">global_parent_obj</A>         <A HREF="#global_parent_player">global_parent_player</A>
 <A HREF="#global_parent_room">global_parent_room</A>        <A HREF="#global_parent_thing">global_parent_thing</A>       <A HREF="#god">GOD</A>
 <A HREF="#good_name">good_name</A>                 <A HREF="#goodmail_host">goodmail_host</A>             <A HREF="#guest">GUEST</A>
 <A HREF="#guest setup">guest setup</A>               <A HREF="#guest_char_num">guest_char_num</A>            <A HREF="#guest_file">guest_file</A>
-<A HREF="#guest_namelist">guest_namelist</A>            <A HREF="#guild_attrname">guild_attrname</A>            <A HREF="#guild_default">guild_default</A>
-<A HREF="#guild_hdr">guild_hdr</A>                 <A HREF="#guildmaster">GUILDMASTER</A>               <A HREF="#guildobj">GUILDOBJ</A>
-<A HREF="#hackattr_nowiz">hackattr_nowiz</A>            <A HREF="#hackattr_see">hackattr_see</A>              <A HREF="#hasattrp_compat">hasattrp_compat</A>
+<A HREF="#guest_namelist">guest_namelist</A>            <A HREF="#guest_randomize">guest_randomize</A>           <A HREF="#guild_attrname">guild_attrname</A>
+<A HREF="#guild_default">guild_default</A>             <A HREF="#guild_hdr">guild_hdr</A>                 <A HREF="#guildmaster">GUILDMASTER</A>
+<A HREF="#guildobj">GUILDOBJ</A>                  <A HREF="#hackattr_nowiz">hackattr_nowiz</A>            <A HREF="#hackattr_see">hackattr_see</A>
+<A HREF="#hardconn_host">hardconn_host</A>             <A HREF="#hardconn_site">hardconn_site</A>             <A HREF="#hasattrp_compat">hasattrp_compat</A>
 <A HREF="#hasdepower()">HASDEPOWER()</A>              <A HREF="#haspower()">HASPOWER()</A>                <A HREF="#hastoggle()">HASTOGGLE()</A>
 <A HREF="#heavy_cpu_max">heavy_cpu_max</A>             <A HREF="#help">help</A>                      <A HREF="#help setup">help setup</A>
-<A HREF="#help_file">help_file</A>                 <A HREF="#help_index">help_index</A>                <A HREF="#hide_nospoof">hide_nospoof</A>
-<A HREF="#hideidle toggle">HIDEIDLE TOGGLE</A>           <A HREF="#hook setup">hook setup</A>                <A HREF="#hook setup2">hook setup2</A>
-<A HREF="#hook setup3">hook setup3</A>               <A HREF="#hook_cmd">hook_cmd</A>                  <A HREF="#hook_obj">hook_obj</A>
-<A HREF="#hostnames">hostnames</A>                 <A HREF="#huh setup">huh setup</A>                 <A HREF="#icmd_obj">icmd_obj</A>
-<A HREF="#idle_interval">idle_interval</A>             <A HREF="#idle_message">idle_message</A>              <A HREF="#idle_stamp">idle_stamp</A>
-<A HREF="#idle_stamp_max">idle_stamp_max</A>            <A HREF="#idle_timeout">idle_timeout</A>              <A HREF="#idle_wiz_cloak">idle_wiz_cloak</A>
-<A HREF="#idle_wiz_dark">idle_wiz_dark</A>             <A HREF="#ifelse_compat">ifelse_compat</A>             <A HREF="#ifelse_substitutions">ifelse_substitutions</A>
-<A HREF="#ignorezone toggle">IGNOREZONE TOGGLE</A>         <A HREF="#imm_nomod">imm_nomod</A>                 <A HREF="#immortal">IMMORTAL</A>
-<A HREF="#immprog toggle">IMMPROG TOGGLE</A>            <A HREF="#include">include</A>                   <A HREF="#includecnt">includecnt</A>
-<A HREF="#includenest">includenest</A>               <A HREF="#inherit">INHERIT</A>                   <A HREF="#inheritance">INHERITANCE</A>
-<A HREF="#initial_size">initial_size</A>              <A HREF="#input_database">input_database</A>            <A HREF="#internal_compress_string">internal_compress_string</A>
-<A HREF="#inventory_name">inventory_name</A>            <A HREF="#ip_address">ip_address</A>                <A HREF="#ishidden()">ISHIDDEN()</A>
-<A HREF="#kill_guarantee_cost">kill_guarantee_cost</A>       <A HREF="#kill_max_cost">kill_max_cost</A>             <A HREF="#kill_min_cost">kill_min_cost</A>
-<A HREF="#lastsite_paranoia">lastsite_paranoia</A>         <A HREF="#lattr_default_oldstyle">lattr_default_oldstyle</A>    <A HREF="#lattrp()">LATTRP()</A>
-<A HREF="#lattrp2 ">LATTRP2 </A>                  <A HREF="#lcon_checks_dark">lcon_checks_dark</A>          <A HREF="#ldepowers()">LDEPOWERS()</A>
-<A HREF="#lfunction_max">lfunction_max</A>             <A HREF="#link_cost">link_cost</A>                 <A HREF="#list_access">list_access</A>
-<A HREF="#list_max_chars">list_max_chars</A>            <A HREF="#listen_parents">listen_parents</A>            <A HREF="#lnum_compat">lnum_compat</A>
+<A HREF="#help_file">help_file</A>                 <A HREF="#help_index">help_index</A>                <A HREF="#help_separator">help_separator</A>
+<A HREF="#hide_nospoof">hide_nospoof</A>              <A HREF="#hideidle toggle">HIDEIDLE TOGGLE</A>           <A HREF="#hook setup">hook setup</A>
+<A HREF="#hook setup2">hook setup2</A>               <A HREF="#hook setup3">hook setup3</A>               <A HREF="#hook_cmd">hook_cmd</A>
+<A HREF="#hook_mogrifiers">hook_mogrifiers</A>           <A HREF="#hook_mogrify">hook_mogrify</A>              <A HREF="#hook_obj">hook_obj</A>
+<A HREF="#hook_offline">hook_offline</A>              <A HREF="#hostnames">hostnames</A>                 <A HREF="#huh setup">huh setup</A>
+<A HREF="#icmd_obj">icmd_obj</A>                  <A HREF="#idle_interval">idle_interval</A>             <A HREF="#idle_message">idle_message</A>
+<A HREF="#idle_stamp">idle_stamp</A>                <A HREF="#idle_stamp_max">idle_stamp_max</A>            <A HREF="#idle_timeout">idle_timeout</A>
+<A HREF="#idle_wiz_cloak">idle_wiz_cloak</A>            <A HREF="#idle_wiz_dark">idle_wiz_dark</A>             <A HREF="#ifelse_compat">ifelse_compat</A>
+<A HREF="#ifelse_substitutions">ifelse_substitutions</A>      <A HREF="#ignorezone toggle">IGNOREZONE TOGGLE</A>         <A HREF="#imm_nomod">imm_nomod</A>
+<A HREF="#immortal">IMMORTAL</A>                  <A HREF="#immprog toggle">IMMPROG TOGGLE</A>            <A HREF="#include">include</A>
+<A HREF="#includecnt">includecnt</A>                <A HREF="#includenest">includenest</A>               <A HREF="#inherit">INHERIT</A>
+<A HREF="#inheritance">INHERITANCE</A>               <A HREF="#initial_size">initial_size</A>              <A HREF="#input_database">input_database</A>
+<A HREF="#internal_compress_string">internal_compress_string</A>  <A HREF="#inventory_name">inventory_name</A>            <A HREF="#ip_address">ip_address</A>
+<A HREF="#ishidden()">ISHIDDEN()</A>                <A HREF="#iter_loop_max">iter_loop_max</A>             <A HREF="#kill_guarantee_cost">kill_guarantee_cost</A>
+<A HREF="#kill_max_cost">kill_max_cost</A>             <A HREF="#kill_min_cost">kill_min_cost</A>             <A HREF="#lastsite_paranoia">lastsite_paranoia</A>
+<A HREF="#lattr_default_oldstyle">lattr_default_oldstyle</A>    <A HREF="#lattrp()">LATTRP()</A>                  <A HREF="#lattrp2 ">LATTRP2 </A>
+<A HREF="#lcon_checks_dark">lcon_checks_dark</A>          <A HREF="#ldepowers()">LDEPOWERS()</A>               <A HREF="#lfunction_max">lfunction_max</A>
+<A HREF="#link_cost">link_cost</A>                 <A HREF="#list_access">list_access</A>               <A HREF="#list_max_chars">list_max_chars</A>
+<A HREF="#listen_parents">listen_parents</A>            <A HREF="#listtags()">LISTTAGS()</A>                <A HREF="#lnum_compat">lnum_compat</A>
 <A HREF="#lock_recursion_limit">lock_recursion_limit</A>      <A HREF="#log">log</A>                       <A HREF="#log_command_list">log_command_list</A>
 <A HREF="#log_maximum">log_maximum</A>               <A HREF="#log_network_errors">log_network_errors</A>        <A HREF="#log_options">log_options</A>
 <A HREF="#logged">LOGGED</A>                    <A HREF="#logging">LOGGING</A>                   <A HREF="#login">LOGIN</A>
@@ -175,65 +214,70 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#mail_default">mail_default</A>              <A HREF="#mail_hidden">mail_hidden</A>               <A HREF="#mail_lockdown toggle">MAIL_LOCKDOWN TOGGLE</A>
 <A HREF="#mail_tolist">mail_tolist</A>               <A HREF="#mail_verbosity">mail_verbosity</A>            <A HREF="#mailalias()">MAILALIAS()</A>
 <A HREF="#mailbox_size">mailbox_size</A>              <A HREF="#maildelete">maildelete</A>                <A HREF="#mailinclude_file">mailinclude_file</A>
-<A HREF="#mailmax_send">mailmax_send</A>              <A HREF="#mailprog">mailprog</A>                  <A HREF="#mailquick()">MAILQUICK()</A>
-<A HREF="#mailquota()">MAILQUOTA()</A>               <A HREF="#mailread()">MAILREAD()</A>                <A HREF="#mailread2">MAILREAD2</A>
-<A HREF="#mailsend()">MAILSEND()</A>                <A HREF="#mailsize()">MAILSIZE()</A>                <A HREF="#mailstatus()">MAILSTATUS()</A>
-<A HREF="#mailsub">mailsub</A>                   <A HREF="#manlog_file">manlog_file</A>               <A HREF="#map_delim_space">map_delim_space</A>
-<A HREF="#marked">MARKED</A>                    <A HREF="#master room">MASTER ROOM</A>               <A HREF="#master_room">master_room</A>
-<A HREF="#match_own_commands">match_own_commands</A>        <A HREF="#max_cpu_cycles">max_cpu_cycles</A>            <A HREF="#max_dest_limit">max_dest_limit</A>
-<A HREF="#max_folders">max_folders</A>               <A HREF="#max_lastsite_cnt">max_lastsite_cnt</A>          <A HREF="#max_name_protect">max_name_protect</A>
-<A HREF="#max_pcreate_lim">max_pcreate_lim</A>           <A HREF="#max_pcreate_time">max_pcreate_time</A>          <A HREF="#max_percentsubs">max_percentsubs</A>
-<A HREF="#max_players">max_players</A>               <A HREF="#max_sitecons">max_sitecons</A>              <A HREF="#max_vattr_limit">max_vattr_limit</A>
-<A HREF="#maximum_size">maximum_size</A>              <A HREF="#min_con_attempt">min_con_attempt</A>           <A HREF="#money_lim_arch">money_lim_arch</A>
+<A HREF="#mailmax_send">mailmax_send</A>              <A HREF="#mailmutt">mailmutt</A>                  <A HREF="#mailprog">mailprog</A>
+<A HREF="#mailquick()">MAILQUICK()</A>               <A HREF="#mailquota()">MAILQUOTA()</A>               <A HREF="#mailread()">MAILREAD()</A>
+<A HREF="#mailread2">MAILREAD2</A>                 <A HREF="#mailsend()">MAILSEND()</A>                <A HREF="#mailsize()">MAILSIZE()</A>
+<A HREF="#mailstatus()">MAILSTATUS()</A>              <A HREF="#mailsub">mailsub</A>                   <A HREF="#manlog_file">manlog_file</A>
+<A HREF="#map_delim_space">map_delim_space</A>           <A HREF="#marked">MARKED</A>                    <A HREF="#master room">MASTER ROOM</A>
+<A HREF="#master_room">master_room</A>               <A HREF="#match_own_commands">match_own_commands</A>        <A HREF="#max_cpu_cycles">max_cpu_cycles</A>
+<A HREF="#max_dest_limit">max_dest_limit</A>            <A HREF="#max_folders">max_folders</A>               <A HREF="#max_lastsite_api">max_lastsite_api</A>
+<A HREF="#max_lastsite_cnt">max_lastsite_cnt</A>          <A HREF="#max_name_protect">max_name_protect</A>          <A HREF="#max_pcreate_lim">max_pcreate_lim</A>
+<A HREF="#max_pcreate_time">max_pcreate_time</A>          <A HREF="#max_percentsubs">max_percentsubs</A>           <A HREF="#max_players">max_players</A>
+<A HREF="#max_sitecons">max_sitecons</A>              <A HREF="#max_vattr_limit">max_vattr_limit</A>           <A HREF="#maximum_size">maximum_size</A>
+<A HREF="#min_con_attempt">min_con_attempt</A>           <A HREF="#mogrify">mogrify</A>                   <A HREF="#money_lim_arch">money_lim_arch</A>
 <A HREF="#money_lim_counc">money_lim_counc</A>           <A HREF="#money_lim_gm">money_lim_gm</A>              <A HREF="#money_lim_off">money_lim_off</A>
 <A HREF="#money_name_plural">money_name_plural</A>         <A HREF="#money_name_singular">money_name_singular</A>       <A HREF="#monitor toggle">MONITOR TOGGLE</A>
 <A HREF="#monitor_areg toggle">MONITOR_AREG TOGGLE</A>       <A HREF="#monitor_bad toggle">MONITOR_BAD TOGGLE</A>        <A HREF="#monitor_conn toggle">MONITOR_CONN TOGGLE</A>
 <A HREF="#monitor_cpu toggle">MONITOR_CPU TOGGLE</A>        <A HREF="#monitor_disreason toggle">MONITOR_DISREASON TOGGLE</A>  <A HREF="#monitor_fail toggle">MONITOR_FAIL TOGGLE</A>
 <A HREF="#monitor_site toggle">MONITOR_SITE TOGGLE</A>       <A HREF="#monitor_stats toggle">MONITOR_STATS TOGGLE</A>      <A HREF="#monitor_time toggle">MONITOR_TIME TOGGLE</A>
-<A HREF="#monitor_userid toggle">MONITOR_USERID TOGGLE</A>     <A HREF="#monitor_vlimit toggle">MONITOR_VLIMIT TOGGLE</A>     <A HREF="#mortalreality toggle">MORTALREALITY TOGGLE</A>
-<A HREF="#motd_file">motd_file</A>                 <A HREF="#motd_message">motd_message</A>              <A HREF="#msizetot()">MSIZETOT()</A>
-<A HREF="#mud_name">mud_name</A>                  <A HREF="#muddb_name">muddb_name</A>                <A HREF="#must_unlquota">must_unlquota</A>
-<A HREF="#mux_child_compat">mux_child_compat</A>          <A HREF="#mux_lcon_compat">mux_lcon_compat</A>           <A HREF="#mysql_base">mysql_base</A>
-<A HREF="#mysql_delay">mysql_delay</A>               <A HREF="#mysql_host">mysql_host</A>                <A HREF="#mysql_pass">mysql_pass</A>
-<A HREF="#mysql_port">mysql_port</A>                <A HREF="#mysql_socket">mysql_socket</A>              <A HREF="#mysql_user">mysql_user</A>
-<A HREF="#name_with_desc">name_with_desc</A>            <A HREF="#nand_compat">nand_compat</A>               <A HREF="#newpass_god">newpass_god</A>
-<A HREF="#news">news</A>                      <A HREF="#news adminlock">news adminlock</A>            <A HREF="#news articlelife">news articlelife</A>
-<A HREF="#news cmdlist">news cmdlist</A>              <A HREF="#news database">news database</A>             <A HREF="#news expire">news expire</A>
-<A HREF="#news extend">news extend</A>               <A HREF="#news flat files">news flat files</A>           <A HREF="#news groupadd">news groupadd</A>
-<A HREF="#news groupdel">news groupdel</A>             <A HREF="#news groupinfo">news groupinfo</A>            <A HREF="#news grouplimit">news grouplimit</A>
-<A HREF="#news groups">news groups</A>               <A HREF="#news off">news off</A>                  <A HREF="#news on">news on</A>
-<A HREF="#news postlist">news postlist</A>             <A HREF="#news postlock">news postlock</A>             <A HREF="#news readlock">news readlock</A>
-<A HREF="#news setup">news setup</A>                <A HREF="#news setup2">news setup2</A>               <A HREF="#news setup3">news setup3</A>
-<A HREF="#news subscribe">news subscribe</A>            <A HREF="#news unsubscribe">news unsubscribe</A>          <A HREF="#news userinfo">news userinfo</A>
-<A HREF="#news userlimit">news userlimit</A>            <A HREF="#news usermem">news usermem</A>              <A HREF="#news yank">news yank</A>
-<A HREF="#news_file">news_file</A>                 <A HREF="#news_index">news_index</A>                <A HREF="#newsdb">newsdb</A>
-<A HREF="#newsdb cmdlist">newsdb cmdlist</A>            <A HREF="#newsdb dbck">newsdb dbck</A>               <A HREF="#newsdb dbinfo">newsdb dbinfo</A>
-<A HREF="#newsdb load">newsdb load</A>               <A HREF="#newsdb unload">newsdb unload</A>             <A HREF="#newuser_file">newuser_file</A>
-<A HREF="#no_ansiname">NO_ANSINAME</A>               <A HREF="#no_backstage">NO_BACKSTAGE</A>              <A HREF="#no_code">NO_CODE</A>
-<A HREF="#no_code2">no_code2</A>                  <A HREF="#no_connect">NO_CONNECT</A>                <A HREF="#no_examine">NO_EXAMINE</A>
-<A HREF="#no_format toggle">NO_FORMAT TOGGLE</A>          <A HREF="#no_gobj">NO_GOBJ</A>                   <A HREF="#no_modify">NO_MODIFY</A>
-<A HREF="#no_move">NO_MOVE</A>                   <A HREF="#no_name">NO_NAME</A>                   <A HREF="#no_override">NO_OVERRIDE</A>
-<A HREF="#no_pester">NO_PESTER</A>                 <A HREF="#no_possess">NO_POSSESS</A>                <A HREF="#no_startup">no_startup</A>
-<A HREF="#no_stop">NO_STOP</A>                   <A HREF="#no_timestamp toggle">NO_TIMESTAMP TOGGLE</A>       <A HREF="#no_uselock">NO_USELOCK</A>
-<A HREF="#no_who">NO_WHO</A>                    <A HREF="#noansiname">NOANSINAME</A>                <A HREF="#noauth_site">noauth_site</A>
-<A HREF="#noautoreg_host">noautoreg_host</A>            <A HREF="#noautoreg_site">noautoreg_site</A>            <A HREF="#nobackstage">NOBACKSTAGE</A>
-<A HREF="#nobroadcast_host">nobroadcast_host</A>          <A HREF="#nocode">NOCODE</A>                    <A HREF="#nocode2">nocode2</A>
-<A HREF="#noconnect">NOCONNECT</A>                 <A HREF="#nodefault toggle">NODEFAULT TOGGLE</A>          <A HREF="#nodns_site">nodns_site</A>
-<A HREF="#noexamine">NOEXAMINE</A>                 <A HREF="#noglobparent toggle">NOGLOBPARENT TOGGLE</A>       <A HREF="#nogobj">NOGOBJ</A>
-<A HREF="#noguest_host">noguest_host</A>              <A HREF="#noguest_site">noguest_site</A>              <A HREF="#nomodify">NOMODIFY</A>
-<A HREF="#nomove">NOMOVE</A>                    <A HREF="#noname">NONAME</A>                    <A HREF="#nonindxtxt_maxlines">nonindxtxt_maxlines</A>
-<A HREF="#nooverride">NOOVERRIDE</A>                <A HREF="#nopester">NOPESTER</A>                  <A HREF="#nopossess">NOPOSSESS</A>
-<A HREF="#noregist_onwho">noregist_onwho</A>            <A HREF="#noshell_prog">noshell_prog</A>              <A HREF="#noshprog toggle">NOSHPROG TOGGLE</A>
-<A HREF="#nospam_connect">nospam_connect</A>            <A HREF="#nostop">NOSTOP</A>                    <A HREF="#notify_recursion_limit">notify_recursion_limit</A>
-<A HREF="#notonerr_return">notonerr_return</A>           <A HREF="#nouselock">NOUSELOCK</A>                 <A HREF="#nowho">NOWHO</A>
-<A HREF="#nslookup()">NSLOOKUP()</A>                <A HREF="#num_guests">num_guests</A>                <A HREF="#oattr_enable_altname">oattr_enable_altname</A>
-<A HREF="#oattr_uses_altname">oattr_uses_altname</A>        <A HREF="#offline_reg">offline_reg</A>               <A HREF="#old_elist">old_elist</A>
-<A HREF="#online_reg">online_reg</A>                <A HREF="#open_cost">open_cost</A>                 <A HREF="#output_database">output_database</A>
-<A HREF="#output_limit">output_limit</A>              <A HREF="#page">page</A>                      <A HREF="#page_cost">page_cost</A>
-<A HREF="#pagelock toggle">PAGELOCK TOGGLE</A>           <A HREF="#paranoid_allocate">paranoid_allocate</A>         <A HREF="#paranoid_exit_linking">paranoid_exit_linking</A>
-<A HREF="#parentable_control_lock">parentable_control_lock</A>   <A HREF="#partial_conn">partial_conn</A>              <A HREF="#partial_deconn">partial_deconn</A>
-<A HREF="#paycheck">paycheck</A>                  <A HREF="#pcreate_paranoia">pcreate_paranoia</A>          <A HREF="#pemit_any_object">pemit_any_object</A>
-<A HREF="#pemit_far_players">pemit_far_players</A>         <A HREF="#penn_playercmds">penn_playercmds</A>           <A HREF="#penn_switches">penn_switches</A>
+<A HREF="#monitor_userid toggle">MONITOR_USERID TOGGLE</A>     <A HREF="#monitor_vlimit toggle">MONITOR_VLIMIT TOGGLE</A>     <A HREF="#morgrification">morgrification</A>
+<A HREF="#mortalreality toggle">MORTALREALITY TOGGLE</A>      <A HREF="#motd_file">motd_file</A>                 <A HREF="#motd_message">motd_message</A>
+<A HREF="#msizetot()">MSIZETOT()</A>                <A HREF="#mtimer">mtimer</A>                    <A HREF="#mud_name">mud_name</A>
+<A HREF="#muddb_name">muddb_name</A>                <A HREF="#must_unlquota">must_unlquota</A>             <A HREF="#mux_child_compat">mux_child_compat</A>
+<A HREF="#mux_lcon_compat">mux_lcon_compat</A>           <A HREF="#mysql_base">mysql_base</A>                <A HREF="#mysql_delay">mysql_delay</A>
+<A HREF="#mysql_host">mysql_host</A>                <A HREF="#mysql_pass">mysql_pass</A>                <A HREF="#mysql_port">mysql_port</A>
+<A HREF="#mysql_socket">mysql_socket</A>              <A HREF="#mysql_user">mysql_user</A>                <A HREF="#name_with_desc">name_with_desc</A>
+<A HREF="#nand_compat">nand_compat</A>               <A HREF="#newpass_god">newpass_god</A>               <A HREF="#news">news</A>
+<A HREF="#news adminlock">news adminlock</A>            <A HREF="#news articlelife">news articlelife</A>          <A HREF="#news cmdlist">news cmdlist</A>
+<A HREF="#news database">news database</A>             <A HREF="#news expire">news expire</A>               <A HREF="#news extend">news extend</A>
+<A HREF="#news flat files">news flat files</A>           <A HREF="#news groupadd">news groupadd</A>             <A HREF="#news groupdel">news groupdel</A>
+<A HREF="#news groupinfo">news groupinfo</A>            <A HREF="#news grouplimit">news grouplimit</A>           <A HREF="#news groups">news groups</A>
+<A HREF="#news off">news off</A>                  <A HREF="#news on">news on</A>                   <A HREF="#news postlist">news postlist</A>
+<A HREF="#news postlock">news postlock</A>             <A HREF="#news readlock">news readlock</A>             <A HREF="#news setup">news setup</A>
+<A HREF="#news setup2">news setup2</A>               <A HREF="#news setup3">news setup3</A>               <A HREF="#news subscribe">news subscribe</A>
+<A HREF="#news unsubscribe">news unsubscribe</A>          <A HREF="#news userinfo">news userinfo</A>             <A HREF="#news userlimit">news userlimit</A>
+<A HREF="#news usermem">news usermem</A>              <A HREF="#news yank">news yank</A>                 <A HREF="#news_file">news_file</A>
+<A HREF="#news_index">news_index</A>                <A HREF="#newsdb">newsdb</A>                    <A HREF="#newsdb cmdlist">newsdb cmdlist</A>
+<A HREF="#newsdb dbck">newsdb dbck</A>               <A HREF="#newsdb dbinfo">newsdb dbinfo</A>             <A HREF="#newsdb load">newsdb load</A>
+<A HREF="#newsdb unload">newsdb unload</A>             <A HREF="#newuser_file">newuser_file</A>              <A HREF="#no_ansiname">NO_ANSINAME</A>
+<A HREF="#no_backstage">NO_BACKSTAGE</A>              <A HREF="#no_code">NO_CODE</A>                   <A HREF="#no_code2">no_code2</A>
+<A HREF="#no_connect">NO_CONNECT</A>                <A HREF="#no_examine">NO_EXAMINE</A>                <A HREF="#no_format toggle">NO_FORMAT TOGGLE</A>
+<A HREF="#no_gobj">NO_GOBJ</A>                   <A HREF="#no_modify">NO_MODIFY</A>                 <A HREF="#no_move">NO_MOVE</A>
+<A HREF="#no_name">NO_NAME</A>                   <A HREF="#no_override">NO_OVERRIDE</A>               <A HREF="#no_pester">NO_PESTER</A>
+<A HREF="#no_possess">NO_POSSESS</A>                <A HREF="#no_startup">no_startup</A>                <A HREF="#no_stop">NO_STOP</A>
+<A HREF="#no_timestamp toggle">NO_TIMESTAMP TOGGLE</A>       <A HREF="#no_uselock">NO_USELOCK</A>                <A HREF="#no_who">NO_WHO</A>
+<A HREF="#noansiname">NOANSINAME</A>                <A HREF="#noauth_site">noauth_site</A>               <A HREF="#noautoreg_host">noautoreg_host</A>
+<A HREF="#noautoreg_site">noautoreg_site</A>            <A HREF="#nobackstage">NOBACKSTAGE</A>               <A HREF="#nobroadcast_host">nobroadcast_host</A>
+<A HREF="#nocode">NOCODE</A>                    <A HREF="#nocode2">nocode2</A>                   <A HREF="#noconnect">NOCONNECT</A>
+<A HREF="#nodefault toggle">NODEFAULT TOGGLE</A>          <A HREF="#nodns_site">nodns_site</A>                <A HREF="#noexamine">NOEXAMINE</A>
+<A HREF="#noglobparent toggle">NOGLOBPARENT TOGGLE</A>       <A HREF="#nogobj">NOGOBJ</A>                    <A HREF="#noguest_host">noguest_host</A>
+<A HREF="#noguest_site">noguest_site</A>              <A HREF="#nomodify">NOMODIFY</A>                  <A HREF="#nomove">NOMOVE</A>
+<A HREF="#noname">NONAME</A>                    <A HREF="#nonindxtxt_maxlines">nonindxtxt_maxlines</A>       <A HREF="#nooverride">NOOVERRIDE</A>
+<A HREF="#nopester">NOPESTER</A>                  <A HREF="#nopossess">NOPOSSESS</A>                 <A HREF="#noregist_onwho">noregist_onwho</A>
+<A HREF="#noshell_prog">noshell_prog</A>              <A HREF="#noshprog toggle">NOSHPROG TOGGLE</A>           <A HREF="#nospam_connect">nospam_connect</A>
+<A HREF="#nostop">NOSTOP</A>                    <A HREF="#notify_recursion_limit">notify_recursion_limit</A>    <A HREF="#notonerr_return">notonerr_return</A>
+<A HREF="#nouselock">NOUSELOCK</A>                 <A HREF="#nowho">NOWHO</A>                     <A HREF="#nslookup()">NSLOOKUP()</A>
+<A HREF="#null_is_idle">null_is_idle</A>              <A HREF="#num_guests">num_guests</A>                <A HREF="#oattr_enable_altname">oattr_enable_altname</A>
+<A HREF="#oattr_uses_altname">oattr_uses_altname</A>        <A HREF="#objid_localtime">objid_localtime</A>           <A HREF="#objid_offset">objid_offset</A>
+<A HREF="#offline_reg">offline_reg</A>               <A HREF="#old_elist">old_elist</A>                 <A HREF="#online_reg">online_reg</A>
+<A HREF="#open_cost">open_cost</A>                 <A HREF="#output_database">output_database</A>           <A HREF="#output_limit">output_limit</A>
+<A HREF="#page">page</A>                      <A HREF="#page_cost">page_cost</A>                 <A HREF="#pagelock toggle">PAGELOCK TOGGLE</A>
+<A HREF="#pagelock_notify">pagelock_notify</A>           <A HREF="#paranoid_allocate">paranoid_allocate</A>         <A HREF="#paranoid_exit_linking">paranoid_exit_linking</A>
+<A HREF="#parent_follow">parent_follow</A>             <A HREF="#parentable_control_lock">parentable_control_lock</A>   <A HREF="#partial_conn">partial_conn</A>
+<A HREF="#partial_deconn">partial_deconn</A>            <A HREF="#passapi_host">passapi_host</A>              <A HREF="#passapi_site">passapi_site</A>
+<A HREF="#passproxy_host">passproxy_host</A>            <A HREF="#passproxy_site">passproxy_site</A>            <A HREF="#paycheck">paycheck</A>
+<A HREF="#pcreate_paranoia">pcreate_paranoia</A>          <A HREF="#pemit_any_object">pemit_any_object</A>          <A HREF="#pemit_far_players">pemit_far_players</A>
+<A HREF="#penn_playercmds">penn_playercmds</A>           <A HREF="#penn_setq">penn_setq</A>                 <A HREF="#penn_switches">penn_switches</A>
 <A HREF="#permissions">PERMISSIONS</A>               <A HREF="#permissions2">permissions2</A>              <A HREF="#permit_site">permit_site</A>
 <A HREF="#pinvisible">PINVISIBLE</A>                <A HREF="#player_attr_default">player_attr_default</A>       <A HREF="#player_dark">player_dark</A>
 <A HREF="#player_flags">player_flags</A>              <A HREF="#player_listen">player_listen</A>             <A HREF="#player_match_commands">player_match_commands</A>
@@ -241,76 +285,94 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#player_queue_limit">player_queue_limit</A>        <A HREF="#player_quota">player_quota</A>              <A HREF="#player_starting_home">player_starting_home</A>
 <A HREF="#player_starting_room">player_starting_room</A>      <A HREF="#player_toggles">player_toggles</A>            <A HREF="#plushelp setup">plushelp setup</A>
 <A HREF="#plushelp_file">plushelp_file</A>             <A HREF="#plushelp_index">plushelp_index</A>            <A HREF="#port">port</A>
-<A HREF="#postdump_message">postdump_message</A>          <A HREF="#power boot">POWER BOOT</A>                <A HREF="#power change_quotas">POWER CHANGE_QUOTAS</A>
-<A HREF="#power chown_anywhere">POWER CHOWN_ANYWHERE</A>      <A HREF="#power chown_me">POWER CHOWN_ME</A>            <A HREF="#power chown_other">POWER CHOWN_OTHER</A>
-<A HREF="#power examine_all">POWER EXAMINE_ALL</A>         <A HREF="#power examine_full">POWER EXAMINE_FULL</A>        <A HREF="#power execscript">POWER EXECSCRIPT</A>
+<A HREF="#posesay_funct">posesay_funct</A>             <A HREF="#postdump_message">postdump_message</A>          <A HREF="#power api">POWER API</A>
+<A HREF="#power boot">POWER BOOT</A>                <A HREF="#power change_quotas">POWER CHANGE_QUOTAS</A>       <A HREF="#power chown_anywhere">POWER CHOWN_ANYWHERE</A>
+<A HREF="#power chown_me">POWER CHOWN_ME</A>            <A HREF="#power chown_other">POWER CHOWN_OTHER</A>         <A HREF="#power examine_all">POWER EXAMINE_ALL</A>
+<A HREF="#power examine_full">POWER EXAMINE_FULL</A>        <A HREF="#power execscript">POWER EXECSCRIPT</A>          <A HREF="#power formatting">POWER FORMATTING</A>
 <A HREF="#power free_page">POWER FREE_PAGE</A>           <A HREF="#power free_quota">POWER FREE_QUOTA</A>          <A HREF="#power free_wall">POWER FREE_WALL</A>
 <A HREF="#power fulltel">POWER FULLTEL</A>             <A HREF="#power grab_player">POWER GRAB_PLAYER</A>         <A HREF="#power halt_queue">POWER HALT_QUEUE</A>
 <A HREF="#power halt_queue_all">POWER HALT_QUEUE_ALL</A>      <A HREF="#power hidebit">POWER HIDEBIT</A>             <A HREF="#power join_player">POWER JOIN_PLAYER</A>
-<A HREF="#power list">POWER LIST</A>                <A HREF="#power long_fingers">POWER LONG_FINGERS</A>        <A HREF="#power no_boot">POWER NO_BOOT</A>
-<A HREF="#power noforce">POWER NOFORCE</A>             <A HREF="#power nokill">POWER NOKILL</A>              <A HREF="#power nowho">POWER NOWHO</A>
-<A HREF="#power pcreate">POWER PCREATE</A>             <A HREF="#power purge">POWER PURGE</A>               <A HREF="#power search_any">POWER SEARCH_ANY</A>
-<A HREF="#power security">POWER SECURITY</A>            <A HREF="#power see_queue">POWER SEE_QUEUE</A>           <A HREF="#power see_queue_all">POWER SEE_QUEUE_ALL</A>
-<A HREF="#power shutdown">POWER SHUTDOWN</A>            <A HREF="#power stat_any">POWER STAT_ANY</A>            <A HREF="#power steal">POWER STEAL</A>
-<A HREF="#power tel_anything">POWER TEL_ANYTHING</A>        <A HREF="#power tel_anywhere">POWER TEL_ANYWHERE</A>        <A HREF="#power who_unfind">POWER WHO_UNFIND</A>
+<A HREF="#power list">POWER LIST</A>                <A HREF="#power long_fingers">POWER LONG_FINGERS</A>        <A HREF="#power monitorapi">POWER MONITORAPI</A>
+<A HREF="#power no_boot">POWER NO_BOOT</A>             <A HREF="#power noforce">POWER NOFORCE</A>             <A HREF="#power nokill">POWER NOKILL</A>
+<A HREF="#power nowho">POWER NOWHO</A>               <A HREF="#power pcreate">POWER PCREATE</A>             <A HREF="#power purge">POWER PURGE</A>
+<A HREF="#power search_any">POWER SEARCH_ANY</A>          <A HREF="#power security">POWER SECURITY</A>            <A HREF="#power see_queue">POWER SEE_QUEUE</A>
+<A HREF="#power see_queue_all">POWER SEE_QUEUE_ALL</A>       <A HREF="#power shutdown">POWER SHUTDOWN</A>            <A HREF="#power stat_any">POWER STAT_ANY</A>
+<A HREF="#power steal">POWER STEAL</A>               <A HREF="#power tel_anything">POWER TEL_ANYTHING</A>        <A HREF="#power tel_anywhere">POWER TEL_ANYWHERE</A>
+<A HREF="#power who_unfind">POWER WHO_UNFIND</A>          <A HREF="#power wiz_idle">POWER WIZ_IDLE</A>            <A HREF="#power wiz_spoof">POWER WIZ_SPOOF</A>
 <A HREF="#power wiz_who">POWER WIZ_WHO</A>             <A HREF="#power wraith">POWER WRAITH</A>              <A HREF="#power2">POWER2</A>
 <A HREF="#power_access">power_access</A>              <A HREF="#power_objects">power_objects</A>             <A HREF="#prog toggle">PROG TOGGLE</A>
-<A HREF="#prog_on_connect toggle">PROG_ON_CONNECT TOGGLE</A>    <A HREF="#proxy_checker">proxy_checker</A>             <A HREF="#public_flags">public_flags</A>
-<A HREF="#queue_active_chunk">queue_active_chunk</A>        <A HREF="#queue_compatible">queue_compatible</A>          <A HREF="#queue_idle_chunk">queue_idle_chunk</A>
-<A HREF="#quiet_look">quiet_look</A>                <A HREF="#quiet_whisper">quiet_whisper</A>             <A HREF="#quit_file">quit_file</A>
-<A HREF="#quota alternate2">quota alternate2</A>          <A HREF="#quota alternate33">quota alternate33</A>         <A HREF="#quota()">QUOTA()</A>
-<A HREF="#quota_cost">quota_cost</A>                <A HREF="#quotas">quotas</A>                    <A HREF="#read_remote_desc">read_remote_desc</A>
-<A HREF="#read_remote_name">read_remote_name</A>          <A HREF="#reality levels">reality levels</A>            <A HREF="#reality levels2">reality levels2</A>
-<A HREF="#reality_compare">reality_compare</A>           <A HREF="#reality_level">reality_level</A>             <A HREF="#reality_locks">reality_locks</A>
-<A HREF="#reality_locktype">reality_locktype</A>          <A HREF="#recover">RECOVER</A>                   <A HREF="#recycling">recycling</A>
-<A HREF="#register_create_file">register_create_file</A>      <A HREF="#register_host">register_host</A>             <A HREF="#register_site">register_site</A>
-<A HREF="#regtry_limit">regtry_limit</A>              <A HREF="#restrict_home">restrict_home</A>             <A HREF="#restrict_home2">restrict_home2</A>
-<A HREF="#restrict_sidefx">restrict_sidefx</A>           <A HREF="#retry_limit">retry_limit</A>               <A HREF="#robot_cost">robot_cost</A>
-<A HREF="#robot_flags">robot_flags</A>               <A HREF="#robot_speech">robot_speech</A>              <A HREF="#robot_toggles">robot_toggles</A>
-<A HREF="#room_aconnect">room_aconnect</A>             <A HREF="#room_adisconnect">room_adisconnect</A>          <A HREF="#room_attr_default">room_attr_default</A>
-<A HREF="#room_flags">room_flags</A>                <A HREF="#room_parent ">room_parent </A>              <A HREF="#room_quota">room_quota</A>
-<A HREF="#room_toggles">room_toggles</A>              <A HREF="#roomlog_path">roomlog_path</A>              <A HREF="#rooms_can_open">rooms_can_open</A>
-<A HREF="#round_kludge">round_kludge</A>              <A HREF="#royalty">ROYALTY</A>                   <A HREF="#rwho_data_port">rwho_data_port</A>
-<A HREF="#rwho_dump_interval">rwho_dump_interval</A>        <A HREF="#rwho_host">rwho_host</A>                 <A HREF="#rwho_info_port">rwho_info_port</A>
-<A HREF="#rwho_password">rwho_password</A>             <A HREF="#rwho_transmit">rwho_transmit</A>             <A HREF="#sacrifice_adjust">sacrifice_adjust</A>
-<A HREF="#sacrifice_factor">sacrifice_factor</A>          <A HREF="#safe_wipe">safe_wipe</A>                 <A HREF="#safer_passwords">safer_passwords</A>
-<A HREF="#safer_ufun">safer_ufun</A>                <A HREF="#scloak">SCLOAK</A>                    <A HREF="#search criteria">SEARCH CRITERIA</A>
-<A HREF="#search criteria2">search criteria2</A>          <A HREF="#search_cost">search_cost</A>               <A HREF="#secure_atruselock">secure_atruselock</A>
-<A HREF="#secure_dark">secure_dark</A>               <A HREF="#secure_functions">secure_functions</A>          <A HREF="#secure_jumpok">secure_jumpok</A>
-<A HREF="#see_oemit">SEE_OEMIT</A>                 <A HREF="#see_owned_dark">see_owned_dark</A>            <A HREF="#see_suspect toggle">SEE_SUSPECT TOGGLE</A>
-<A HREF="#session">SESSION</A>                   <A HREF="#showother_altname">showother_altname</A>         <A HREF="#shs_reverse">shs_reverse</A>
+<A HREF="#prog_on_connect toggle">PROG_ON_CONNECT TOGGLE</A>    <A HREF="#protect_addenh">protect_addenh</A>            <A HREF="#proxy setup">PROXY SETUP</A>
+<A HREF="#proxy_checker">proxy_checker</A>             <A HREF="#public_flags">public_flags</A>              <A HREF="#queue_active_chunk">queue_active_chunk</A>
+<A HREF="#queue_compatible">queue_compatible</A>          <A HREF="#queue_idle_chunk">queue_idle_chunk</A>          <A HREF="#quiet_look">quiet_look</A>
+<A HREF="#quiet_whisper">quiet_whisper</A>             <A HREF="#quit_file">quit_file</A>                 <A HREF="#quota alternate2">quota alternate2</A>
+<A HREF="#quota alternate33">quota alternate33</A>         <A HREF="#quota()">QUOTA()</A>                   <A HREF="#quota_cost">quota_cost</A>
+<A HREF="#quotas">quotas</A>                    <A HREF="#read_remote_desc">read_remote_desc</A>          <A HREF="#read_remote_name">read_remote_name</A>
+<A HREF="#reality levels">reality levels</A>            <A HREF="#reality levels2">reality levels2</A>           <A HREF="#reality_compare">reality_compare</A>
+<A HREF="#reality_level">reality_level</A>             <A HREF="#reality_locks">reality_locks</A>             <A HREF="#reality_locktype">reality_locktype</A>
+<A HREF="#recover">RECOVER</A>                   <A HREF="#recycling">recycling</A>                 <A HREF="#register_create_file">register_create_file</A>
+<A HREF="#register_host">register_host</A>             <A HREF="#register_site">register_site</A>             <A HREF="#regtry_limit">regtry_limit</A>
+<A HREF="#restrict_home">restrict_home</A>             <A HREF="#restrict_home2">restrict_home2</A>            <A HREF="#restrict_sidefx">restrict_sidefx</A>
+<A HREF="#retry_limit">retry_limit</A>               <A HREF="#robot_cost">robot_cost</A>                <A HREF="#robot_flags">robot_flags</A>
+<A HREF="#robot_speech">robot_speech</A>              <A HREF="#robot_toggles">robot_toggles</A>             <A HREF="#room_aconnect">room_aconnect</A>
+<A HREF="#room_adisconnect">room_adisconnect</A>          <A HREF="#room_attr_default">room_attr_default</A>         <A HREF="#room_flags">room_flags</A>
+<A HREF="#room_parent ">room_parent </A>              <A HREF="#room_quota">room_quota</A>                <A HREF="#room_toggles">room_toggles</A>
+<A HREF="#roomlog_path">roomlog_path</A>              <A HREF="#rooms_can_open">rooms_can_open</A>            <A HREF="#round_kludge">round_kludge</A>
+<A HREF="#royalty">ROYALTY</A>                   <A HREF="#rwho_data_port">rwho_data_port</A>            <A HREF="#rwho_dump_interval">rwho_dump_interval</A>
+<A HREF="#rwho_host">rwho_host</A>                 <A HREF="#rwho_info_port">rwho_info_port</A>            <A HREF="#rwho_password">rwho_password</A>
+<A HREF="#rwho_transmit">rwho_transmit</A>             <A HREF="#sacrifice_adjust">sacrifice_adjust</A>          <A HREF="#sacrifice_factor">sacrifice_factor</A>
+<A HREF="#safe_wipe">safe_wipe</A>                 <A HREF="#safer_passwords">safer_passwords</A>           <A HREF="#safer_ufun">safer_ufun</A>
+<A HREF="#scloak">SCLOAK</A>                    <A HREF="#sconnect_cmd">sconnect_cmd</A>              <A HREF="#sconnect_host">sconnect_host</A>
+<A HREF="#sconnect_reip">sconnect_reip</A>             <A HREF="#search criteria">SEARCH CRITERIA</A>           <A HREF="#search criteria2">search criteria2</A>
+<A HREF="#search_cost">search_cost</A>               <A HREF="#secure_atruselock">secure_atruselock</A>         <A HREF="#secure_dark">secure_dark</A>
+<A HREF="#secure_functions">secure_functions</A>          <A HREF="#secure_jumpok">secure_jumpok</A>             <A HREF="#see_oemit">SEE_OEMIT</A>
+<A HREF="#see_owned_dark">see_owned_dark</A>            <A HREF="#see_suspect toggle">SEE_SUSPECT TOGGLE</A>        <A HREF="#session">SESSION</A>
+<A HREF="#sha2rounds">sha2rounds</A>                <A HREF="#showother_altname">showother_altname</A>         <A HREF="#shs_reverse">shs_reverse</A>
 <A HREF="#sideeffects">sideeffects</A>               <A HREF="#sideeffects_examples">sideeffects_examples</A>      <A HREF="#sideeffects_txt">sideeffects_txt</A>
 <A HREF="#sidefx_maxcalls">sidefx_maxcalls</A>           <A HREF="#sidefx_returnval">sidefx_returnval</A>          <A HREF="#signal_action">signal_action</A>
-<A HREF="#signal_cron">signal_cron</A>               <A HREF="#signal_object">signal_object</A>             <A HREF="#signal_object_type">signal_object_type</A>
+<A HREF="#signal_crontab">signal_crontab</A>            <A HREF="#signal_object">signal_object</A>             <A HREF="#signal_object_type">signal_object_type</A>
 <A HREF="#signals">signals</A>                   <A HREF="#silenteffect toggle">SILENTEFFECT TOGGLE</A>       <A HREF="#site lists">SITE LISTS</A>
 <A HREF="#site lists2">site lists2</A>               <A HREF="#size()">SIZE()</A>                    <A HREF="#slave">SLAVE</A>
-<A HREF="#slay">slay</A>                      <A HREF="#snuffdark toggle">SNUFFDARK TOGGLE</A>          <A HREF="#space_compress">space_compress</A>
-<A HREF="#spam_limit">spam_limit</A>                <A HREF="#spam_msg">spam_msg</A>                  <A HREF="#spam_objmsg">spam_objmsg</A>
-<A HREF="#spammonitor">SPAMMONITOR</A>               <A HREF="#spoof">SPOOF</A>                     <A HREF="#sqlite_db_path">sqlite_db_path</A>
-<A HREF="#sqlite_query_limit">sqlite_query_limit</A>        <A HREF="#stack_limit">stack_limit</A>               <A HREF="#start_build">start_build</A>
-<A HREF="#starting_money">starting_money</A>            <A HREF="#starting_quota">starting_quota</A>            <A HREF="#startup">STARTUP</A>
-<A HREF="#status_file">status_file</A>               <A HREF="#stop">STOP</A>                      <A HREF="#sub_include">sub_include</A>
+<A HREF="#slay">slay</A>                      <A HREF="#snoop">snoop</A>                     <A HREF="#snoop history">snoop history</A>
+<A HREF="#snuffdark toggle">SNUFFDARK TOGGLE</A>          <A HREF="#space_compress">space_compress</A>            <A HREF="#spam_limit">spam_limit</A>
+<A HREF="#spam_msg">spam_msg</A>                  <A HREF="#spam_objmsg">spam_objmsg</A>               <A HREF="#spammonitor">SPAMMONITOR</A>
+<A HREF="#special attribs">SPECIAL ATTRIBS</A>           <A HREF="#spoof">SPOOF</A>                     <A HREF="#sqlite_db_path">sqlite_db_path</A>
+<A HREF="#sqlite_query_limit">sqlite_query_limit</A>        <A HREF="#ssl setup">SSL SETUP</A>                 <A HREF="#stack_limit">stack_limit</A>
+<A HREF="#start_build">start_build</A>               <A HREF="#starting_money">starting_money</A>            <A HREF="#starting_quota">starting_quota</A>
+<A HREF="#startup">STARTUP</A>                   <A HREF="#status_file">status_file</A>               <A HREF="#stop">STOP</A>
+<A HREF="#string_conn">string_conn</A>               <A HREF="#string_conndark">string_conndark</A>           <A HREF="#string_connhide">string_connhide</A>
+<A HREF="#string_create">string_create</A>             <A HREF="#string_register">string_register</A>           <A HREF="#sub_include">sub_include</A>
 <A HREF="#sub_override">sub_override</A>              <A HREF="#sub_override2">sub_override2</A>             <A HREF="#superMINUSroyalty">SUPER-ROYALTY</A>
 <A HREF="#suspect">SUSPECT</A>                   <A HREF="#suspect_host">suspect_host</A>              <A HREF="#suspect_site">suspect_site</A>
 <A HREF="#sweep_dark">sweep_dark</A>                <A HREF="#switch_default_all">switch_default_all</A>        <A HREF="#switch_search">switch_search</A>
-<A HREF="#switch_substitutions">switch_substitutions</A>      <A HREF="#terse_shows_contents">terse_shows_contents</A>      <A HREF="#terse_shows_exits">terse_shows_exits</A>
-<A HREF="#terse_shows_move_messages">terse_shows_move_messages</A> <A HREF="#textfile()">TEXTFILE()</A>                <A HREF="#thing_attr_default">thing_attr_default</A>
-<A HREF="#thing_flags">thing_flags</A>               <A HREF="#thing_parent ">thing_parent </A>             <A HREF="#thing_quota">thing_quota</A>
-<A HREF="#timeslice">timeslice</A>                 <A HREF="#toggle_access_see">toggle_access_see</A>         <A HREF="#toggle_access_set">toggle_access_set</A>
-<A HREF="#toggle_access_type">toggle_access_type</A>        <A HREF="#toggle_access_unset">toggle_access_unset</A>       <A HREF="#toggles">TOGGLES</A>
-<A HREF="#topics">topics</A>                    <A HREF="#tor ">TOR </A>                      <A HREF="#tor_localhost">tor_localhost</A>
-<A HREF="#tor_paranoid">tor_paranoid</A>              <A HREF="#trace_output_limit">trace_output_limit</A>        <A HREF="#trace_topdown">trace_topdown</A>
+<A HREF="#switch_substitutions">switch_substitutions</A>      <A HREF="#tagmatch()">TAGMATCH()</A>                <A HREF="#tags">TAGS</A>
+<A HREF="#terse_shows_contents">terse_shows_contents</A>      <A HREF="#terse_shows_exits">terse_shows_exits</A>         <A HREF="#terse_shows_move_messages">terse_shows_move_messages</A>
+<A HREF="#textfile()">TEXTFILE()</A>                <A HREF="#thing_attr_default">thing_attr_default</A>        <A HREF="#thing_flags">thing_flags</A>
+<A HREF="#thing_parent ">thing_parent </A>             <A HREF="#thing_quota">thing_quota</A>               <A HREF="#timeslice">timeslice</A>
+<A HREF="#toggle_access_see">toggle_access_see</A>         <A HREF="#toggle_access_set">toggle_access_set</A>         <A HREF="#toggle_access_type">toggle_access_type</A>
+<A HREF="#toggle_access_unset">toggle_access_unset</A>       <A HREF="#toggles">TOGGLES</A>                   <A HREF="#topics">topics</A>
+<A HREF="#tor ">TOR </A>                      <A HREF="#tor_localhost">tor_localhost</A>             <A HREF="#tor_paranoid">tor_paranoid</A>
+<A HREF="#totem add">totem add</A>                 <A HREF="#totem alias">totem alias</A>               <A HREF="#totem clean">totem clean</A>
+<A HREF="#totem display">totem display</A>             <A HREF="#totem fulllist">totem fulllist</A>            <A HREF="#totem info">totem info</A>
+<A HREF="#totem letter">totem letter</A>              <A HREF="#totem remove">totem remove</A>              <A HREF="#totem rename">totem rename</A>
+<A HREF="#totem see">totem see</A>                 <A HREF="#totem set">totem set</A>                 <A HREF="#totem slots">totem slots</A>
+<A HREF="#totem type">totem type</A>                <A HREF="#totem unalias">totem unalias</A>             <A HREF="#totem unset">totem unset</A>
+<A HREF="#totem validate">totem validate</A>            <A HREF="#totem2">TOTEM2</A>                    <A HREF="#totem_access_see">totem_access_see</A>
+<A HREF="#totem_access_set">totem_access_set</A>          <A HREF="#totem_access_type">totem_access_type</A>         <A HREF="#totem_access_uset">totem_access_uset</A>
+<A HREF="#totem_add">totem_add</A>                 <A HREF="#totem_alias">totem_alias</A>               <A HREF="#totem_letter">totem_letter</A>
+<A HREF="#totem_name">totem_name</A>                <A HREF="#totem_rename">totem_rename</A>              <A HREF="#totem_types">totem_types</A>
+<A HREF="#totems">TOTEMS</A>                    <A HREF="#trace_output_limit">trace_output_limit</A>        <A HREF="#trace_topdown">trace_topdown</A>
 <A HREF="#tree_character">tree_character</A>            <A HREF="#trust_site">trust_site</A>                <A HREF="#uncompress_program">uncompress_program</A>
 <A HREF="#unowned_safe">unowned_safe</A>              <A HREF="#unsafe">unsafe</A>                    <A HREF="#user_attr_access">user_attr_access</A>
-<A HREF="#validate_host">validate_host</A>             <A HREF="#vattr_limit_checkwiz">vattr_limit_checkwiz</A>      <A HREF="#vlimit">vlimit</A>
-<A HREF="#wait_cost">wait_cost</A>                 <A HREF="#wall_cost">wall_cost</A>                 <A HREF="#wanderer">WANDERER</A>
-<A HREF="#whereis_notify">whereis_notify</A>            <A HREF="#whisper">whisper</A>                   <A HREF="#who">WHO</A>
-<A HREF="#who_comment">who_comment</A>               <A HREF="#who_default">who_default</A>               <A HREF="#who_showwiz">who_showwiz</A>
-<A HREF="#who_showwiztype">who_showwiztype</A>           <A HREF="#who_unfindable">who_unfindable</A>            <A HREF="#who_wizlevel">who_wizlevel</A>
-<A HREF="#whohost_size">whohost_size</A>              <A HREF="#wielded toggle">WIELDED TOGGLE</A>            <A HREF="#wiz_always_real">wiz_always_real</A>
-<A HREF="#wiz_override">wiz_override</A>              <A HREF="#wiz_uselock">wiz_uselock</A>               <A HREF="#wizard">WIZARD</A>
-<A HREF="#wizard_help_file">wizard_help_file</A>          <A HREF="#wizard_help_index">wizard_help_index</A>         <A HREF="#wizard_motd_file">wizard_motd_file</A>
-<A HREF="#wizard_motd_message">wizard_motd_message</A>       <A HREF="#wizard_queue_limit">wizard_queue_limit</A>        <A HREF="#wizhelp">wizhelp</A>
+<A HREF="#validate_host">validate_host</A>             <A HREF="#vattr_command">vattr_command</A>             <A HREF="#vattr_limit_checkwiz">vattr_limit_checkwiz</A>
+<A HREF="#vercustomstr">vercustomstr</A>              <A HREF="#vlimit">vlimit</A>                    <A HREF="#wait_cost">wait_cost</A>
+<A HREF="#wall_cost">wall_cost</A>                 <A HREF="#wanderer">WANDERER</A>                  <A HREF="#whereis_notify">whereis_notify</A>
+<A HREF="#whisper">whisper</A>                   <A HREF="#who">WHO</A>                       <A HREF="#who_comment">who_comment</A>
+<A HREF="#who_default">who_default</A>               <A HREF="#who_showwiz">who_showwiz</A>               <A HREF="#who_showwiztype">who_showwiztype</A>
+<A HREF="#who_unfindable">who_unfindable</A>            <A HREF="#who_wizlevel">who_wizlevel</A>              <A HREF="#whohost_size">whohost_size</A>
+<A HREF="#wielded toggle">WIELDED TOGGLE</A>            <A HREF="#wiz_always_real">wiz_always_real</A>           <A HREF="#wiz_override">wiz_override</A>
+<A HREF="#wiz_uselock">wiz_uselock</A>               <A HREF="#wizard">WIZARD</A>                    <A HREF="#wizard_help_file">wizard_help_file</A>
+<A HREF="#wizard_help_index">wizard_help_index</A>         <A HREF="#wizard_motd_file">wizard_motd_file</A>          <A HREF="#wizard_motd_message">wizard_motd_message</A>
+<A HREF="#wizard_queue_limit">wizard_queue_limit</A>        <A HREF="#wizcommand_quota_max">wizcommand_quota_max</A>      <A HREF="#wizhelp">wizhelp</A>
 <A HREF="#wizmax_dest_limit">wizmax_dest_limit</A>         <A HREF="#wizmax_vattr_limit">wizmax_vattr_limit</A>        <A HREF="#wmail">wmail</A>
 <A HREF="#wmail access">wmail access</A>              <A HREF="#wmail alias">wmail alias</A>               <A HREF="#wmail clean">wmail clean</A>
 <A HREF="#wmail cmdlist">wmail cmdlist</A>             <A HREF="#wmail cmdlist2">wmail cmdlist2</A>            <A HREF="#wmail dtime">wmail dtime</A>
@@ -318,7 +380,9 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#wmail lock">wmail lock</A>                <A HREF="#wmail off">wmail off</A>                 <A HREF="#wmail on ">wmail on </A>
 <A HREF="#wmail override">wmail override</A>            <A HREF="#wmail remove">wmail remove</A>              <A HREF="#wmail restart">wmail restart</A>
 <A HREF="#wmail size">wmail size</A>                <A HREF="#wmail smax">wmail smax</A>                <A HREF="#wmail time">wmail time</A>
-<A HREF="#wmail unload">wmail unload</A>              <A HREF="#wmail wipe">wmail wipe</A>                <A HREF="#worn toggle">WORN TOGGLE</A>
+<A HREF="#wmail unload">wmail unload</A>              <A HREF="#wmail wipe">wmail wipe</A>                <A HREF="#working with execscript">WORKING WITH EXECSCRIPT</A>
+<A HREF="#working with execscript2">WORKING WITH EXECSCRIPT2</A>  <A HREF="#working with execscript3">WORKING WITH EXECSCRIPT3</A>  <A HREF="#working with execscript4">WORKING WITH EXECSCRIPT4</A>
+<A HREF="#worn toggle">WORN TOGGLE</A>               <A HREF="#writing callbacks">WRITING CALLBACKS</A>         <A HREF="#writing callbacks2">WRITING CALLBACKS2</A>
 <A HREF="#writing scripts">WRITING SCRIPTS</A>           <A HREF="#zone_parents">zone_parents</A>              <A HREF="#zones_like_parents">zones_like_parents</A>
 <HR><A NAME="#1"><H3>#1</H3></A><PRE>
   Database owner. [bitlevel 7]
@@ -377,6 +441,10 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@admin"><H3>@admin</H3></A><PRE>
   Command: @admin[/&lt;switch&gt;] &lt;param&gt;=&lt;value&gt;
+  
+  You may display most config options with the 'config()' function or with
+  the command '@list options display' where you specify the config option.
+  
   Sets a RhostMUSH configuration parameter to the indicated value.
   Type 'wizhelp config parameters' for a list of the config parameters that
   may be set.
@@ -414,7 +482,7 @@ Generated: Wed Jan 13 04:15:57 2016
   loaded as a comment and have a '#' when you save.  Any lines over 1000
   will not be read.
   
-  See Also: admin_object
+  See Also: admin_object, @list, config()
 
 </PRE>
 <A HREF="#@adesc2">[PREV]</A>
@@ -423,6 +491,9 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@aflags"><H3>@aflags</H3></A><PRE>
   Command: @aflags[&lt;/switch&gt;] &lt;attribute or value&gt; [=&lt;argument&gt;]
+  
+  Note: Attributes that start with a prefix of _ will automatically
+        be wizard settable and seeable.
   
   This command will return all the toggled flags of that
   given attribute.  This will also show prefix based permissions from
@@ -468,6 +539,9 @@ Generated: Wed Jan 13 04:15:57 2016
   are defined by any entry that matches the prefix, the owner, and 
   the target.  If you wish to modify an entry, use @aflags/mod.
   
+  Permissions are handled by FIRST MATCH in the array.  To see the order
+  of permissions please check @aflags/list.
+   
   Example:  @aflags/add boogie=7 6
             @aflags/add boogie=7 6 #1234 #9876 #123
   
@@ -485,6 +559,9 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="@aflags args"><H3>@aflags args</H3></A><PRE>
   Command: @aflags/mod &lt;prefix&gt; [&lt;own&gt; &lt;tgt&gt;]=&lt;set&gt; &lt;see&gt; [&lt;own&gt; &lt;tgt&gt; &lt;enact&gt;]
   
+  Permissions are handled by FIRST MATCH in the array.  To see the order
+  of permissions please check @aflags/list.
+   
   The arguments are the following:
     &lt;prefix&gt;   --  The prefix is the attribute prefix that the permissions 
                    masking is applied.  Any attribute that starts with the
@@ -525,6 +602,9 @@ Generated: Wed Jan 13 04:15:57 2016
   permissions or &lt;set&gt; permissions.  &lt;set&gt; permissions handles setting and 
   UN-setting.
   
+  Permissions are handled by FIRST MATCH in the array.  To see the order
+  of permissions please check @aflags/list.
+   
   The following bits exist for the &lt;set&gt; and &lt;see&gt; parameters:
       0 - Unable to &lt;set/see&gt; if target is a guest or wanderer
       1 - Normal mortal or higher may &lt;set/see&gt;
@@ -569,6 +649,9 @@ Generated: Wed Jan 13 04:15:57 2016
   
   If there are no matching prefixes, it'll alert you of that fact.
    
+  Permissions are handled by FIRST MATCH in the array.  To see the order
+  of permissions please check @aflags/list.
+   
   See Also: @aflags, @aflags add, @aflags mod, @aflags perm
 
 </PRE>
@@ -588,6 +671,9 @@ Generated: Wed Jan 13 04:15:57 2016
   the owner, target, or enactor, set the value to '#-1' which means 'global' 
   or 'all'.
   
+  Permissions are handled by FIRST MATCH in the array.  To see the order
+  of permissions please check @aflags/list.
+   
   Example:  @aflags/mod boogie=6 3
             @aflags/mod boogie #1234 #9876=5 5 #-1 #9876 #-1
   
@@ -617,6 +703,9 @@ Generated: Wed Jan 13 04:15:57 2016
   the results (20 lines per page).  Otherwise it will display all
   the results without page breaks (default).
   
+  Permissions are handled by FIRST MATCH in the array.  To see the order
+  of permissions please check @aflags/list.
+   
   Example:  @aflags/perm
             @aflags/perm 2
 
@@ -660,6 +749,9 @@ Generated: Wed Jan 13 04:15:57 2016
   have.  This can be based on who can SET it, who can SEE it, as well as
   lock that specific mask by owner or by individual object.  Owner and
   object are specified by their dbref#'s.
+  
+  Permissions are handled by FIRST MATCH in the array.  To see the order
+  of permissions please check @aflags/list.
    
   Individual help and examples are available on each attribute prefix switch:
      'wizhelp @aflags perm'    -- help on displaying prefix permissions.
@@ -669,7 +761,7 @@ Generated: Wed Jan 13 04:15:57 2016
      'wizhelp @aflags args'    -- explains the arguments to @aflags
      'wizhelp @aflags bits'    -- help on the level bits for see/set perms
   
-  See Also: atrperms, atrperms_max
+  See Also: atrperms, atrperms_max, atrperms_checkall
 
 </PRE>
 <A HREF="#@aflags perm">[PREV]</A>
@@ -679,6 +771,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="@allowance"><H3>@allowance</H3></A><PRE>
   Attribute: Allowance
   Command: @allowance &lt;object&gt;[=&lt;amount&gt;]
+  
   Sets the amount of money that the player receives each day he/she connects
   to the RhostMUSH.  The Allowance attribute overrides the default allowance
   specified by the paycheck config parameter.
@@ -721,10 +814,57 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#@allowance">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@api">[NEXT]</A>
+<BR>
+<HR><A NAME="@api"><H3>@api</H3></A><PRE>
+  Command: @api[/switch] &lt;target&gt; [=&lt;value&gt;]
+  
+  Note:  This requires the config parameter power_objects to be enabled.
+         This is because this sets the API power on non-player types.
+  
+  The @api command is used to enable/disable a target from using the API 
+  interface as well as enable authentication through both password and
+  IP.   This is the central tool for configurating an object to be allowed
+  for the API interface.
+  
+  The following switches exist:
+    /status    -- (default) show the current API status of the target object
+    /enable    -- entables the target to use the API interface.  This will
+                  effectively @power the object API
+    /disable   -- disables the target from using the API interface.  This will
+                  remove the API @power
+    /password  -- this will set the password into the _APIPASSWD attribute
+                  on the target in a hash.  This should NOT BE CONFUSED with
+                  the @password or @newpassword command.  TOTALLY different.
+    /chkpasswd -- This will compare the password in the hash to one you enter
+    /ip        -- This will set IP range(s) that is allowed to use the target.
+                  If this is unset, it defaults to localhost.
+   
+  Examples: 
+    &gt; @api/enable #12345
+    @api: Target is now allowed to process API handling
+    &gt; @api/ip #12345=123.123.*.*
+    @api: IP allow list set
+    &gt; @api/password #12345=foobar
+    @api: Password set
+    &gt; @api/chkpasswd #12345=bob
+    @api: Password did not match.
+    &gt; @api/chkpasswd #12345=foobar
+    @api: Password matched.
+    &gt; @api/disable #12345
+    @api: Target is no longer allowed to process API handling
+  
+  See Also: API, api_port, api_nodns, forbidapi_host, forbidapi_site, 
+            passapi_host, passapi_site, max_lastsite_api, power_objects
+
+</PRE>
+<A HREF="#@altname">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@apply_marked">[NEXT]</A>
 <BR>
 <HR><A NAME="@apply_marked"><H3>@apply_marked</H3></A><PRE>
   Command: @apply_marked &lt;command&gt;
+  
   Performs &lt;command&gt; once for each object in the database that has its MARK
   flag set, substituting the characters ## for the object number of the
   marked object.  The command is performed by the player invoking the
@@ -737,7 +877,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: @mark, @mark_all, MARKED.
 
 </PRE>
-<A HREF="#@altname">[PREV]</A>
+<A HREF="#@api">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@areg">[NEXT]</A>
 <BR>
@@ -799,6 +939,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@attribute"><H3>@attribute</H3></A><PRE>
   Command: @attribute[/&lt;switch&gt;] &lt;attrib&gt;[=&lt;value&gt;]
+  
   Performs operations on user-named attributes depending on the switch used.
   The following switches are available:
      /access   - Changes the access to the named attribute.  &lt;value&gt; is a
@@ -840,7 +981,7 @@ Generated: Wed Jan 13 04:15:57 2016
   Command: @badsite &lt;player&gt;=&lt;list of sites&gt;
   
   This command will set up what sites a given player can _NOT_ log in from.
-  All sites must be seperated by a space and be put into their numerical
+  All sites must be separated by a space and be put into their numerical
   form.   this accepts wildcard matching.
   
   Example:  @badsite *tinyjerk=250.250.2.1 250.100.90.90 123.245.*
@@ -851,9 +992,13 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@blacklist">[NEXT]</A>
 <BR>
 <HR><A NAME="@blacklist"><H3>@blacklist</H3></A><PRE>
-  Command: @blacklist[/&lt;switch&gt;]
+  Command: @blacklist[/&lt;switch&gt;] [&lt;argument&gt;]
+           @blacklist/nodns[/&lt;switch&gt;] [&lt;argument&gt;]
+  
+  NOTE:  If you @blacklist 127.0.0.1 you may inadvertently disable SSL tunnels
+  
   This command lists, loads, or clears the current blacklists.  Blacklists are
-  similiar to forbid sites, except it keeps them in a seperate list to avoid
+  similiar to forbid sites, except it keeps them in a separate list to avoid
   spamming the site list.  You can have a maximum of 100,000 entries in the
   blacklist.  This reads a list of sites in a file blacklist.txt that it 
   populates into the blacklist.  All invalid sites will be ignored.  All
@@ -862,21 +1007,84 @@ Generated: Wed Jan 13 04:15:57 2016
   blacklist.  There is a script that can be ran that will populate this
   file with all known TOR exit points.
   
+  The second argument, like the normal @blacklist, only applies to NoDNS 
+  entries.
+  
+  The blacklist file will be blacklist.txt
+  The NoDNS blacklist file will be blacklist_nodns.txt
+  
+  You may optionally have a netmask (in ipv4 or CIDR notation) after the IP
+  in the blacklist.txt.  If no masks is seen, it will assume /32.  
+  
   The following switches exist for @blacklist:
-    /load  - Load in all sites in the blacklist.txt file
-    /clear - purges the blacklist
-    /list  - lists all sites in the blacklist
+    /load   - Load in all sites in the blacklist.txt file
+    /clear  - purges the blacklist
+    /list   - lists all sites in the blacklist.  This shows 4 to a line.
+    /mask   - like list but will show the IP and associated NETMASK.  This
+              shows 2 IP's and 2 NETMASK's to a line.
+    /search - search for a wildcard IP address (@blacklist/search 127.*)
+    /add    - Add an IP with a mask (syntax: @blacklist/add IP MASK)
+    /del    - Delete an IP with a mask (syntax: @blacklist/del IP MASK)
+              Note: MASK if not specified assumes 255.255.255.255
+  
+  The following feature switches can be used with the above 4 switches:
+    /nodns - If this is used with any of the 4 main switches, it will 
+             work against the NoDNS lists and not the blacklists.
+  
+{ see 'wizhelp @blacklist2' for arguments and examples }
+{ 'wizhelp blacklist file' for an example of the blacklist.txt file }
+
+</PRE>
+<A HREF="#@badsite">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@blacklist2">[NEXT]</A>
+<BR>
+<HR><A NAME="@blacklist2"><H3>@blacklist2</H3></A><PRE>
+  (CONTINUED)
+  Command: @blacklist[/&lt;switch&gt;] [&lt;argument&gt;]
   
   If no switch is specified, it gives a summary of sites in the blacklist.
   
-  See Also: forbid_site, @site
+  /list and /mask may specify a page value &lt;argument&gt; or the argument 'all'.  
+  If you do not specify a value &lt;argument&gt; it defaults to '1'.  You must 
+  specify '0' or 'all' to get a complete listing.
+  
+  It is STRONGLY suggested you use the paging values with most blacklists 
+  that hold proxies, it could contain tens of thousands of entries.  
+  Using /list or /mask with the '0' or 'all' argument will list ALL sites
+  and can be extremely long and spammy.
+  
+    Examples:
+    &gt; @blacklist/list 1   (shows page 1)
+    &gt; @blacklist/list     (shows page 1)
+    &gt; @blacklist/list all (shows all sites)
+    &gt; @blacklist/list 0   (shows all sites)
+    &gt; @blacklist/mask 20  (shows page 20) 
+    &gt; @blacklist/mask all (shows all sites)
+    &gt; @blacklist/mask 0   (shows all sites)
+    &gt; @blacklist/search 50.42.* (shows all sites starting with 50.42.)
+    &gt; @blacklist/add 12.12.12.0 255.255.255.0 (add IP with MASK)
+    &gt; @blacklist/del 12.12.12.0 255.255.255.0 (delete IP with MASK)
+  
+  With /list, any entry that has a [M] before the IP signifies that there
+  is a non-standard netmask associated with the IP.  A nonstandard netmask
+  is considered one that is not /32 (255.255.255.255).
+  
+  The default value of blacklists allowed are 100,000.  This value can
+  be configured with blacklist_max for between 1000 and 5,000,000.
+  
+  { 'wizhelp blacklist file' for an example of the blacklist.txt file }
+  
+  See Also: forbid_site, @site, blacklist_max
+
 </PRE>
-<A HREF="#@badsite">[PREV]</A>
+<A HREF="#@blacklist">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@boot">[NEXT]</A>
 <BR>
 <HR><A NAME="@boot"><H3>@boot</H3></A><PRE>
   Command: @boot[/&lt;switches&gt;] &lt;player&gt;
+  
   Severs the named player's connection to the game.  The player is given a
   notice that they have been booted.  If the player is connected to the game
   more than once, then all connections to that player are severed.
@@ -892,7 +1100,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: @destroy, @toad, @turtle, SESSION.
 
 </PRE>
-<A HREF="#@blacklist">[PREV]</A>
+<A HREF="#@blacklist2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@chown">[NEXT]</A>
 <BR>
@@ -954,26 +1162,62 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#@chownall">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@cmdquota">[NEXT]</A>
+<BR>
+<HR><A NAME="@cmdquota"><H3>@cmdquota</H3></A><PRE>
+  Command: @cmdquota[/&lt;switch&gt;] &lt;player|port&gt; = &lt;1-99999&gt;
+  
+  This sets a temporary maximum command quota for the target player's current
+  connections.  This only works for connected players, and only sets it
+  for the duration of the player being connected.  Once logged out of 
+  their account, the value is reset to default maximum for either player
+  or wizard, depending on their bitlevel.
+  
+  The value must be greater than 0 and less than 100,000.
+  
+  Following switches are available:
+    /port -- specify a port/descriptor instead of a player for target.
+   
+  You may use @conncheck/quota to see command quotas of connected sockets. 
+  
+  Example:
+    &gt; @cmdquota tinyplayer=10000
+    @cmdquota: tinyplayer online command quota duration has been set to 10000.
+               Once this value is below 100 it will regenerate as normal.
+  
+  See Also: command_quota_max, wizcommand_quota_max, @conncheck
+ 
+</PRE>
+<A HREF="#@clone">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@comment">[NEXT]</A>
 <BR>
 <HR><A NAME="@comment"><H3>@comment</H3></A><PRE>
   Attribute: Comment
   Command: @comment &lt;object&gt;[=&lt;text&gt;]
+  
   Sets a wizard-visible comment on the indicated object.
   This attribute is only visible and settable by wizards.
   
   Example:  @comment *tinyjerk=Watch him, he's a twit.
 
 </PRE>
-<A HREF="#@clone">[PREV]</A>
+<A HREF="#@cmdquota">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@conncheck">[NEXT]</A>
 <BR>
 <HR><A NAME="@conncheck"><H3>@conncheck</H3></A><PRE>
-  Command: @conncheck
+  Command: @conncheck[/&lt;switch&gt;]
+  
   This works like WHO or DOING but shows full email idents as well.
   This is only useable by Super-Royalty (Immortals).  This command also
   shows what DOORS (help @door) that people are currently using.
+  
+  The following switches exist:
+    /quota   - show the command quotas for all connected sockets/ports.
+    /account - show account information for all connected players
+  
+  See Also: @cmdquota, WHO, DOING, ACCOUNT MEMBERSHIP
 
 </PRE>
 <A HREF="#@comment">[PREV]</A>
@@ -982,6 +1226,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@convert"><H3>@convert</H3></A><PRE>
   Command: @convert[/alternate] &lt;player&gt;
+  
   This converts the player's current QUOTA system from their current system
   to either the alternate and enhanced quota system (by using the /alternate)
   or back to the default system (no switches)
@@ -1001,11 +1246,18 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@create">[NEXT]</A>
 <BR>
 <HR><A NAME="@create"><H3>@create</H3></A><PRE>
-  Command: @create [#dbref] &lt;name&gt; [=cost]
+  Command: @create[/switch] [#dbref] &lt;name&gt; [=cost]
+  
   This works just like the mortal's @create except you can specify the dbref#
   that you wish to use for the object.  The #dbref *must* be in the
   free list else it will default to the first free object available instead.
   This command can only be used by super-royalty.
+  
+  Switches available:
+    /strict -- will enforce [#dbref] to be a valid free dbref before create.
+  
+  Note: @reclist/free to display the free list.
+        @stat to show the 'next free dbref#'
   
   Example:  @create #5 An Object
   
@@ -1049,8 +1301,13 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="@darkexitformat"><H3>@darkexitformat</H3></A><PRE>
   Attribute: @darkexitformat &lt;target&gt;=&lt;value&gt; (royalty and higher only)
   This attribute works like @exitformat except it's a secondary descriptor
-  incase the wizard wants to specify how a seperate exit-format list is
+  incase the wizard wants to specify how a separate exit-format list is
   to be displayed.  An example would be the dark exit formats.
+  
+  If the target is @powered FORMATTING, then the dbref# list of items that
+  the target sees will be passed as %0 and the | separated list of names
+  will be passed as %1.  Any dark exits that the target sees will be passed
+  as dbref#'s into %2, and their respective names | separated as %3.
   
   Example:
     &gt; @darkexitformat here=No dark exits!
@@ -1064,6 +1321,8 @@ Generated: Wed Jan 13 04:15:57 2016
     No dark exits!
   
   Refer to the normal help on @exitformat and @conformat for more help.
+  
+  See Also: power formatting, formats_are_local, format_exits
 
 </PRE>
 <A HREF="#@cut">[PREV]</A>
@@ -1072,6 +1331,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@dbck"><H3>@dbck</H3></A><PRE>
   Command: @dbck
+  
   Performs a scan of the database looking for inconsistencies in the object
   chains, disconnected rooms, rooms waiting to be destroyed, and problems in
   the object free list.  Problems that are found are reported to the log
@@ -1088,6 +1348,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@dbclean"><H3>@dbclean</H3></A><PRE>
   Command: @dbclean[/&lt;switch&gt;]
+  
   This command will perform an attribute purge of the database of any
   unused attributes in the hash tables.  Unused is defined as an attribute
   that is not currently defined (set) on ANY database object in the database.
@@ -1154,6 +1415,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@destroy"><H3>@destroy</H3></A><PRE>
   Command: @destroy[/&lt;switches&gt;] &lt;object&gt;
+  
   Players are always considered SAFE.  Objects owned by other players are
   not otherwise treated specially.
   
@@ -1167,11 +1429,18 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@dig">[NEXT]</A>
 <BR>
 <HR><A NAME="@dig"><H3>@dig</H3></A><PRE>
-  Command: @dig [#dbref] &lt;name&gt; [=&lt;exit to link here&gt;, &lt;exit to link there&gt;]
+  Command: @dig[/switch] [#dbref] &lt;name&gt; [=&lt;exit to here&gt;, &lt;exit to target&gt;]
+  
   This works just like the mortal's @dig except you can specify the dbref#
   that you wish to use for the room.  The #dbref *must* be in the
   free list else it will default to the first free object available instead.
   This command can only be used by super-royalty.
+  
+  Switches available:
+    /strict -- will enforce [#dbref] to be a valid free dbref before create.
+  
+  Note: @reclist/free to display the free list.
+        @stat to show the 'next free dbref#'
   
   Example:  @dig #5 An Object
   
@@ -1184,6 +1453,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@disable"><H3>@disable</H3></A><PRE>
   Command: @disable &lt;option&gt;
+  
   Turns off the indicated RhostMUSH runtime parameter.  The following 
   parameters may be turned off:
     building      - Allows players to use the building commands.
@@ -1214,6 +1484,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@doing"><H3>@doing</H3></A><PRE>
   Command: @doing[/&lt;switch&gt;] &lt;text&gt;
+  
   Wizards may use the /header switch to set the Doing header in the WHO 
   report.  If no header is specified, the header is reset to &quot;Doing&quot;.
   
@@ -1226,6 +1497,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@dump"><H3>@dump</H3></A><PRE>
   Command: @dump[/&lt;switches&gt; [&lt;arg&gt;]]
+  
   Writes a checkpoint dump of the database to disk.  Checkpoint dumps are
   automatically performed periodically, so there is usually no need to use
   this command.  Switches may be used to either dump just the structure
@@ -1237,7 +1509,7 @@ Generated: Wed Jan 13 04:15:57 2016
      text       - Ensure that all changes to the text portion of the
                   database are written out to disk.
      flat       - Create full flatfile backup database '&lt;mudname&gt;.db.flat'
-                  You may specify a seperate filename &lt;arg&gt; but it will
+                  You may specify a separate filename &lt;arg&gt; but it will
                   have '.flat' appended to it.  The filename will have
                   validation checking.
   
@@ -1262,9 +1534,13 @@ Generated: Wed Jan 13 04:15:57 2016
   files you wish to read.  Use a '^' to specify sub-directories.  '.' is not
   valid as part of the filename (or path).
   
+  Note: For /search and /query you must have wildcards for patterns.
+  
   Available switches:
-    /parse - this will parse the help evaluating all %n's/functions.
-    /search - search content and list topics containing '&lt;topic&gt;'.
+    /parse   - this will parse the help evaluating all %n's/functions.
+    /search  - search content and list topics containing '&lt;topic&gt;'.
+    /query   - like /search, but gives details on matching lines of '&lt;topic&gt;'
+    /nolabel - snuff the hilight index of the topic &lt;topic&gt; when showing.
   
   Example:
     (let's say you want to read a history text file called 'history.txt')
@@ -1286,6 +1562,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@enable"><H3>@enable</H3></A><PRE>
   Command: @enable &lt;option&gt;
+  
   Turns on the indicated RhostMUSH runtime parameter.  The following 
   parameters may be turned on:
     building      - Allows players to use the building commands.
@@ -1316,6 +1593,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@fixdb"><H3>@fixdb</H3></A><PRE>
   Command: @fixdb[/&lt;switch&gt;] &lt;object&gt;=&lt;value&gt;
+  
   This command directly edits the database structure according to the
   switch specified.  As such, it is possible to produce database
   inconsistencies that can hang or crash the server.  This command should
@@ -1373,6 +1651,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="@flagdef"><H3>@flagdef</H3></A><PRE>
   Command: @flagdef[/&lt;switches&gt;] [&lt;flagname&gt;=&lt;permission(s)&gt;]
            @toggledef[/&lt;switches&gt;] [&lt;togglename&gt;=&lt;permission(s)&gt;]
+           @totemdef[/&lt;switches&gt;] [&lt;totemname&gt;=&lt;permission(s)&gt;]
   
   This command defines ONLINE all the permissions for who can set, unset,
   and see a given flag.  The only flags that you can NOT define by this
@@ -1380,8 +1659,9 @@ Generated: Wed Jan 13 04:15:57 2016
   changes override the current default settings and are only good for
   the current boot of the machine (i.e.  Cleared on @shutdowns and @reboots).
   
-  The @toggledef handles all TOGGLES.
-  The @flagdef handlds all FLAGS. 
+  The @toggledef handles all TOGGLES.  (help @toggledef4 for options)
+  The @flagdef handlds all FLAGS.      (help @flagdef4 for options)
+  The @totemdef handlds all TOTEMS.      (help @totemdef4 for options)
   
   The following switches exist for this command.
     /set    - This sets permissions of who can SET the flag.
@@ -1393,11 +1673,13 @@ Generated: Wed Jan 13 04:15:57 2016
               associated letter.
     /list   - This lists the flags, settings, and permissions. (default)
               Columns are:
-                 'Set'   - defines who can set the flag.
-                 'Unset' - defines who can remove the flag.
-                 'See'   - defines who can see the flag.
-                 'Type'  - defines type restrictions for flag.
-                 'NoM'   - defines if the flag is un-modifiable.
+                 'Set'  - defines who can set the flag.
+                 'Unset'- defines who can remove the flag.
+                 'See'  - defines who can see the flag.
+                 'Type' - defines type restrictions for flag.
+                 'NoM'  - defines if the flag is un-modifiable.
+                 'T'    - Unique to Totems ([P]ermanent, [S]tatic, [T]emporary)
+                 'Slot' - Unique to Totems (slot position for @totem)
   
   Keep in mind that if the columns are EMPTY, it defaults to whatever the mush
   standard permissions are for setting and unsetting those flags.
@@ -1440,8 +1722,12 @@ Generated: Wed Jan 13 04:15:57 2016
   
   If you wish to remove a permission, you can use '!permission' to unset a
   given permission.  You may specify multiple permissions to set and remove at
-  the same time.  (i.e.  @flagdef/set marker0=god immortal !royalty mortal)
- 
+  the same time.  
+  
+  Examples:
+    InGame command -&gt; @flagdef/set marker0=!god !immortal !royalty mortal
+    netrhost.conf  -&gt; flag_access_set marker0 !god !immortal !royalty mortal 
+  
   { see 'wizhelp @flagdef3' for a list of available type restrictions }
   { see 'wizhelp @flagdef4' for a list of all @admin related parameters }
 
@@ -1473,8 +1759,12 @@ Generated: Wed Jan 13 04:15:57 2016
    
   If you wish to remove a permission, you can use '!permission' to unset a
   given permission.  You may specify multiple permissions to set and remove at
-  the same time.  (i.e.  @flagdef/type marker0=immortal !royalty room)
-
+  the same time.  
+  
+  Examples: 
+    InGame command -&gt; @flagdef/type marker0=immortal !royalty room
+    netrhost.conf  -&gt; flag_access_type marker0 immortal !royalty room
+  
   {see 'wizhelp @flagdef4' for a list of all @admin related parameters}
   
   See Also: @flag, @flagdef, @toggledef
@@ -1538,6 +1828,10 @@ Generated: Wed Jan 13 04:15:57 2016
   the arguments to the function are loaded into %0-%9, the &lt;attr&gt; attribute
   from &lt;object&gt; is fetched, and substitution is performed on the resulting
   text.  The result of that substitution is returned as the function result.
+  
+  The @admin config parameter function_max will define how many @functions
+  can be defined.  It defaults to 1000, and setting to '-1' allows unlimited.
+  
   The following switches exist:
     /privilege  - the function is evaluated as if the evaluation were being 
                   performed by the object on which it is stored, instead of 
@@ -1556,12 +1850,10 @@ Generated: Wed Jan 13 04:15:57 2016
   The function definitions created by @function are not stored in the database
   so they need to be re-created each time the RhostMUSH is started.  It is
   recommended that the Startup attribute for player #1 include code to
-  set up all global functions.  The privalaged and preserved, protect, and
+  set up all global functions.  The privileged and preserved, protect, and
   notrace switches may be combined.
    
-  Function definitions may not be removed (aside from shutting down and
-  restarting the RhostMUSH, but they may be redefined so that they point to an
-  unused attribute.  This command may normally only be invoked by player #1.
+  Function definitions may be removed or redefined on the fly.
   
   {see 'wizhelp @function2' for examples}
 
@@ -1584,7 +1876,7 @@ Generated: Wed Jan 13 04:15:57 2016
              @function/min myfunction=3
   
   Note: With the /list switch, the following letters represent the following:
-             W - privalaged
+             W - privileged
              p - preserved
              + - protected
              t - notrace
@@ -1594,7 +1886,7 @@ Generated: Wed Jan 13 04:15:57 2016
   
   Note: you may use @function/display to see the flag permissions.
    
-  See Also: @attribute 
+  See Also: @attribute, @lfunction, lfunction_max, function_max
  
 </PRE>
 <A HREF="#@function">[PREV]</A>
@@ -1618,6 +1910,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@halt"><H3>@halt</H3></A><PRE>
   Command: @halt[/&lt;switches&gt;] [&lt;object&gt;]
+  
   This command can be used to halt commands being run by a specific object,
   all commands being run by objects owned by a specific player, or all
   commands in the game.  If &lt;object&gt; is not specified, the object running
@@ -1651,7 +1944,9 @@ Generated: Wed Jan 13 04:15:57 2016
   
   This command will set up 'hooks' to be applied to various commands or
   attributes.  You may specify multiple hooks on items.  The HOOK_OBJ is
-  an @admin param that specifies the hook object.  The following hooks exist:
+  an @admin param that specifies the hook object.  
+  
+  The following hooks exist:
          /before    - Set up a BEFORE hook on a command.  This will execute
                       functionality BEFORE the command/attribute is done.
                       The attribute is 'b_&lt;command&gt;' on the HOOK_OBJ.
@@ -1674,6 +1969,7 @@ Generated: Wed Jan 13 04:15:57 2016
          /clear     - When used in junction with any of the above switches, 
                       will clear the hook from being applied.
          /list      - This lists the current commands/attributes with hooks.
+         /include   - Convert the BEFORE and AFTER hooks to command @includes.
   
 { help @hook2 for examples}
 
@@ -1684,6 +1980,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@hook2"><H3>@hook2</H3></A><PRE>
   Command: @hook[/&lt;switch(s)&gt;] [&lt;command/attribute&gt;]  (continued)
+  
   Exmaples of @hook are as follows:
     &gt; @hook/before look 
     @hook: new mask for 'look' -&gt; before
@@ -1707,8 +2004,16 @@ Generated: Wed Jan 13 04:15:57 2016
     ---------------------------------+---------------------------------------
                          -- No percent substitions defined --
     ---------------------------------+---------------------------------------
+    Say/Pose/@emit Morgrifies        | Morgrify Status
+    ---------------------------------+---------------------------------------------
+    say, &quot;                           | DISABLED
+    pose, :, ;                       | DISABLED
+    @emit, \\                        | DISABLED
+    ---------------------------------+---------------------------------------------
+    The hook object is currently: #123 (VALID)
   
-  See Also: hook_obj, hook_cmd, HOOK SETUP, sub_override, sub_include
+  See Also: hook_obj, hook_cmd, HOOK SETUP, sub_override, sub_include,
+            morgrify
 
 </PRE>
 <A HREF="#@hook">[PREV]</A>
@@ -1788,6 +2093,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@icmd2"><H3>@icmd2</H3></A><PRE>
   Command: @icmd&lt;/switch&gt; &lt;player [= arguments]&gt;  (CONTINUED)
+  
   Continued Switches:
     /DROOM    - This sets commands disabled on the location.
                 This returns the 'Permission Denied'.
@@ -1897,6 +2203,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@kick"><H3>@kick</H3></A><PRE>
   Command: @kick[/switch] &lt;count&gt;
+  
   Immediately executes the first &lt;count&gt; commands from the top of the queue.
   The following switches change the format and syntax:
       /pid      -- This kicks the target pid from the queue and executes it.
@@ -1909,6 +2216,33 @@ Generated: Wed Jan 13 04:15:57 2016
 
 </PRE>
 <A HREF="#@invtype">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@leveldefault">[NEXT]</A>
+<BR>
+<HR><A NAME="@leveldefault"><H3>@leveldefault</H3></A><PRE>
+  Command: @leveldefault[/switch] &lt;target(s)&gt;
+
+  This wipes all Reality Level information from the specified object.
+  The purpose of this is to make the target use the Reality Level defaults
+  as specified in the appropriate &quot;def_*_rx&quot; and &quot;def_*tx_&quot; config options of
+  the MUSH again. This is not doable with @rxlevel and @txlevel as those always
+  set an override of the defaults.
+  
+  Switches:
+    /list - allows passing more than one target
+
+  See also: @rxlevel, @txlevel, REALITY LEVELS
+
+</PRE>
+<A HREF="#@kick">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lfunction">[NEXT]</A>
+<BR>
+<HR><A NAME="@lfunction"><H3>@lfunction</H3></A><PRE>
+  See: 'help @lfunction'
+  
+</PRE>
+<A HREF="#@leveldefault">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@limit">[NEXT]</A>
 <BR>
@@ -1940,37 +2274,56 @@ Generated: Wed Jan 13 04:15:57 2016
             wizmax_dest_limit, vattr_limit_checkwiz, lfunction_max
 
 </PRE>
-<A HREF="#@kick">[PREV]</A>
+<A HREF="#@lfunction">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@list">[NEXT]</A>
 <BR>
 <HR><A NAME="@list"><H3>@list</H3></A><PRE>
   Command: @list [&lt;option&gt;]
+  
   Lists information from internal databases.  Information is available
   about the following options:
  
-    allocations         attr_permissions    attributes          bad_names
-    buffers             commands            costs               db_stats
-    default_flags       flags               functions           globals
-    hashstats           logging             options             permissions
-    process             site_info           switches            user_attributes
-    toggles             mail_globals        guest_names        *rlevels
-    cmdslogged          powers              depowers            stacks
-    funperms
+    advbuffers      allocations       attr_permissions  attributes 
+    bad_names       buffers           commands          config_permissions
+    costs           db_stats          default_flags     flags             
+    functions       funperms          globals           hashstats         
+    logging         options           permissions       process         
+    site_info       switches          user_attributes   toggles         
+    mail_globals    guest_names      *rlevels           cmdslogged      
+    powers          depowers         *stacks            vattrcmds
  
   Type wizhelp @list &lt;option&gt; for help with a particular option.
   
   Options with a '*' by them may not be enabled at compiletime.
   
   Example:  @list alloc
+  
+  See Also: @admin, config()
 
 </PRE>
 <A HREF="#@limit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@list advbuffers">[NEXT]</A>
+<BR>
+<HR><A NAME="@list advbuffers"><H3>@list advbuffers</H3></A><PRE>
+  Command: @list advbuffers
+  
+  For each buffer in a buffer pool that is currently allocated, lists where
+  within RhostMUSH the buffer was allocated.  This works like 'buffers' 
+  except it also lists the filename and line number where the buffer was
+  allocated.  This will help greatly in tracing down leaks.
+  
+  This option is available to immortal/#1 only.
+
+</PRE>
+<A HREF="#@list">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@list allocations">[NEXT]</A>
 <BR>
 <HR><A NAME="@list allocations"><H3>@list allocations</H3></A><PRE>
   Command: @list allocations
+  
   This command lists the usage statistics for the internal buffer pools.
   For each buffer pool, the following information is listed:
     Size       - The size of a buffer, in characters.
@@ -1979,7 +2332,7 @@ Generated: Wed Jan 13 04:15:57 2016
     Allocs     - The total number of buffers ever allocated from the pool.
     Lost       - The number of buffers lost due to buffer header corruption.
     Total Mem  - The total memory required for each catagory (in-use memory)
-
+  
   Information is reported for the following pools:
     Sbufs      - Small buffers, for when you need only a little space.
     Mbufs      - Medium-sized buffers, for when an sbuf is too small but an 
@@ -1993,21 +2346,43 @@ Generated: Wed Jan 13 04:15:57 2016
                  queue. (@wait, @trigger, @switch, @dolist, etc).
     Pcaches    - Total number of cache entries of players.
     ZListNodes - Zone buffers, used to hold the zone linking information.
- 
+   
+  Information is given for current Tprintf dynamic allocation buffers:
+    Current    - Current allocated dynamic (unsafe_tprintf) buffers
+    Maximum    - Current maximum ever allocated
+    Average    - Average allocated over period of time
+  
+  Information is given for total network usage:
+    Total-In   - Total bytes of all inbound traffic for current reboot
+    Daily-In   - Total inbound for current 24 hour period for current reboot
+    Avg-In     - Total inbound daily average for current reboot
+    Total-Out  - Total bytes of all outbound traffic for current reboot
+    Daily-Out  - Total outbound for current 24 hour period for current reboot
+    Avg-Out    - Total outbound daily average for current reboot
+   
   Information is given for total ammounts with disk/memory use:
     DB Size         - Gives the total size of the database in Kbytes
     DB Top          - Gives the size of the database since last startup
     DB Object Size  - Gives size of a single object
+    VHash Size      - Gives total memory of all overhead of all user-attribs
     Total Mem       - Gives total memory that the RhostMUSH is taking up in K
+  
+  Misc statistics:
+    Total Lbufs used in Q-regs: These are always allocated.
+    Total Sbufs used in Q-regs: These are always allocated.  
+    Highest debugmon stack depth: How many stack levels the mush has reached
+    Current debugmon stack depth: Current stack depth (should be around 7)
+  
   See Also: @list buffers.
 
 </PRE>
-<A HREF="#@list">[PREV]</A>
+<A HREF="#@list advbuffers">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@list attr_permissions">[NEXT]</A>
 <BR>
 <HR><A NAME="@list attr_permissions"><H3>@list attr_permissions</H3></A><PRE>
   Command: @list attr_permissions
+  
   Lists the attributes and the access restrictions that have been placed on
   them. The attributes are listed one per line.  Refer to the attr_access
   config parameter for the meanings of the restrictions.
@@ -2023,6 +2398,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list attributes"><H3>@list attributes</H3></A><PRE>
   Command: @list attributes
+  
   Lists the attributes that are visible or settable by you.
   See Also: @list attr_access, @list permissions.
 
@@ -2033,6 +2409,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list bad_names"><H3>@list bad_names</H3></A><PRE>
   Command: @list bad_names
+  
   This command lists the player names that are not allowed to be created.
   Any create request (whether via the login screen or @pcreate) that matches
   (after wildcard expansion) one of the names in the list will be rejected.
@@ -2044,6 +2421,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list buffers"><H3>@list buffers</H3></A><PRE>
   Command: @list buffers
+  
   For each buffer in a buffer pool that is currently allocated, lists where
   within RhostMUSH the buffer was allocated.
 
@@ -2053,6 +2431,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@list cmdslogged">[NEXT]</A>
 <BR>
 <HR><A NAME="@list cmdslogged"><H3>@list cmdslogged</H3></A><PRE>
+  Command: @list cmdslogged
+  
   Lists all commands that are currently being logged.
   
   To set them, use the @admin parameter 'log_command_list'
@@ -2064,28 +2444,46 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list commands"><H3>@list commands</H3></A><PRE>
   Command: @list commands
+  
   Lists the internal commands that you may execute.  This command does not
   list the attribute-setting commands that you may use (like @va or @ahear),
   and does not list exits in your current room or $-commands on objects.
-  See Also: @list attr_access, @list attributes, @list permissions.
+  
+  See Also: @list attr_access, @list attributes, @list permissions,
+            @list vattrcmds
 
 </PRE>
 <A HREF="#@list cmdslogged">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@list config_permissions">[NEXT]</A>
+<BR>
+<HR><A NAME="@list config_permissions"><H3>@list config_permissions</H3></A><PRE>
+  Command: @list config_permissions
+  
+  This will show you all the config options and permissions for them.
+  You may change these permissions with the @admin param  'config_access'.
+  
+  See Also: config_access
+  
+</PRE>
+<A HREF="#@list commands">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@list costs">[NEXT]</A>
 <BR>
 <HR><A NAME="@list costs"><H3>@list costs</H3></A><PRE>
   Command: @list costs
+  
   Lists the costs that are associated with some commands, particularly those
   that expand the database.
 
 </PRE>
-<A HREF="#@list commands">[PREV]</A>
+<A HREF="#@list config_permissions">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@list db_stats">[NEXT]</A>
 <BR>
 <HR><A NAME="@list db_stats"><H3>@list db_stats</H3></A><PRE>
   Command: @list db_stats
+  
   Lists statistics for the database cache.
 
 </PRE>
@@ -2095,8 +2493,10 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list default_flags"><H3>@list default_flags</H3></A><PRE>
   Command: @list default_flags
+  
   Lists the flags that are automatically given to players, things, rooms,
   exits, and robots when they are created.
+  
   See Also: player_flags, thing_flags, room_flags, exit_flags, robot_flags.
 
 </PRE>
@@ -2105,6 +2505,9 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@list depowers">[NEXT]</A>
 <BR>
 <HR><A NAME="@list depowers"><H3>@list depowers</H3></A><PRE>
+  Command: @list depowers
+  
+  Lists the access restrictions on the various depowers
     wall            - Player can not use @wall.
     steal           - Player is limited on rob/steal.
     wiz_who         - Player can't see a wiz-who.
@@ -2136,6 +2539,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@list depowers2">[NEXT]</A>
 <BR>
 <HR><A NAME="@list depowers2"><H3>@list depowers2</H3></A><PRE>
+  Command: @list depowers (continued)
+  
     command         - Player can't use any $commands.
     examine         - Player can't examine anything but self.
     free            - Player doesn't have free/infinite money.
@@ -2158,6 +2563,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list flags"><H3>@list flags</H3></A><PRE>
   Command: @list flags
+  
   For each object type, lists the name and key letter for all flags that may
   be set on that object type that are visible to you.
 
@@ -2168,9 +2574,17 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list functions"><H3>@list functions</H3></A><PRE>
   Command: @list functions
+  
   Lists the functions that may be used to obtain information when evaluating
   command lines.
-
+  
+  You may specify the sub-categories:
+      built-in - list only the built-in hardcoded functions.
+      user     - list only user-defined global @functions.
+      local    - list only the local @lfunctions
+  
+  By default, it lists all functions.
+ 
 </PRE>
 <A HREF="#@list flags">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -2178,6 +2592,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list funperms"><H3>@list funperms</H3></A><PRE>
   Command: @list funperms
+  
   This command will list all built-in functions and the permissions of each
   function.
   
@@ -2190,6 +2605,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list globals"><H3>@list globals</H3></A><PRE>
   Command: @list globals
+  
   Lists the global parameters that may be set or cleared by the @enable and
   @disable commands.  The following parameters are displayed.
  
@@ -2215,10 +2631,13 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@list globals2">[NEXT]</A>
 <BR>
 <HR><A NAME="@list globals2"><H3>@list globals2</H3></A><PRE>
+  Command: @list globals (continued)
+  
     logins        - Indicates whether or not nonwizard players are allowed
                     to connect.
     transmit_rwho - Indicates whether or not user information is to be
                     periodically sent to the configured remote RWHO server.
+  
   See Also: RWHO, @dbck, @disable, @enable, @kick, @list permissions, @purge,
             @timewarp, checkpoint, conn_timeout, dump_interval, dump_offset,
             idle_interval, idle_timeout, rwho_data_port, rwho_dump_interval,
@@ -2230,6 +2649,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@list guest_names">[NEXT]</A>
 <BR>
 <HR><A NAME="@list guest_names"><H3>@list guest_names</H3></A><PRE>
+  Command: @list guest_names
+  
   Lists all the guest chars and information about each.
 
 </PRE>
@@ -2239,6 +2660,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list hashstats"><H3>@list hashstats</H3></A><PRE>
   Command: @list hashstats
+  
   Lists the hashing statistics for each of the internal hash tables.
   For each hash table, the following information is displayed:
     Size    - The number of hash buckets in the hash table.
@@ -2260,6 +2682,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@list hashstats2">[NEXT]</A>
 <BR>
 <HR><A NAME="@list hashstats2"><H3>@list hashstats2</H3></A><PRE>
+  Command: @list hashstats (continued)
+  
   Information is displayed for the following hash tables:
     Commands            - Internal RhostMUSH commands
     Logged-out commands - Commands valid whether or not you are connected
@@ -2285,6 +2709,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list logging"><H3>@list logging</H3></A><PRE>
   Command: @list logging
+  
   Lists the type of information that is written to the log file and how it is
   displayed.  The following types of information may be logged:
     accounting     - Usage information on player disconnect.
@@ -2315,6 +2740,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@list logging2">[NEXT]</A>
 <BR>
 <HR><A NAME="@list logging2"><H3>@list logging2</H3></A><PRE>
+  Command: @list logging (continued)
+  
   The following formatting information is listed:
     flags          - Include flags for players/objects/rooms listed.
     location       - Include location if player/object when requested.
@@ -2330,6 +2757,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list mail_globals"><H3>@list mail_globals</H3></A><PRE>
   Command: @list mail_globals
+  
   Lists the various global settings for the mail system.
   
     auto deletion         - Shows if the mail autodeletion program is working.
@@ -2352,6 +2780,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list options"><H3>@list options</H3></A><PRE>
   Command: @list options
+  
   Lists the value of many of the configuration parameters.  You may specify
   sub-options with this.  The suboptions are:
     boolean        - list boolean values and the matching admin param.
@@ -2359,33 +2788,194 @@ Generated: Wed Jan 13 04:15:57 2016
     config         - list config information
     mail           - list current mail configuration
     system         - list system configuration parameters
+    mysql          - list MySQL parameters (if enabled)
+    convtime       - list convtime extended formats
+    display        - display target config parameter ( works like config() )
   
+  Individual help is available on each sub option.
+   
   You may page the value by applying a number (from 1 to max-pages) after the
-  parameter.  For example:
+  parameter.  This works for boolean and values.  For example:
     &gt; @list options boolean        - lists first page
     &gt; @list options boolean 3      - lists third page
     &gt; @list options boolean *mail* - list all options that contain 'mail'
+  
+  The display parameter works by specifying the parameter after.  For example:
+    &gt; @list options display global_error_obj
+      global_error_obj             Object who's @va is executed for non-cmds.
+                                   Default: -1   Value: 123
   
   See Also: @admin
 
 </PRE>
 <A HREF="#@list mail_globals">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@list options boolean">[NEXT]</A>
+<BR>
+<HR><A NAME="@list options boolean"><H3>@list options boolean</H3></A><PRE>
+  Command Subtopic: @list options boolean
+  
+  This will allow you to query boolean based config parameters.  The following
+  arguments are used with this sub-topic:
+  
+    &gt; @list options boolean &lt;wild&gt;   -- List booleans based on wildcard where
+                                        &lt;wild&gt; uses '*' or '?' globbing.
+      Example: @list options boolean *command*
+  
+    &gt; @list options boolean [1-N]    -- Page 1 to page N of display
+      Example: @list options boolean 1
+  
+    &gt; @list options boolean &lt;config&gt; -- Display statistics of specified param
+      Example: @list options boolean wiz_uselock
+  
+  See Also: @list options
+
+</PRE>
+<A HREF="#@list options">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@list options config">[NEXT]</A>
+<BR>
+<HR><A NAME="@list options config"><H3>@list options config</H3></A><PRE>
+  Command Subtopic: @list options config
+  
+  This will list a (spammy) list of all the major config settings that
+  RhostMUSH has.  This is a subset of the base '@list options' that is
+  far far more spammy.
+  
+  You may wish to use the sub-topic 'display' to break down individual
+  config parameters.
+  
+  See Also: @list options
+
+</PRE>
+<A HREF="#@list options boolean">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@list options convtime">[NEXT]</A>
+<BR>
+<HR><A NAME="@list options convtime"><H3>@list options convtime</H3></A><PRE>
+  Command Subtopic: @list options convtime
+  
+  This will list all advanced formatting that convtime() will handle.
+  This will require the config parameter to allow enhanced convtime
+  formats to be enabled.
+  
+  See Also: enhanced_convtime, @list options
+
+</PRE>
+<A HREF="#@list options config">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@list options display">[NEXT]</A>
+<BR>
+<HR><A NAME="@list options display"><H3>@list options display</H3></A><PRE>
+  Config Subtopic: @list options display
+  
+  This will give detailed display values on any given config parameter
+  in the mush.  It handles all string, int, float, or boolean value.
+  
+  Some internal parameters and non-standard parameters will be unable
+  to be queried by this method, but the majority of the approximate 500
+  config parameters will be available with this method.
+  
+  All display values will be in alpha-numerical order.
+  
+  The following options exist for the display value: 
+    &gt; @list options display &lt;wild&gt;   -- Display values based on wildcard where
+                                        &lt;wild&gt; uses '*' or '?' globbing.
+      Example: @list options display *command*
+  
+    &gt; @list options display &lt;config&gt; -- Display statistics of specified param
+      Example: @list options display wiz_uselock
+ 
+  See Also: config(), @list options 
+
+</PRE>
+<A HREF="#@list options convtime">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@list options mail">[NEXT]</A>
+<BR>
+<HR><A NAME="@list options mail"><H3>@list options mail</H3></A><PRE>
+  Command Subtopic: @list options mail
+  
+  This will list all mail related config parametes and their existing
+  settings.  The mail parameters are used for the auto-registration
+  system.
+  
+  See Also: AUTOREG, @list options
+
+</PRE>
+<A HREF="#@list options display">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@list options mysql">[NEXT]</A>
+<BR>
+<HR><A NAME="@list options mysql"><H3>@list options mysql</H3></A><PRE>
+  Command Subtopic: @list options mysql
+  
+  This will list all MySQL config parameters that RhostMUSH is 
+  currently using.  If MySQL is not compiled into the base code
+  then it will alert you of this fact.
+  
+  See Also: @list options
+  
+</PRE>
+<A HREF="#@list options mail">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@list options system">[NEXT]</A>
+<BR>
+<HR><A NAME="@list options system"><H3>@list options system</H3></A><PRE>
+  Command Subtopic: @list options system
+  
+  This will list the key compile time options that RhostMUSH has been
+  compiled and configured with.  As RhostMUSH is highly configurable
+  it is useful for staff and end-users to know how the RhostMUSH they
+  are currently on is configured and what options may or may not
+  be available in a single display.
+  
+  See Also: @list options
+
+</PRE>
+<A HREF="#@list options mysql">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@list options values">[NEXT]</A>
+<BR>
+<HR><A NAME="@list options values"><H3>@list options values</H3></A><PRE>
+  Command Subtopic: @list options values
+  
+  This will allow you to query value (int/float) based config parameters.  The 
+  following arguments are used with this sub-topic:
+  
+    &gt; @list options values &lt;wild&gt;   -- List values based on wildcard where
+                                        &lt;wild&gt; uses '*' or '?' globbing.
+      Example: @list options values *command*
+  
+    &gt; @list options values [1-N]    -- Page 1 to page N of display
+      Example: @list options values 1
+  
+    &gt; @list options values &lt;config&gt; -- Display statistics of specified param
+      Example: @list options values wiz_uselock
+  
+  See Also: @list options
+
+</PRE>
+<A HREF="#@list options system">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@list permissions">[NEXT]</A>
 <BR>
 <HR><A NAME="@list permissions"><H3>@list permissions</H3></A><PRE>
   Command: @list permissions
+  
   For each command that you are allowed to use, lists the permissions that are
   needed to execute it.
+  
   See Also: access, attr_cmd_access.
 
 </PRE>
-<A HREF="#@list options">[PREV]</A>
+<A HREF="#@list options values">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@list powers">[NEXT]</A>
 <BR>
 <HR><A NAME="@list powers"><H3>@list powers</H3></A><PRE>
   Command: @list powers
+  
   Lists the access restrictions on the various powers
     change_quotas   - Player may change the building quotas of others.
     chown_mine      - Player may @chown objects to yourself even if not
@@ -2406,6 +2996,7 @@ Generated: Wed Jan 13 04:15:57 2016
     see_all_queue   - Player sees entire contents of queue.
     see_hidden      - Player sees hidden players in the WHO report.
     stat_any        - Player may get @stats on any player.
+  
 { 'wizhelp @list powers2' for more }
 </PRE>
 <A HREF="#@list permissions">[PREV]</A>
@@ -2413,6 +3004,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@list powers2">[NEXT]</A>
 <BR>
 <HR><A NAME="@list powers2"><H3>@list powers2</H3></A><PRE>
+  Command: @list powers (continued)
+  
     steal_money     - Player may give negative money.
     nokill          - Player may not be killed.
     search_any      - Player can @search/@find based on level.
@@ -2460,6 +3053,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@list rlevels">[NEXT]</A>
 <BR>
 <HR><A NAME="@list rlevels"><H3>@list rlevels</H3></A><PRE>
+  Command: @list rlevels
+  
   Lists all the current reality levels and information about each.  Will
   only work if enabled at compiletime.
   
@@ -2477,42 +3072,57 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list site_information"><H3>@list site_information</H3></A><PRE>
   Command: @list site_information
+  
   Lists the contents of the site access and suspect lists.
  
-    Address - The address to which this entry applies.
-    Mask    - The mask that is ANDed to both the input address and the address
-              in the entry when checking to see if this entry is to be used.
-    Status  - Indicates what type of access or restriction is to be applied.
-              The following statuses may occur in the site access list:
+    Address   - The address to which this entry applies.
+    Mask      - The mask that is ANDed to both the input address and the address
+                in the entry when checking to see if this entry is to be used.
+    Max-Conns - Maximum connections allowed before site restriction is
+                enabled.  'Restricted' means use default method.  N/A in this
+                field means it's not applicable.
+    Status    - Indicates what type of access or restriction is to be applied.
+                The following statuses may occur in the site access list:
  
                 Forbidden    - Connections from this site are rejected.
+                               (AutoSite) means the block was automatic.
+                Forbid API   - API connections from this site are rejected.
+                               (AutoSite) means the block was automatic.
                 Registration - Connections from this site are accepted,
                                new characters may not be created with the
                                'create' command, players wanting a character
                                must get a wizard to create one for them.
+                               (AutoSite) means the block was automatic.
                 Unrestricted - Connections from this site are accepted,
                                new characters may be created with the 'create'
                                command.
 { 'wizhelp @list site_information2' for more }
+
 </PRE>
 <A HREF="#@list rlevels">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@list site_information2">[NEXT]</A>
 <BR>
 <HR><A NAME="@list site_information2"><H3>@list site_information2</H3></A><PRE>
+  Command: @list site_information (continued)
+  
               The following statuses may occur in the site suspect list:
  
                 Suspected    - Notify logged-in wizards of any connects or
                                disconnects from this site.
                 Trusted      - Don't notify wizards of connects or disconnects
                                from this site.
+                Proxy Bypass - Sites will bypass the automatic proxy detection
+                API Bypass   - Sites will bypass the max connections api limit
                 NoGuest      - Disallows guests from connecting by this site
                 NoAutoReg    - This site can not autoregister
+                Hard Connect - This site can use connect screen commands.
  
-  See Also: forbid_site, permit_site, register_site, suspect_site, trust_site,
-            noguest_site, noautoreg_site, forbid_host, suspect_host, 
-            register_host, noguest_host, noautoreg_host, validate_host,
-            nobroadcast_host
+  See Also: forbid_site, forbidapi_site, permit_site, register_site, 
+            suspect_site, trust_site, noguest_site, noautoreg_site, 
+            forbid_host, suspect_host, register_host, noguest_host, 
+            noautoreg_host, validate_host, hardconn_host, nobroadcast_host, 
+            passproxy_host, passapi_site, passapi_host
 
 </PRE>
 <A HREF="#@list site_information">[PREV]</A>
@@ -2521,6 +3131,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list stacks"><H3>@list stacks</H3></A><PRE>
   Command: @list stacks
+  
   This command will list the current level of debugmon stacks and all the
   information in the debugmon stack.  It could be helpful in tracing down
   buggy code or other problems when you hack around the hardcode.
@@ -2534,6 +3145,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list switches"><H3>@list switches</H3></A><PRE>
   Command: @list switches
+  
   Lists the commands that support switches as well as the switches that may
   be used.
 
@@ -2544,6 +3156,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list toggles"><H3>@list toggles</H3></A><PRE>
   Command: @list toggles
+  
   Lists all the toggles available at your level.
 
 </PRE>
@@ -2553,6 +3166,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@list user_attributes"><H3>@list user_attributes</H3></A><PRE>
   Command: @list user_attributes [&lt;optional wildcard&gt;]
+   
   Lists the defined user-named attributes, along with their internal
   attribute numbers and access restrictions.
   
@@ -2571,10 +3185,25 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#@list toggles">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@list vattrcmds">[NEXT]</A>
+<BR>
+<HR><A NAME="@list vattrcmds"><H3>@list vattrcmds</H3></A><PRE>
+  Command: @list vattrcmds
+  
+  This will list all the dynamically defined @commands that are linked to
+  user defined attributes.  These are defined with the @admin config
+  parameter 'vattr_command'.
+  
+  See Also: vattr_command, @list commands
+ 
+</PRE>
+<A HREF="#@list user_attributes">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@list_file">[NEXT]</A>
 <BR>
 <HR><A NAME="@list_file"><H3>@list_file</H3></A><PRE>
   Command: @list_file &lt;file&gt;
+  
   Lists the contents of one of the message files that are shown during the
   connect/create/disconnect process as conditions warrant.  The following
   files may be listed:
@@ -2596,12 +3225,15 @@ Generated: Wed Jan 13 04:15:57 2016
      guest_motd       - shown to guest characters immediately after they
                         connect.
 { 'wizhelp @list_file2' for more }
+
 </PRE>
-<A HREF="#@list user_attributes">[PREV]</A>
+<A HREF="#@list vattrcmds">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@list_file2">[NEXT]</A>
 <BR>
 <HR><A NAME="@list_file2"><H3>@list_file2</H3></A><PRE>
+  Command: @list_file &lt;file&gt;  (continued)
+  
      motd             - shown to all players immediately after they connect.
                         (except guests and players connecting for the first
                         time)
@@ -2632,6 +3264,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@listmotd"><H3>@listmotd</H3></A><PRE>
   Command: @listmotd
+  
   Lists the current MOTD messages as set by the @motd command.
   
   See Also: @motd.
@@ -2643,31 +3276,98 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@lock"><H3>@lock</H3></A><PRE>
   Command: @lock &lt;object&gt;=&lt;key&gt;
+  
   Note that with attribute locking, a ROYALTY object can read any attribute of
   any object, including attributes invisible to players.
- 
+   
   Player #1 may also make attribute locks of the form &lt;attr-num&gt;:&lt;value&gt;
   Note that if &lt;attr-num&gt; is not a valid attribute number, the lock will
   never succeed.
   
   Available Locktypes:
   
-       LockType:  AllowPage - allows cloaked wizzes to enable/disable locking 
-                              off receiving of pages.  Not yet enabled.
        LockType:  AltName   - defines who is allowed to see the real name
                               or not with the altname in {}'s after.
-
+  
+  Individual help is available with 'wizhelp @lock type &lt;type&gt;'
 
 </PRE>
 <A HREF="#@listmotd">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock type altname">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock type altname"><H3>@lock type altname</H3></A><PRE>
+  Lock Type: Altname
+  Syntax   : @lock/altname &lt;target&gt;=&lt;key&gt;
+  
+  Players, Objects:
+     The Altname lock controls who sees through the @altname that is set on
+     them.  Without passing this lock or without being a wizard or owning
+     the object, you will only see the @altname of the target.  
+     This only impacts looking and contents.
+  
+  Rooms, Exits:
+     This has no effect on these data types.
+  
+  Examples:
+    &gt; look bob
+    Bob(#123)
+    You see nothing special.
+    &gt; @altname Bob=Fred
+    Set.
+    &gt; look bob
+    Bob(#123) {Fred}
+    You see nothing special.
+    &gt; look fred
+    Bob(#123) {Fred}
+    You see nothing special.
+  
+  See Also: @altname
+
+</PRE>
+<A HREF="#@lock">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@lock/altname">[NEXT]</A>
+<BR>
+<HR><A NAME="@lock/altname"><H3>@lock/altname</H3></A><PRE>
+  Lock Type: Altname
+  Syntax   : @lock/altname &lt;target&gt;=&lt;key&gt;
+  
+  Players, Objects:
+     The Altname lock controls who sees through the @altname that is set on
+     them.  Without passing this lock or without being a wizard or owning
+     the object, you will only see the @altname of the target.  
+     This only impacts looking and contents.
+  
+  Rooms, Exits:
+     This has no effect on these data types.
+  
+  Examples:
+    &gt; look bob
+    Bob(#123)
+    You see nothing special.
+    &gt; @altname Bob=Fred
+    Set.
+    &gt; look bob
+    Bob(#123) {Fred}
+    You see nothing special.
+    &gt; look fred
+    Bob(#123) {Fred}
+    You see nothing special.
+  
+  See Also: @altname
+
+</PRE>
+<A HREF="#@lock type altname">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@log">[NEXT]</A>
 <BR>
 <HR><A NAME="@log"><H3>@log</H3></A><PRE>
   Command: @log[/&lt;switches&gt;] &lt;text&gt;
-  This command will append to the log (or a seperate manual-log entry) a 
+  
+  This command will append to the log (or a separate manual-log entry) a 
   string of text.  If no switch is specified, it is sent to the mushname.log
-  file.  The following switches exist.  Ansi and carrage returns are stripped.
+  file.  The following switches exist.  Ansi and carriage returns are stripped.
   
       /manual - append text to the file specified by manlog_file @admin param
                 please note that percautions are taken to avoid this being
@@ -2676,7 +3376,7 @@ Generated: Wed Jan 13 04:15:57 2016
                 to alphanumeric and '_' and is forced to end with '_manual.log'
                 to the filename.  You may specify subdirectories (up to 127
                 total characters for the filename including path).  This option
-                allows carrage returns, tabs, and ansi.
+                allows carriage returns, tabs, and ansi.
                     Example: @log/file withthisname.
                 This makes a file with the name: withthisname_manual.log
       /stats  - gives you the current stats of the manual log file specified
@@ -2689,12 +3389,13 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: logtofile(), log_maximum
 
 </PRE>
-<A HREF="#@lock">[PREV]</A>
+<A HREF="#@lock/altname">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@logrotate">[NEXT]</A>
 <BR>
 <HR><A NAME="@logrotate"><H3>@logrotate</H3></A><PRE>
   Command: @logrotate[/&lt;switches&gt;] 
+  
   The logrotate command will either rotate the existing game log file or give
   the current statistics of the file.  At this time, the statistics include
   just the current size (in bytes, kbytes, mbytes, or gbytes) depending
@@ -2768,6 +3469,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@mark"><H3>@mark</H3></A><PRE>
   Command: @mark[/&lt;switches&gt;] [&lt;player&gt;] [&lt;class&gt;=&lt;restriction&gt;]
+  
   Sets or clears the MARKED flags for objects that match the search criteria.
   This command may only be used when database cleaning is disabled (via
   @disable cleaning), as cleaning uses the MARKED flag to check
@@ -2860,14 +3562,27 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@newpassword">[NEXT]</A>
 <BR>
 <HR><A NAME="@newpassword"><H3>@newpassword</H3></A><PRE>
-  Command: @newpassword &lt;player&gt;[=&lt;newpassword&gt;]
+  Command: @newpassword[&lt;/switch&gt;] &lt;player&gt;[=&lt;newpassword&gt;]
+  
   Gives &lt;player&gt; the new password &lt;newpassword&gt;.  If &lt;newpassword&gt; is not
   specified, the player is given a null password.  If logged in, the player
   is notified that his password has been changed.
   
-  Example:  @newpassword aplayer=test123
+  DES passwords are limited to 8 characters or less in length.
+  SHA512 passwords are limited to 160 characters or less in length.
   
-  See Also: @password.
+  You can not have white space in passwords.
+  
+  The following switches exist:
+    /des    - Enforce a DES password instead of the system default.
+   
+  Example:  
+    &gt; @newpassword aplayer=test123
+    Password changed.
+    &gt; @newpassword/des aplayer=test123
+    Password changed.
+  
+  See Also: (normal help) @password
 
 </PRE>
 <A HREF="#@motd">[PREV]</A>
@@ -2876,6 +3591,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@nuke"><H3>@nuke</H3></A><PRE>
   Command: @nuke[/&lt;switch&gt;] &lt;player&gt;
+  
   Destroys &lt;player&gt; like the scum they are.  It will wipe their mailbox
   automatically as well as modify their mail sent to others and their
   news postings to detail that they've been turned into a radioactive
@@ -2890,11 +3606,18 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@open">[NEXT]</A>
 <BR>
 <HR><A NAME="@open"><H3>@open</H3></A><PRE>
-  Command: @open [#dbref] &lt;name&gt; [=&lt;#room&gt;]
+  Command: @open[/switch] [#dbref] &lt;name&gt; [=&lt;#room&gt;]
+  
   This works just like the mortal's @open except you can specify the dbref#
   that you wish to use for the exit.  The #dbref *must* be in the free
   list else it will default to the first free object available instead.
   This command can only be used by super-royalty.
+  
+  Switches available:
+    /strict -- will enforce [#dbref] to be a valid free dbref before create.
+  
+  Note: @reclist/free to display the free list.
+        @stat to show the 'next free dbref#'
   
   Example:  @open #5 An Exit &lt;AE&gt;;ae;an exit=#12345
   
@@ -2933,7 +3656,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@pcreate">[NEXT]</A>
 <BR>
 <HR><A NAME="@pcreate"><H3>@pcreate</H3></A><PRE>
-  Command: @pcreate [#dbref] &lt;player&gt;=&lt;password&gt;
+  Command: @pcreate[/switch] [#dbref] &lt;player&gt;=&lt;password&gt;
            @pcreate/register [#dbref] &lt;player&gt;=&lt;email&gt;
   
   Creates a new player with the indicated password.  This command is
@@ -2942,17 +3665,27 @@ Generated: Wed Jan 13 04:15:57 2016
   
   Super-royalty have the added ability to specify the dbref# they wish
   to use for that player.  The dbref# *must* be in the free list else
-  it will default to the highest dbref# on the free list automatically.
+  it will default to the highest dbref# on the free list automatically,
+  
+  Note: @reclist/free to display the free list.
+        @stat to show the 'next free dbref#'
   
   Optional switches are:
       /register - Allows you to email a registration email to the
                   target email.  Only wizards and higher may use this.
+      /ansi     - Combines @pcreate with @extansi to ansify the name
+                  of the player.  This follows @extansi permissions.
+      /strict -- will enforce [#dbref] to be a valid free dbref before create.
   
   Example:  @pcreate #5 NewPlayer=test123
             @pcreate NewPlayer=test123
             @pcreate/reg NewPlayer=myfriend@myemail.net
+            @pcreate/ansi [ansi(hb,Blueboy)]=test123
+   
+  You may use the lastcreate() function to see the last player @pcreate'd.
   
-  See Also: REGISTRATION.
+  See Also: REGISTRATION 
+  Normal Help: lastcreate()
 
 </PRE>
 <A HREF="#@paylim">[PREV]</A>
@@ -2961,6 +3694,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@pemit"><H3>@pemit</H3></A><PRE>
   Command: @pemit[/switch] &lt;target&gt; [=&lt;message&gt;] (royalty and higher only)
+  
   This command has an additional switch available for royalty and higher.
   The following switches are available in addition to the existing:
      /PORT   - This switch allows the pemitting to a given port number
@@ -2991,6 +3725,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@poor"><H3>@poor</H3></A><PRE>
   Command: @poor &lt;amount&gt;
+  
   Sets the wealth of all players to &lt;amount&gt;.
   
   The value must have a valid numerical value for @poor to work.
@@ -3009,7 +3744,7 @@ Generated: Wed Jan 13 04:15:57 2016
   The @power command is used to give players given abilities not normally
   had.  Any power that SUPER-ROYALTY/ROYALTY wish to grant them are inhereted
   to any/all of their belongings as long as the INHERIT flag is set on it.
-  Each 'arg' specified in the list will be a seperate power to set/unset.  
+  Each 'arg' specified in the list will be a separate power to set/unset.  
   And the toggle for individual powers is optional.  Note that if no switch 
   is specified, /OFF is defaulted.  The @admin param 'power_objects' must
   be enabled for this to have effect on non-players.
@@ -3030,12 +3765,30 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@progreset"><H3>@progreset</H3></A><PRE>
   Command: @progreset &lt;playername&gt;
+           @progreset &lt;playername&gt; = &lt;newvalue&gt;
   
-  This command, only useful on players, will target the player 
-  for a @program prompt reset.  This in effect nulls out their
-  prog-prompt that would display on their client.  As this can
-  only be done on players who are NOT in a program, it is 
-  obviously intended as a forced method to reset a bad prompt.
+  This command has two uses.
+
+  First use: (first syntax)
+     This command, only useful on players, will target the player 
+     for a @program prompt reset.  This in effect nulls out their
+     prog-prompt that would display on their client.  As this can
+     only be done on players who are NOT in a program, it is 
+     obviously intended as a forced method to reset a bad prompt.
+  
+  Second use: (second syntax)
+     This command, only useful on players, will target the player
+     for a @program prompt set.  This in effect overrides the
+     player's existing prompt with the new one you assign.  This
+     is useful to set a customized prompt or reset it mid-program
+     based on maybe an error that they type or if they're sitting
+     idle for too long and you will shortly abort them.
+  
+  Examples:
+     &gt; @progreset *Player
+     Program prompt reset.
+     &gt; @progreset *player=New Prompt&gt;
+     Program prompt customized.
   
   See Also: IMMPROG
   
@@ -3068,6 +3821,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@ps"><H3>@ps</H3></A><PRE>
   Command: @ps[/&lt;switches&gt;] [&lt;object&gt;]
+  
   Wizards may also use the following switches with the @ps command:
       /all      - switch to view the entire queue.
       /freeze   - switch to view the frozen queue.
@@ -3084,6 +3838,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@purge"><H3>@purge</H3></A><PRE>
   Command: @purge[/&lt;switches&gt;] [&lt;object&gt;]
+  
   Immediately destroys any rooms that are waiting to be destroyed, crediting
   their owners for the cost of creating the room.  The freelist is also 
   repaired if it is damaged.  These operations are performed periodically,
@@ -3196,6 +3951,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@readcache"><H3>@readcache</H3></A><PRE>
   Command: @readcache
+  
   Reads the commonly-used text files and help indexes on the game directory
   into an internal cache, destroying the prior contents of the cache.
   Use this command whenever you change one of the text of index files in
@@ -3208,6 +3964,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@reboot"><H3>@reboot</H3></A><PRE>
   Command: @reboot[/silent]
+  
   This command will reboot the server loading in any new source code changes
   and successfully unloading and reloading the database to insure database
   integrity. Network socket connections and the log file will remain
@@ -3249,26 +4006,42 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@reclist">[NEXT]</A>
 <BR>
 <HR><A NAME="@reclist"><H3>@reclist</H3></A><PRE>
-  Command: @reclist
+  Command: @reclist[/switch] &lt;args&gt;
+  
   This command will display any object that had previously been destroyed
   that is in the recover list (that can currently be recovered with @recover)
   This command can only be used by super-royalty.
+  
   The following toggles exist for @reclist:
-      /count              - This switch may be used in junction with any
-                            other switch.  It returns the total count of
-                            items found.
-      /age &lt;1-100&gt;        - This switch returns the items that were destroyed
-                            after the given number of days.
-      /type &lt;TYPE&gt;        - This returns the types of objects destroyed that
-                            match the type specified.
-      /owner &lt;player&gt;     - This returns the objects destroyed owned by the
-                            specified player.
-      /dest &lt;player&gt;      - This returns the objects destroyed by the
-                            specified player.
-      /free               - This will list all the objects in the free list.
-                            The free list being all reusable objects.
+      /count                    - This switch may be used in junction with any
+                                  other switch.  It returns the total count of
+                                  items found.
+      /age &lt;1-100&gt; [=&lt;wild&gt;]    - This switch returns the items that were 
+                                  destroyed after the given number of days.
+      /type &lt;TYPE&gt; [=&lt;wild&gt;]    - This returns the types of objects destroyed 
+                                  that match the type specified.
+      /owner &lt;player&gt; [=&lt;wild&gt;] - This returns the objects destroyed owned by
+                                  the specified player.
+      /dest &lt;player&gt; [=&lt;wild&gt;]  - This returns the objects destroyed by the
+                                  specified player.
+      /free [&lt;wild&gt;]            - This will list all the objects in the free 
+                                  list.  The free list being all reusable 
+                                  objects.
  
-  Example:  @reclist/owner Dweeb
+  Note:  &lt;=wild&gt; will be in the form =*wildcard* where *wildcard* is the
+         patten you wish to match.  The &lt;wild&gt; is the same but without an
+         equals (=) sign.
+  
+  Note2: Wildcard patterns for =&lt;wild&gt; patterns may be the NAME of an item
+         or a partial dbref#.  For /free's &lt;wild&gt; only dbref# is available.
+
+  Examples:  
+    &gt; @reclist/owner Dweeb
+    &gt; @reclist/owner Dweeb=*Da Room*   (search room names containing 'Da Room')
+    &gt; @reclist/owner Dweeb=*#123*      (search dbref#'s containing '#123')
+    &gt; @reclist/count
+    &gt; @reclist/free/count
+    &gt; @reclist/free *#123*             (search dbref#'s containing '#123')
   
   See Also: @recover, @purge
 
@@ -3278,7 +4051,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@recover">[NEXT]</A>
 <BR>
 <HR><A NAME="@recover"><H3>@recover</H3></A><PRE>
-  Command: @recover &lt;#dbref&gt;
+  Command: @recover[/&lt;switch&gt;] &lt;#dbref&gt;
+  
   This command will recover from destruction the specified dbref# shown
   as previously destroyed in the recover list by the @reclist command.
   Do note, anything recovered will be owned by you and automatically set
@@ -3293,8 +4067,27 @@ Generated: Wed Jan 13 04:15:57 2016
   
   Items @purged are gone for good.
   
-  Example:  @recover #123
+  The following switches are available:
+    /detail - Instead of recovering the object list details of the
+              object in question.  This will display the dbref#,
+              flags, and attributes on the object.  The Rectime is
+              the time (in secs()) the object was destroyed.
+    
+  Example:  
+    &gt; @recover/detail #123
+    MyObj(#123$Ih)
+    Type: THING Flags: RECOVER INHERIT HALTED
+    FOO: $fooz:@pipe/on va;think test;@pipe/off
+    VA: xyz
+    OOC: $ooc *:@pemit %#=[parsestr(%0,%0,&quot;,&quot;,,&amp;[ansi(hy,&lt;,hc,OOC,hy,&gt;)] %k)]
+    AnsiName([$]): %cr%chMy%cn%cc%chO%cn%cb%chbj%cn
+    TRACE_GREP: sub(
+    TRACE_COLOR_WATSON: +pink
+    Rectime([$Mi]): 1507055461
   
+    &gt; @recover #123
+    Restored.
+   
   See Also: @purge, @reclist
 
 </PRE>
@@ -3304,6 +4097,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@remote"><H3>@remote</H3></A><PRE>
   Command: @remote &lt;location&gt;=&lt;command&gt;
+  
   This will execute &lt;command&gt; at a remote location &lt;location&gt;.  The location
   must be valid and controlled by you otherwise it will give a permission 
   denied and execute the command at your current location as normal.
@@ -3337,6 +4131,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@rwho"><H3>@rwho</H3></A><PRE>
   Command: @rwho[/&lt;switches&gt;]
+  
   Sets up or breaks the connection to the remote RWHO server over which
   WHO data is transmitted.  Note that changes to many of the RWHO
   configuration parameters only take effect when RWHO transmission is next
@@ -3356,13 +4151,18 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#@rxlevel">[NEXT]</A>
 <BR>
 <HR><A NAME="@rxlevel"><H3>@rxlevel</H3></A><PRE>
-  Command: @rxlevel &lt;target&gt;=&lt;list&gt;
+  Command: @rxlevel[/&lt;switch&gt;] &lt;target&gt;=[&lt;list&gt;]
   
   Sets or clears the Rx levels for the target. If a level name in list is
   prefixed with !, then the level is cleared.
   
   The @rxlevel is used for RECEIVING reality levels.  It determines what
   the target can see/hear/interact with.
+  
+  You may use the following switches:
+    /reset -- will reset (clear) the reality.  Using this switch you do not 
+              have to specify &lt;list&gt;.  &lt;list&gt; will be applied after
+              clearing.
   
   Example: @rxlevel *Joe=!Real Umbra
 
@@ -3373,6 +4173,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@shutdown"><H3>@shutdown</H3></A><PRE>
   Command: @shutdown &lt;text&gt;
+  
   Disconnects all connected players, saves the database to disk, and shuts
   down the game.  The game is unavailable until it is restarted.  If an
   argument is specified, it is written to the file named by the status_file
@@ -3397,10 +4198,14 @@ Generated: Wed Jan 13 04:15:57 2016
     /REGISTER      - removes site information for register only sites.
     /SUSPECT       - removes site information for suspect sites.
     /FORBID        - removes site information for forbidden sites.
+    /FORBIDAPI     - removes site information for API forbidden sites.
     /PERMIT        - removes site information for unrestricted sites.
     /TRUST         - removes site information for trusted sites.
     /NOAUTH        - removes site information for authentication checks.
     /NOHOST        - removes site information for DNS checks.
+    /PASSPROX      - removes site information for bypassing proxy checks.
+    /PASSAPI       - removes site information for API bypasses
+    /HARDCONN      - removes site information for hardconnections.
     /ALL           - removes all matching site information.
     /LIST          - show the raw *_host listings that you can use for
                      removal.  Handy if you use the optional connection args.
@@ -3412,7 +4217,9 @@ Generated: Wed Jan 13 04:15:57 2016
             @site/permit 123.123.123.0=/24
   
   See Also:  @admin, permit_site, register_site, suspect_site, forbid_site,
-             noguest_site, trust_site, noautoreg_site, @list 
+             noguest_site, trust_site, passproxy_site, forbidapi_site,
+             passapi_site, noautoreg_site, nodns_site, noauth_site, 
+             hardconn_site, @list 
 
 </PRE>
 <A HREF="#@shutdown">[PREV]</A>
@@ -3426,28 +4233,124 @@ Generated: Wed Jan 13 04:15:57 2016
   optionally performs a task based on the optional switch to both the
   image file and the object in question.  The following switches exist:
   
-    /list   - Syntax: @snapshot/list  (default)
-              This lists all image files you currently have to disk.
-    /verify - Syntax: @snapshot/verify &lt;imagefile&gt;
-              This issues a sanity check on the image file and lets
-              you know if the file is valid or corrupt.
-    /del    - Syntax: @snapshot/del &lt;imagefile&gt;
-              This deletes the specified image file from the drive.
-    /unload - Syntax: @snapshot/unload &lt;target&gt; [=&lt;optional prefix&gt;]
-              This makes a snapshot file of the specified target and
-              creates an optional prefix name for it.  Default name
-              will be the dbref#.  '123.img' for example.
-    /load   - Syntax: @snapshot/load &lt;target&gt; = &lt;imagefile&gt;
-              This will load the image file onto the specified object.
-              The object types MUST be the same, the object MUST be
-              a valid object, and some things (like location) will
-              be skipped on the restore.  Parents and Zones will be
-              set if validated.
+    /list      - Syntax: @snapshot/list  (default)
+                   This lists all image files you currently have to disk.
+    /verify    - Syntax: @snapshot/verify &lt;imagefile&gt;
+                   This issues a sanity check on the image file and lets
+                   you know if the file is valid or corrupt.
+    /del       - Syntax: @snapshot/del &lt;imagefile(s)&gt;
+                   This deletes the specified image file(s) from the drive.
+                   You may specify more than one in a space-delimited list.
+    /unload    - Syntax: @snapshot/unload &lt;target&gt; [=&lt;optional suffix&gt;]
+                   This makes a snapshot file of the specified target and
+                   creates an optional suffix name for it.  Default name
+                   will be the dbref#.  '123.img' for example.  The new
+                   name will be 123_&lt;suffix&gt;.img.
+    /unall     - Syntax: @snapshot/unall &lt;list of targets&gt;
+                   This works like /unload but takes a list of targets.
+                   You can not specify a destination name with this arg.
+    /load      - Syntax: @snapshot/load &lt;target&gt; = &lt;imagefile&gt;
+                   This will load the image file onto the specified object.
+                   The object types MUST be the same, the object MUST be
+                   a valid object, and some things (like location) will
+                   be skipped on the restore.  Parents and Zones will be
+                   set if validated.
+    /overwrite - when specified with /unload or /unall will allow
+                 overwriting the target file.
   
   See Also: @dump, @dbck
 
 </PRE>
 <A HREF="#@site">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@snoop">[NEXT]</A>
+<BR>
+<HR><A NAME="@snoop"><H3>@snoop</H3></A><PRE>
+  Command: @snoop[/switch] &lt;target&gt; [=&lt;owner&gt;]
+  
+  See 'snoop history' on reasons for adding this.
+   
+  Note: By adding -DNO_SNOOP to your compile options you can disable @snoop
+        entirely, but this capability exists with @hooking and many other
+        softcode alternatives.  This just is an all-in-one tool for it that
+        allows game owners much better accountability of its use.
+  
+  This can only be ran by IMMORTALS or by #1.  This is a hardcoded limitation.
+  
+  The @snoop command is a monitoring and administrative tool that connects a
+  port listener to the player's descriptor.  Once connected, anything that
+  the target player sees, does, or interacts with is passed along to the
+  watchers who are tagged to montior this user.
+  
+  A player disconnecting automatically turns off the snoop process.  You may
+  optionally set up a log monitoring that can be automated.
+  
+  The following switches exist:
+    /on       -- This is the default switch.  It turns on snooping on the
+                 specific target.
+    /off      -- This turns off all logging on the target, including file
+                 logging.
+    /log      -- Specify that it should make a file log of the target
+                 player.  All logs are timestamped.  The filename will be
+                 snoop&lt;dbref&gt;.txt located in your 'game' directory.
+   /status    -- Show status of all currently active @snoops.
+  
+  Examples: (Assume player Troll is dbref #123)
+    &gt; @snoop Troll            (online monitoring of Troll player)
+    &gt; @snoop Troll=Wizard     (online monitoring of Troll to player Wizard)
+    &gt; @snoop/off Troll        (disable monitoring of Troll player)
+    &gt; @snoop/off Troll=Wizard (disable monitoring of Troll from player wizard)
+    &gt; @snoop/log Troll        (logs in 'game' to snoop123.txt)
+    &gt; @snoop/status           (shows all current active snoops)
+  
+  See Also: @hook, SUSPECT, LOGROOM TOGGLE, log_command_list 
+  
+</PRE>
+<A HREF="#@snapshot">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@tag">[NEXT]</A>
+<BR>
+<HR><A NAME="@tag"><H3>@tag</H3></A><PRE>
+  Command: @tag &lt;tagname&gt;
+           @tag/list 
+           @tag/list &lt;searchstring&gt;
+           @tag/add &lt;tagname&gt;=&lt;#dbref&gt;
+           @tag/remove &lt;tagname&gt;
+  
+  This command gets used to manage and list the named tags of Rhost's tag
+  system (see wizhelp tags).
+ 
+  The first form lists the #dbref stored behind the tag named &lt;tagname&gt;. If
+  the tag does not exist, #-1 gets returned. This also goes for tags that
+  previously existed, but the #dbref stored behind them has been @destroyed
+  in the meantime - even if a new object once more is valid behind this
+  #dbref.
+ 
+  @tag/list lists all current valid tags and the #dbref associated with them.
+  @tag/list also accepts an optional search string as an argument. This
+  can get used to filter the taglist by names. It accepts wildcards and is
+  case-insensitive. 
+ 
+  @tag/add gets used to add a tag. If a named tag already exists, an error
+  is returned.
+ 
+  @tag/remove removes an existing tag. If the tag named &lt;tagname&gt; does not
+  exist, an error is returned.
+ 
+  The following sanity checks are performend for tags:
+ 
+  * Tagnames cannot be more than 32 characters in length
+  * Tagnames cannot cointain whitespace.
+  * Tags need to be supplied with a valid, existing object's #dbref on
+     creation.
+  * Up to 16 tags can reference the same #dbref
+  * Unicode is valid in tagnames!
+  * On destruction of an object, all referencing tags get also removed.
+ 
+  See also: wizhelp tags, help tag()
+   
+</PRE>
+<A HREF="#@snoop">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@thaw">[NEXT]</A>
 <BR>
@@ -3468,13 +4371,14 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: @ps, @freeze
 
 </PRE>
-<A HREF="#@snapshot">[PREV]</A>
+<A HREF="#@tag">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@timeout">[NEXT]</A>
 <BR>
 <HR><A NAME="@timeout"><H3>@timeout</H3></A><PRE>
   Attribute: Timeout
   Command: @timeout &lt;object&gt;[=&lt;seconds&gt;]
+  
   Sets an idle timeout value on &lt;object&gt; that is different from the default
   value.  If the value is non-numeric or less than or equal to zero, then
   the default value is used.  The only exception is if the value you set is
@@ -3495,6 +4399,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@timewarp"><H3>@timewarp</H3></A><PRE>
   Command: @timewarp[/&lt;switches&gt;] &lt;secs&gt;
+  
   Subtracts (or adds if negative) &lt;secs&gt; to one or more internal timers,
   depending on the switches specified from the following list:
      /check    - The time left until the next consistency check and database
@@ -3522,6 +4427,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@toad"><H3>@toad</H3></A><PRE>
   Command: @toad[/&lt;switches&gt;] &lt;victim&gt;[=&lt;recipient&gt;]
+  
   Turns the victim into an object (a slimy toad) and disconnects them from
   the game.  The named recipient (or the @toading wizard) get ownership of
   all the victim's things, rooms, and exits, as well as of the toad object
@@ -3542,6 +4448,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="@toggledef"><H3>@toggledef</H3></A><PRE>
   Command: @flagdef[/&lt;switches&gt;] [&lt;flagname&gt;=&lt;permission(s)&gt;]
            @toggledef[/&lt;switches&gt;] [&lt;togglename&gt;=&lt;permission(s)&gt;]
+           @totemdef[/&lt;switches&gt;] [&lt;totemname&gt;=&lt;permission(s)&gt;]
   
   This command defines ONLINE all the permissions for who can set, unset,
   and see a given flag.  The only flags that you can NOT define by this
@@ -3549,8 +4456,9 @@ Generated: Wed Jan 13 04:15:57 2016
   changes override the current default settings and are only good for
   the current boot of the machine (i.e.  Cleared on @shutdowns and @reboots).
   
-  The @toggledef handles all TOGGLES.
-  The @flagdef handlds all FLAGS. 
+  The @toggledef handles all TOGGLES.  (help @toggledef4 for options)
+  The @flagdef handlds all FLAGS.      (help @flagdef4 for options)
+  The @totemdef handlds all TOTEMS.      (help @totemdef4 for options)
   
   The following switches exist for this command.
     /set    - This sets permissions of who can SET the flag.
@@ -3562,11 +4470,13 @@ Generated: Wed Jan 13 04:15:57 2016
               associated letter.
     /list   - This lists the flags, settings, and permissions. (default)
               Columns are:
-                 'Set'   - defines who can set the flag.
-                 'Unset' - defines who can remove the flag.
-                 'See'   - defines who can see the flag.
-                 'Type'  - defines type restrictions for flag.
-                 'NoM'   - defines if the flag is un-modifiable.
+                 'Set'  - defines who can set the flag.
+                 'Unset'- defines who can remove the flag.
+                 'See'  - defines who can see the flag.
+                 'Type' - defines type restrictions for flag.
+                 'NoM'  - defines if the flag is un-modifiable.
+                 'T'    - Unique to Totems ([P]ermanent, [S]tatic, [T]emporary)
+                 'Slot' - Unique to Totems (slot position for @totem)
   
   Keep in mind that if the columns are EMPTY, it defaults to whatever the mush
   standard permissions are for setting and unsetting those flags.
@@ -3609,8 +4519,12 @@ Generated: Wed Jan 13 04:15:57 2016
   
   If you wish to remove a permission, you can use '!permission' to unset a
   given permission.  You may specify multiple permissions to set and remove at
-  the same time.  (i.e.  @flagdef/set marker0=god immortal !royalty mortal)
- 
+  the same time.  
+  
+  Examples:
+    InGame command -&gt; @flagdef/set marker0=!god !immortal !royalty mortal
+    netrhost.conf  -&gt; flag_access_set marker0 !god !immortal !royalty mortal 
+  
   { see 'wizhelp @flagdef3' for a list of available type restrictions }
   { see 'wizhelp @flagdef4' for a list of all @admin related parameters }
 
@@ -3642,8 +4556,12 @@ Generated: Wed Jan 13 04:15:57 2016
    
   If you wish to remove a permission, you can use '!permission' to unset a
   given permission.  You may specify multiple permissions to set and remove at
-  the same time.  (i.e.  @flagdef/type marker0=immortal !royalty room)
-
+  the same time.  
+  
+  Examples: 
+    InGame command -&gt; @flagdef/type marker0=immortal !royalty room
+    netrhost.conf  -&gt; flag_access_type marker0 immortal !royalty room
+  
   {see 'wizhelp @flagdef4' for a list of all @admin related parameters}
   
   See Also: @flag, @flagdef, @toggledef
@@ -3702,10 +4620,1024 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#@toggledef4">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem"><H3>@totem</H3></A><PRE>
+  Command: @totem[/&lt;switches&gt;] [&lt;totemname&gt; [=&lt;args&gt;]
+  
+  See 'TOTEMS' for a general overview of totems.
+  
+  The @totem command is the administative tool for in-game adding and
+  manipulation of @totems.  You may also add them in the source or through
+  the netrhost.conf file.  They can be issued through the @admin admin_object
+  as well.
+  
+  The following switches exist for @totem:
+    /add      - Add the totem.  CONFIG: totem_add
+                Syntax:  @totem/add totemname=slot# bitvalue
+    /remove   - Remove the totem.  (Can only remove temporary totems)
+                Syntax:  @totem/remove totemname
+    /list     - List the totems you have access to.  Does permission checks.
+                Syntax:  @totem/list
+    /set      - Controls who may set the totem.  CONFIG: totem_access_set
+                Syntax:  @totem/set totemname=permission(s)
+    /unset    - Controls who may unset the totem.  CONFIG: totem_access_unset
+                Syntax:  @totem/unset totemname=permission(s)
+    /see      - Controls who may see the totem.  CONFIG: totem_access_see
+                Syntax:  @totem/see totemname=permission(s)
+    /type     - Controls what types are denied.  CONFIG: totem_access_type
+                Syntax:  @totem/type totemname=permission(s)
+    /rename   - Rename the totem.  CONFIG: totem_rename
+                Syntax:  @totem/rename totemname=newname
+    /validate - Does a validation check on totems for dangling slot/values
+                Syntax:  @totem/validate
+    /info     - Does information lookup on the specified totem.
+                Syntax:  @totem/info totemname
+    /fulllist - Does full expansion of totem list (NAME|SLOT|VALUE)
+              - Syntax:  @totem/full totemname
+    /alias    - Assigns one or more aliases to a totem.  CONFIG: totem_alias
+              - Syntax:  @totem/alias totemname=alias(s)
+    /unalias  - Removes the alias of the targeted totem.
+              - Syntax:  @totem/unalias totemname=alias(s)
+    /display  - Show flags assigned to flag values of given slot.
+                Syntax:  @totem/display slotnumber
+    /letter   - Assign a flag letter to totem.  CONFIG: totem_letter
+                Syntax:  @totem/letter totemname=tierlevel letter
+    /slot     - display all the slots and the number of totems assigned.
+  
+    Currently not implemented:
+    /clean    - Will clean the dangling slot/values off all players
+                Syntax:  @totem/clean
+   
+  You may see individual help with 'help @totem/switchname' for any of the
+  above switches for more detail on each sub-topic.
+   
+  See Also:  totem_add, totem_alias, totem_access_set, totem_access_unset,
+             totem_access_see, totem_access_type, totem_letter, totem_rename,
+             totem_name
+
+</PRE>
+<A HREF="#@tor">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem add">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem add"><H3>@totem add</H3></A><PRE>
+  Command: @totem/add &lt;totem&gt; = &lt;slot&gt; &lt;mask&gt;
+  
+  This option will add the &lt;totem&gt; by name into the given &lt;slot&gt; with the
+  bitwise &lt;mask&gt; specified.  The mask must be a unique bitmask and the
+  slot must not currently be used.   The mask can be either in hex starting
+  with 0x as shown, or the decimal equivelant.  The valid slots are defined
+  to whatever the max slots are for that RhostMUSH.  The default is 0-9.
+  
+  Totem names must be less than 20 characters long.
+  
+  The following are the valid bitmasks:
+  
+    HEX        DECIMAL      HEX        DECIMAL      HEX        DECIMAL
+    ---------- -----------  ---------- -----------  ---------- ----------
+    0x00000001           1  0x00000800        2048  0x0040000      4194304
+    0x00000002           2  0x00001000        4096  0x0080000      8388608     
+    0x00000004           4  0x00002000        8192  0x0100000     16777216    
+    0x00000008           8  0x00004000       16384  0x0200000     33554432    
+    0x00000010          16  0x00008000       32768  0x0400000     67108864    
+    0x00000020          32  0x00010000       65536  0x0800000    134217728   
+    0x00000040          64  0x00020000      131072  0x1000000    268435456   
+    0x00000080         128  0x00040000      262144  0x2000000    536870912   
+    0x00000100         256  0x00080000      524288  0x4000000   1073741824  
+    0x00000200         512  0x00100000     1048576  0x8000000   2147483648  
+    0x00000400        1024  0x00200000     2097152     
+  
+  Examples:
+    &gt; @totem/add mytotem=1 0x00000001
+    &gt; @totem/add anothertotem=2 2
+  
+  Config parameter equivelant:
+    &gt; totem_add mytotem 1 0x00000001
+    &gt; totem_add anothertotem 2 2 
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem alias">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem alias"><H3>@totem alias</H3></A><PRE>
+  Command: @totem/alias &lt;totem&gt;=&lt;alias(es)&gt;
+  
+  This command will set the specified aliases for the target totem.  You 
+  may have a maximum of 10 aliases per totem.  This value is hardcoded and
+  can not be changed.  There should not be a reason for more than 10 aliases
+  for a totem.
+  
+  If a totem alias already exists, is invalid, or is the name of an existing
+  totem, the alias will fail for that totem alias name only.  The rest will
+  work, if valid.
+  
+  You may specify multiple aliases at one time.
+  
+  Examples:
+    &gt; @totem/alias mytotem=my myt myto mytot mytote
+    &gt; @totem/alias marker0=0
+
+  Config parameter equivelant:
+    &gt; totem_alias mytotem my myt myto mytot mytote
+    &gt; totem_alias marker0 0
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem add">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem clean">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem clean"><H3>@totem clean</H3></A><PRE>
+  Not currently implemented.
+
+</PRE>
+<A HREF="#@totem alias">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem display">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem display"><H3>@totem display</H3></A><PRE>
+  Command: @totem/display &lt;slot&gt;
+  
+  This command will display all the totems, totem letters, and values for
+  the specified slot.  If slot is not specified, it defaults to slot 0.
+  
+  Examples:
+    &gt; @totem/display
+    &gt; @totem/display 9
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem clean">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem fulllist">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem fulllist"><H3>@totem fulllist</H3></A><PRE>
+  Command: @totem/fulllist [&lt;slot&gt;]
+  
+  This will give a listing of all the totems.  You may optionally specify 
+  a totem slot you wish to see as this may be necessary as the complete
+  totem list can easily exceed the LBUF buffers.
+  
+  The administrative quick-list will show totems in the following format:
+               TOTEMNAME|SLOT-POSITION|SLOT-MASK-VALUE
+  
+  An example output would be:
+               MYTOTEM|1|0x00000001
+  
+  If you wish to see more details on a specific totem, please refer to
+  the @totem/info command.
+  
+  Examples:
+    &gt; @totem/fulllist
+    &gt; @totem/fulllist 0
+  
+  See Also: @totem, @totem/info
+
+</PRE>
+<A HREF="#@totem display">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem info">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem info"><H3>@totem info</H3></A><PRE>
+  Command: @totem/info &lt;totem&gt;
+  
+  This command gives detailed information on the specified totem.
+  Such information will be the bitmask, the slot, it's permanency 
+  level, permissions, and what dbref#'s currently have the particular 
+  totem set.
+  
+  Examples:
+    &gt; @totem/info marker0
+    &gt; @totem/info mytotem 
+  
+  See Also: @totem, @totem/clean
+
+</PRE>
+<A HREF="#@totem fulllist">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem letter">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem letter"><H3>@totem letter</H3></A><PRE>
+  Command: @totem/letter &lt;totem&gt;=&lt;tier-level&gt; &lt;letter&gt;
+  
+  This will define (or redefine) the character associated with a totem.  You
+  may reuse letters on totems.  The default letter '?' for tier-level 0 is 
+  used as a mask to not display letters for the totems.  This is intentional 
+  as some totems you may want to hide the letter value.  
+  
+  There are three tier levels you may use to define a letter.
+    0  - this is the default letter type.
+    1  - characters in tier 1 will be surrounded by []'s
+    2  - characters in tier 2 will be surrounded by {}'s
+  
+  Examples:
+    &gt; @totem/letter mytotem=0 m
+    &gt; @totem/letter mytotem1=1 m
+    &gt; @totem/letter mytotem2=2 m
+    &gt; think totems(me)
+    m[m]{m}
+  
+  Config parameter equivelant:
+    &gt; totem_letter mytotem 0 m
+    &gt; totem_letter mytotem1 1 m
+    &gt; totem_letter mytotem2 2 m
+   
+</PRE>
+<A HREF="#@totem info">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem remove">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem remove"><H3>@totem remove</H3></A><PRE>
+  Command: @totem/remove &lt;totem&gt;
+  
+  This will remove the specified totem.  By default you can only remove
+  temporary or static totems.  A temporary totem is defined as one that
+  is added via the @totem/add command.  A static totem is one that is defined
+  using the .conf file totem_add option.  A permanent totem is one defined
+  through the use of the internal source totem_add() as documented in the
+  source itself.
+
+  Examples:
+    &gt; @totem/remove mytotem
+    &gt; @totem/remove myothertotem    
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem letter">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem rename">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem rename"><H3>@totem rename</H3></A><PRE>
+  Command: @totem/rename &lt;totem&gt;=&lt;newname&gt;
+  
+  This command will rename the totem for the duration of the boot cycle.
+  If you have specified the config parameter 'totem_rename' with the
+  specified override, you may rename static and/or permanent totems.
+  
+  If either the totem name is invalid or the destination totem name is
+  invalid or in use, the command will fail.  
+  
+  Totem names must be less than 20 characters long.
+   
+  Examples:
+    &gt; @totem/rename mytotem=mynewtotem
+    &gt; @totem/rename anothertotem=anothernew
+  
+  Config parameter equivelant:
+    &gt; totem_name mytotem mynewtotem
+    &gt; totem_name anothertotem anothernew
+  
+  See Also: totem_rename, @totem
+
+</PRE>
+<A HREF="#@totem remove">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem see">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem see"><H3>@totem see</H3></A><PRE>
+  Command: @totem/see &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given permissions on the given totem on who may see them.
+  Valid permissions can be seen with 'wizhelp permissions'.  A special 
+  permission of 'mortal' is allowable.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls who may see the given totem.
+  
+  Examples:
+    &gt; @totem/see mytotem=wizard
+    &gt; @totem/see mytotem=!wizard architect
+  
+  Config parameter equivelant:
+    &gt; totem_access_see mytotem wizard
+    &gt; totem_access_see mytotem !wizard architect
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem rename">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem set">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem set"><H3>@totem set</H3></A><PRE>
+  Command: @totem/set &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given permissions on the given totem on who may set them.  
+  Valid permissions can be seen with 'wizhelp permissions'.  A special 
+  permission of 'mortal' is allowable.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls who may set the given totem.
+  
+  Examples:
+    &gt; @totem/set mytotem=wizard
+    &gt; @totem/set mytotem=!wizard architect
+  
+  Config parameter equivelant:
+    &gt; totem_access_set mytotem wizard
+    &gt; totem_access_set mytotem !wizard architect
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem see">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem slots">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem slots"><H3>@totem slots</H3></A><PRE>
+  Command: @totem/slots 
+  
+  This command will list every current active totem slot and the total number
+  of totems assigned to each slot.  It's a quick way to see what slots are 
+  available and how many free spaces are available to each slot.
+  
+  The output will be in the form: [Slot: &lt;slot&gt;:&lt;totems&gt;]
+  
+  Where &lt;slot&gt; is the slot number and &lt;totems&gt; are the number of totems
+  assigned to that specific slot.
+   
+  Exmaple:
+    &gt; @totem/slots
+  
+  See Also: @totem
+  
+</PRE>
+<A HREF="#@totem set">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem type">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem type"><H3>@totem type</H3></A><PRE>
+  Command: @totem/type &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given restrictions on the given totem on who may iset/unset
+  them based on type restrictions.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls a special type-case of what targets are allowable
+  to set or be set.
+  
+  Valid types are: THING, PLAYER, EXIT, ROOM, REGISTERED, GUILDMASTER,
+                   ARCHITECT, COUNCILOR, WIZARD, IMMORTAL
+  
+  If the type is set to THING, then the target can not be a type of THING.
+  If in addition you add COUNCILOR, then only COUNCILOR and higher may set
+  type THING.
+  
+  Examples:
+    &gt; @totem/type mytotem=room
+    &gt; @totem/type mytotem=!room thing wizard
+  
+  Config parameter equivelant:
+    &gt; totem_access_type mytotem room
+    &gt; totem_access_type mytotem !room thing wizard
+  
+  See Also: @totem
+
+
+</PRE>
+<A HREF="#@totem slots">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem unalias">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem unalias"><H3>@totem unalias</H3></A><PRE>
+  Command: @totem/unalias &lt;totem&gt;=&lt;alias(es)&gt;
+  
+  This command will remove the specified aliases from the target totem. 
+  
+  If a totem alias does not exist, is invalid, or is the name of an existing
+  totem, the unalias will fail for that totem unalias only.  The rest will
+  work, if valid.  Aliases that are not part of the target totem will not
+  be removed.
+  
+  You may specify multiple aliases to remove at one time.
+  
+  Examples:
+    &gt; @totem/unalias mytotem=my myt myto mytot mytote
+    &gt; @totem/unalias marker0=0
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem type">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem unset">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem unset"><H3>@totem unset</H3></A><PRE>
+  Command: @totem/unset &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given permissions on the given totem on who may unset them.
+  Valid permissions can be seen with 'wizhelp permissions'.  A special 
+  permission of 'mortal' is allowable.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls who may unset (ergo clear) the given totem.
+  
+  Examples:
+    &gt; @totem/unset mytotem=wizard
+    &gt; @totem/unset mytotem=!wizard architect
+  
+  Config parameter equivelant:
+    &gt; totem_access_unset mytotem wizard
+    &gt; totem_access_unset mytotem !wizard architect
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem unalias">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem validate">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem validate"><H3>@totem validate</H3></A><PRE>
+  Command: @totem/validate
+  
+  This command will go through all the totems and print out any invalid
+  totems.  Invalid totems are totems that are defined on players that 
+  were undefined or removed.
+  
+  The way totems work is it still saves the bitmask of what the totem
+  was on the player.  This is intentional since totems may dynamically
+  change, and it does no harm.
+  
+  This will display all invalid totem values, what slot they exist in,
+  and a list of every dbref# in the database that currently has defined
+  an unreferenced totem bitmask.
+   
+  Example:
+    &gt; @totem/validate
+  
+  See Also: @totem 
+
+</PRE>
+<A HREF="#@totem unset">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/add">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/add"><H3>@totem/add</H3></A><PRE>
+  Command: @totem/add &lt;totem&gt; = &lt;slot&gt; &lt;mask&gt;
+  
+  This option will add the &lt;totem&gt; by name into the given &lt;slot&gt; with the
+  bitwise &lt;mask&gt; specified.  The mask must be a unique bitmask and the
+  slot must not currently be used.   The mask can be either in hex starting
+  with 0x as shown, or the decimal equivelant.  The valid slots are defined
+  to whatever the max slots are for that RhostMUSH.  The default is 0-9.
+  
+  Totem names must be less than 20 characters long.
+  
+  The following are the valid bitmasks:
+  
+    HEX        DECIMAL      HEX        DECIMAL      HEX        DECIMAL
+    ---------- -----------  ---------- -----------  ---------- ----------
+    0x00000001           1  0x00000800        2048  0x0040000      4194304
+    0x00000002           2  0x00001000        4096  0x0080000      8388608     
+    0x00000004           4  0x00002000        8192  0x0100000     16777216    
+    0x00000008           8  0x00004000       16384  0x0200000     33554432    
+    0x00000010          16  0x00008000       32768  0x0400000     67108864    
+    0x00000020          32  0x00010000       65536  0x0800000    134217728   
+    0x00000040          64  0x00020000      131072  0x1000000    268435456   
+    0x00000080         128  0x00040000      262144  0x2000000    536870912   
+    0x00000100         256  0x00080000      524288  0x4000000   1073741824  
+    0x00000200         512  0x00100000     1048576  0x8000000   2147483648  
+    0x00000400        1024  0x00200000     2097152     
+  
+  Examples:
+    &gt; @totem/add mytotem=1 0x00000001
+    &gt; @totem/add anothertotem=2 2
+  
+  Config parameter equivelant:
+    &gt; totem_add mytotem 1 0x00000001
+    &gt; totem_add anothertotem 2 2 
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem validate">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/alias">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/alias"><H3>@totem/alias</H3></A><PRE>
+  Command: @totem/alias &lt;totem&gt;=&lt;alias(es)&gt;
+  
+  This command will set the specified aliases for the target totem.  You 
+  may have a maximum of 10 aliases per totem.  This value is hardcoded and
+  can not be changed.  There should not be a reason for more than 10 aliases
+  for a totem.
+  
+  If a totem alias already exists, is invalid, or is the name of an existing
+  totem, the alias will fail for that totem alias name only.  The rest will
+  work, if valid.
+  
+  You may specify multiple aliases at one time.
+  
+  Examples:
+    &gt; @totem/alias mytotem=my myt myto mytot mytote
+    &gt; @totem/alias marker0=0
+
+  Config parameter equivelant:
+    &gt; totem_alias mytotem my myt myto mytot mytote
+    &gt; totem_alias marker0 0
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem/add">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/clean">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/clean"><H3>@totem/clean</H3></A><PRE>
+  Not currently implemented.
+
+</PRE>
+<A HREF="#@totem/alias">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/display">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/display"><H3>@totem/display</H3></A><PRE>
+  Command: @totem/display &lt;slot&gt;
+  
+  This command will display all the totems, totem letters, and values for
+  the specified slot.  If slot is not specified, it defaults to slot 0.
+  
+  Examples:
+    &gt; @totem/display
+    &gt; @totem/display 9
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem/clean">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/fulllist">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/fulllist"><H3>@totem/fulllist</H3></A><PRE>
+  Command: @totem/fulllist [&lt;slot&gt;]
+  
+  This will give a listing of all the totems.  You may optionally specify 
+  a totem slot you wish to see as this may be necessary as the complete
+  totem list can easily exceed the LBUF buffers.
+  
+  The administrative quick-list will show totems in the following format:
+               TOTEMNAME|SLOT-POSITION|SLOT-MASK-VALUE
+  
+  An example output would be:
+               MYTOTEM|1|0x00000001
+  
+  If you wish to see more details on a specific totem, please refer to
+  the @totem/info command.
+  
+  Examples:
+    &gt; @totem/fulllist
+    &gt; @totem/fulllist 0
+  
+  See Also: @totem, @totem/info
+
+</PRE>
+<A HREF="#@totem/display">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/info">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/info"><H3>@totem/info</H3></A><PRE>
+  Command: @totem/info &lt;totem&gt;
+  
+  This command gives detailed information on the specified totem.
+  Such information will be the bitmask, the slot, it's permanency 
+  level, permissions, and what dbref#'s currently have the particular 
+  totem set.
+  
+  Examples:
+    &gt; @totem/info marker0
+    &gt; @totem/info mytotem 
+  
+  See Also: @totem, @totem/clean
+
+</PRE>
+<A HREF="#@totem/fulllist">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/letter">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/letter"><H3>@totem/letter</H3></A><PRE>
+  Command: @totem/letter &lt;totem&gt;=&lt;tier-level&gt; &lt;letter&gt;
+  
+  This will define (or redefine) the character associated with a totem.  You
+  may reuse letters on totems.  The default letter '?' for tier-level 0 is 
+  used as a mask to not display letters for the totems.  This is intentional 
+  as some totems you may want to hide the letter value.  
+  
+  There are three tier levels you may use to define a letter.
+    0  - this is the default letter type.
+    1  - characters in tier 1 will be surrounded by []'s
+    2  - characters in tier 2 will be surrounded by {}'s
+  
+  Examples:
+    &gt; @totem/letter mytotem=0 m
+    &gt; @totem/letter mytotem1=1 m
+    &gt; @totem/letter mytotem2=2 m
+    &gt; think totems(me)
+    m[m]{m}
+  
+  Config parameter equivelant:
+    &gt; totem_letter mytotem 0 m
+    &gt; totem_letter mytotem1 1 m
+    &gt; totem_letter mytotem2 2 m
+   
+</PRE>
+<A HREF="#@totem/info">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/remove">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/remove"><H3>@totem/remove</H3></A><PRE>
+  Command: @totem/remove &lt;totem&gt;
+  
+  This will remove the specified totem.  By default you can only remove
+  temporary or static totems.  A temporary totem is defined as one that
+  is added via the @totem/add command.  A static totem is one that is defined
+  using the .conf file totem_add option.  A permanent totem is one defined
+  through the use of the internal source totem_add() as documented in the
+  source itself.
+
+  Examples:
+    &gt; @totem/remove mytotem
+    &gt; @totem/remove myothertotem    
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem/letter">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/rename">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/rename"><H3>@totem/rename</H3></A><PRE>
+  Command: @totem/rename &lt;totem&gt;=&lt;newname&gt;
+  
+  This command will rename the totem for the duration of the boot cycle.
+  If you have specified the config parameter 'totem_rename' with the
+  specified override, you may rename static and/or permanent totems.
+  
+  If either the totem name is invalid or the destination totem name is
+  invalid or in use, the command will fail.  
+  
+  Totem names must be less than 20 characters long.
+   
+  Examples:
+    &gt; @totem/rename mytotem=mynewtotem
+    &gt; @totem/rename anothertotem=anothernew
+  
+  Config parameter equivelant:
+    &gt; totem_name mytotem mynewtotem
+    &gt; totem_name anothertotem anothernew
+  
+  See Also: totem_rename, @totem
+
+</PRE>
+<A HREF="#@totem/remove">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/see">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/see"><H3>@totem/see</H3></A><PRE>
+  Command: @totem/see &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given permissions on the given totem on who may see them.
+  Valid permissions can be seen with 'wizhelp permissions'.  A special 
+  permission of 'mortal' is allowable.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls who may see the given totem.
+  
+  Examples:
+    &gt; @totem/see mytotem=wizard
+    &gt; @totem/see mytotem=!wizard architect
+  
+  Config parameter equivelant:
+    &gt; totem_access_see mytotem wizard
+    &gt; totem_access_see mytotem !wizard architect
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem/rename">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/set">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/set"><H3>@totem/set</H3></A><PRE>
+  Command: @totem/set &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given permissions on the given totem on who may set them.  
+  Valid permissions can be seen with 'wizhelp permissions'.  A special 
+  permission of 'mortal' is allowable.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls who may set the given totem.
+  
+  Examples:
+    &gt; @totem/set mytotem=wizard
+    &gt; @totem/set mytotem=!wizard architect
+  
+  Config parameter equivelant:
+    &gt; totem_access_set mytotem wizard
+    &gt; totem_access_set mytotem !wizard architect
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem/see">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/slots">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/slots"><H3>@totem/slots</H3></A><PRE>
+  Command: @totem/slots 
+  
+  This command will list every current active totem slot and the total number
+  of totems assigned to each slot.  It's a quick way to see what slots are 
+  available and how many free spaces are available to each slot.
+  
+  The output will be in the form: [Slot: &lt;slot&gt;:&lt;totems&gt;]
+  
+  Where &lt;slot&gt; is the slot number and &lt;totems&gt; are the number of totems
+  assigned to that specific slot.
+   
+  Exmaple:
+    &gt; @totem/slots
+  
+  See Also: @totem
+  
+</PRE>
+<A HREF="#@totem/set">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/type">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/type"><H3>@totem/type</H3></A><PRE>
+  Command: @totem/type &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given restrictions on the given totem on who may iset/unset
+  them based on type restrictions.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls a special type-case of what targets are allowable
+  to set or be set.
+  
+  Valid types are: THING, PLAYER, EXIT, ROOM, REGISTERED, GUILDMASTER,
+                   ARCHITECT, COUNCILOR, WIZARD, IMMORTAL
+  
+  If the type is set to THING, then the target can not be a type of THING.
+  If in addition you add COUNCILOR, then only COUNCILOR and higher may set
+  type THING.
+  
+  Examples:
+    &gt; @totem/type mytotem=room
+    &gt; @totem/type mytotem=!room thing wizard
+  
+  Config parameter equivelant:
+    &gt; totem_access_type mytotem room
+    &gt; totem_access_type mytotem !room thing wizard
+  
+  See Also: @totem
+
+
+</PRE>
+<A HREF="#@totem/slots">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/unalias">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/unalias"><H3>@totem/unalias</H3></A><PRE>
+  Command: @totem/unalias &lt;totem&gt;=&lt;alias(es)&gt;
+  
+  This command will remove the specified aliases from the target totem. 
+  
+  If a totem alias does not exist, is invalid, or is the name of an existing
+  totem, the unalias will fail for that totem unalias only.  The rest will
+  work, if valid.  Aliases that are not part of the target totem will not
+  be removed.
+  
+  You may specify multiple aliases to remove at one time.
+  
+  Examples:
+    &gt; @totem/unalias mytotem=my myt myto mytot mytote
+    &gt; @totem/unalias marker0=0
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem/type">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/unset">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/unset"><H3>@totem/unset</H3></A><PRE>
+  Command: @totem/unset &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given permissions on the given totem on who may unset them.
+  Valid permissions can be seen with 'wizhelp permissions'.  A special 
+  permission of 'mortal' is allowable.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls who may unset (ergo clear) the given totem.
+  
+  Examples:
+    &gt; @totem/unset mytotem=wizard
+    &gt; @totem/unset mytotem=!wizard architect
+  
+  Config parameter equivelant:
+    &gt; totem_access_unset mytotem wizard
+    &gt; totem_access_unset mytotem !wizard architect
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#@totem/unalias">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totem/validate">[NEXT]</A>
+<BR>
+<HR><A NAME="@totem/validate"><H3>@totem/validate</H3></A><PRE>
+  Command: @totem/validate
+  
+  This command will go through all the totems and print out any invalid
+  totems.  Invalid totems are totems that are defined on players that 
+  were undefined or removed.
+  
+  The way totems work is it still saves the bitmask of what the totem
+  was on the player.  This is intentional since totems may dynamically
+  change, and it does no harm.
+  
+  This will display all invalid totem values, what slot they exist in,
+  and a list of every dbref# in the database that currently has defined
+  an unreferenced totem bitmask.
+   
+  Example:
+    &gt; @totem/validate
+  
+  See Also: @totem 
+
+</PRE>
+<A HREF="#@totem/unset">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totemdef">[NEXT]</A>
+<BR>
+<HR><A NAME="@totemdef"><H3>@totemdef</H3></A><PRE>
+  Command: @flagdef[/&lt;switches&gt;] [&lt;flagname&gt;=&lt;permission(s)&gt;]
+           @toggledef[/&lt;switches&gt;] [&lt;togglename&gt;=&lt;permission(s)&gt;]
+           @totemdef[/&lt;switches&gt;] [&lt;totemname&gt;=&lt;permission(s)&gt;]
+  
+  This command defines ONLINE all the permissions for who can set, unset,
+  and see a given flag.  The only flags that you can NOT define by this
+  method is the IMMORTAL flag and any internal flags to the mush.  These
+  changes override the current default settings and are only good for
+  the current boot of the machine (i.e.  Cleared on @shutdowns and @reboots).
+  
+  The @toggledef handles all TOGGLES.  (help @toggledef4 for options)
+  The @flagdef handlds all FLAGS.      (help @flagdef4 for options)
+  The @totemdef handlds all TOTEMS.      (help @totemdef4 for options)
+  
+  The following switches exist for this command.
+    /set    - This sets permissions of who can SET the flag.
+    /unset  - This sets permissions of who can UNSET (remove) the flag.
+    /see    - This sets permissions of who can SEE the flag.  (see below)
+    /type   - This sets restrictions of what type can NOT set/unset the flag.
+    /letter - This sets the specific letter defined for the flag.
+    /index  - This gives an index of flags and their hex representation and
+              associated letter.
+    /list   - This lists the flags, settings, and permissions. (default)
+              Columns are:
+                 'Set'  - defines who can set the flag.
+                 'Unset'- defines who can remove the flag.
+                 'See'  - defines who can see the flag.
+                 'Type' - defines type restrictions for flag.
+                 'NoM'  - defines if the flag is un-modifiable.
+                 'T'    - Unique to Totems ([P]ermanent, [S]tatic, [T]emporary)
+                 'Slot' - Unique to Totems (slot position for @totem)
+  
+  Keep in mind that if the columns are EMPTY, it defaults to whatever the mush
+  standard permissions are for setting and unsetting those flags.
+  
+  The 'see' is special in the fact this is actually the permission(s) of who 
+  can truly see the flag.
+  
+  { see 'wizhelp @flagdef2' for a list of available permissions }
+  { see 'wizhelp @flagdef3' for a list of available type restrictions }
+  { see 'wizhelp @flagdef4' for a list of all @admin related parameters }
+
+</PRE>
+<A HREF="#@totem/validate">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totemdef2">[NEXT]</A>
+<BR>
+<HR><A NAME="@totemdef2"><H3>@totemdef2</H3></A><PRE>
+  Command: @flagdef[/&lt;switches&gt;] [&lt;flagname&gt;=&lt;permission(s)&gt;]  (continued)
+           @toggledef[/&lt;switches&gt;] [&lt;togglename&gt;=&lt;permission(s)&gt;]
+  
+  The permissions available for the /set, /unset, and /see switches are:
+  G   god - only #1 has access
+  I   immortal - only immortal and higher have access
+  W   royalty - only royalty (wiz) and higher have access (can use 'wizard')
+  C   councilor - only councilor and higher have access
+  A   architect - only architect and higher has access
+  S   guildmaster - only guildmaster and higher has access
+  M   mortal - mortals and higher have access
+  +   no_suspect - suspects can not use this
+  !   no_guest - guests can not use this
+  ^   no_wanderer - wanderers can not use this
+  g   ignore - no one has access to it
+  i   ignore_im - only #1 has access to it
+  w   ignore_royal - only immortals and higher have access to it
+  c   ignore_counc - only royalty and higher have access to it
+  a   ignore_arch - only councilors and higher have access to it.
+  s   ignore_gm - only architects and higher have access to it.
+  m   ignore_mortal - only guildmaster and higher have access.
+  L   logflag - log all setting (/set) or removing (/unset) of specified flag.
+  
+  If you wish to remove a permission, you can use '!permission' to unset a
+  given permission.  You may specify multiple permissions to set and remove at
+  the same time.  
+  
+  Examples:
+    InGame command -&gt; @flagdef/set marker0=!god !immortal !royalty mortal
+    netrhost.conf  -&gt; flag_access_set marker0 !god !immortal !royalty mortal 
+  
+  { see 'wizhelp @flagdef3' for a list of available type restrictions }
+  { see 'wizhelp @flagdef4' for a list of all @admin related parameters }
+
+</PRE>
+<A HREF="#@totemdef">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totemdef3">[NEXT]</A>
+<BR>
+<HR><A NAME="@totemdef3"><H3>@totemdef3</H3></A><PRE>
+  Command: @flagdef[/&lt;switches&gt;] [&lt;flagname&gt;=&lt;permission(s)&gt;]  (continued)
+           @toggledef[/&lt;switches&gt;] [&lt;togglename&gt;=&lt;permission(s)&gt;]
+  
+  The restrictions available for /type are:
+  P   player - players can not set/unset this
+  T   thing - things (objects) can not set/unset this 
+  R   room - rooms can not set/unset this
+  E   exit - exits can not set/unset this
+  r   registered - enforce type setting to registered players and higher
+  g   guildmaster - enforce type setting to guildmaster and higher
+  a   architect - enforce type setting to architect and higher
+  c   councilor - enforce type setting to councilor and higher
+  w   wizard - enforce type setting to wizard (royalty) and higher
+  i   immortal - enforce type setting to immmortal/#1 only
+  
+  Note type restrictions if no bit restriction (rgacwi) specified, it assumes
+  no one will be allowed to set that given type.  Ergo, it locks it down
+  based on type only.  Registered players are defined as any player who does
+  not have the GUEST or WANDERER flag.
+   
+  If you wish to remove a permission, you can use '!permission' to unset a
+  given permission.  You may specify multiple permissions to set and remove at
+  the same time.  
+  
+  Examples: 
+    InGame command -&gt; @flagdef/type marker0=immortal !royalty room
+    netrhost.conf  -&gt; flag_access_type marker0 immortal !royalty room
+  
+  {see 'wizhelp @flagdef4' for a list of all @admin related parameters}
+  
+  See Also: @flag, @flagdef, @toggledef
+
+</PRE>
+<A HREF="#@totemdef2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#@totemdef4">[NEXT]</A>
+<BR>
+<HR><A NAME="@totemdef4"><H3>@totemdef4</H3></A><PRE>
+  Command: @flagdef[/&lt;switches&gt;] [&lt;flagname&gt;=&lt;permission(s)&gt;]  (continued)
+           @toggledef[/&lt;switches&gt;] [&lt;togglename&gt;=&lt;permission(s)&gt;]
+  
+  You may use @admin parameters and/or the netrhost.conf file to set the
+  override permissions for flags and toggles.  The following exist.
+  
+  @admin parameters for FLAG based perissions:
+  flag_access_set     - [@flagdef/set] Sets override permission on 'set'.
+  flag_access_unset   - [@flagdef/unset] Sets override permission on 'unset'.
+  flag_access_see     - [@flagdef/see] Sets override permission on 'see'.
+  flag_access_type    - [@flagdef/type] Sets type restrictions on set/unset.
+  
+  @admin parameters for TOGGLE based permissions.
+  toggle_access_set   - [@flagdef/set] Sets override permission on 'set'.
+  toggle_access_unset - [@flagdef/unset] Sets override permission on 'unset'.
+  toggle_access_see   - [@flagdef/see] Sets override permission on 'see'.
+  toggle_access_type  - [@flagdef/type] Sets type restrictions on set/unset.
+  
+  These parameters allow them to be 'permanent' in so much that they're 
+  applied at the booting of the mush.  Be aware that if you use flag_name
+  you must specify the flag that flag_name has renamed it to if put after
+  the flag_name renaming.
+  
+  See Also: flag_access_set, flag_access_unset, flag_access_see,
+            toggle_access_set, toggle_access_unset, toggle_access_see,
+            flag_access_type, toggle_access_type, @flagdef, @toggledef
+</PRE>
+<A HREF="#@totemdef3">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#@turtle">[NEXT]</A>
 <BR>
 <HR><A NAME="@turtle"><H3>@turtle</H3></A><PRE>
   Command: @turtle[/&lt;switch&gt;] &lt;victim&gt;[=&lt;given name|recipient/given name&gt;]
+  
   Turns, by default, the victim into a turtle.  This is just like @toad, but
   allows some special options.  You may specify a different name to call
   the target.  If left out, or null, it assumes the default of
@@ -3722,12 +5654,12 @@ Generated: Wed Jan 13 04:15:57 2016
     @turtle/no_chown *tinyjerk=small worm
 
 </PRE>
-<A HREF="#@tor">[PREV]</A>
+<A HREF="#@totemdef4">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#@txlevel">[NEXT]</A>
 <BR>
 <HR><A NAME="@txlevel"><H3>@txlevel</H3></A><PRE>
-  Command: @txlevel &lt;target&gt;=&lt;list&gt;
+  Command: @txlevel[/&lt;switch&gt;] &lt;target&gt;=[&lt;list&gt;]
   
   Sets or clears the Tx levels for the target. If a level name in list is
   prefixed with !, then the level is cleared.
@@ -3735,7 +5667,10 @@ Generated: Wed Jan 13 04:15:57 2016
   The @txlevel is used for TRANSMITTING reality levels.  It determines what
   things outside of the target can see/hear/interact on.
   
-  Example: @txlevel *Joe=Real !Umbra
+  You may use the following switches:
+    /reset -- will reset the reality.  Using this switch you do not have
+              to specify &lt;list&gt;.  &lt;list&gt; will be applied after
+              clearing.
 
 </PRE>
 <A HREF="#@turtle">[PREV]</A>
@@ -3744,6 +5679,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="@wall"><H3>@wall</H3></A><PRE>
   Command: @wall[/&lt;switches&gt;] &lt;message&gt;
+  
   With no switches, shouts &lt;message&gt; to every connected player or to every
   connected wizard, prefixed by either 'Announcement:' (if for everyone) or
   'Broadcast:' (if for wizards).  The following switches can be used to get 
@@ -3766,6 +5702,82 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#@txlevel">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#_">[NEXT]</A>
+<BR>
+<HR><A NAME="_"><H3>_</H3></A><PRE>
+  Command: @aflags[&lt;/switch&gt;] &lt;attribute or value&gt; [=&lt;argument&gt;]
+  
+  Note: Attributes that start with a prefix of _ will automatically
+        be wizard settable and seeable.
+  
+  This command will return all the toggled flags of that
+  given attribute.  This will also show prefix based permissions from
+  '_' attributes as well as those with the atrperms @admin parameter.
+  
+  Following switches exist:
+    /full -- give full statistics of the attribute, like count in use.
+    /perm -- list all current attribute based prefix permissions.
+    /list -- alias for /perm
+    /add  -- add a prefix attribute mask.
+    /del  -- delete a prefix attribute mask.
+    /mod  -- modify a prefix attribute mask.
+  
+  The @aflags without the switches display the permissions of the
+  specified attribute name.  Using the /full switch returns the count
+  of how many attributes are in active use by that name.  Be aware, the
+  /full switch walks the database so may take a few seconds to process.
+  
+  Examples:  
+    &gt; @aflags comment
+    (Attribute 44) Flags are: hidden no_command royalty wizard 
+    &gt; @aflags/full comment
+    (Attribute 44, Total Used: 36) Flags are: hidden no_command royalty wizard 
+ 
+  For the more advanced feature of @aflags with regards for attribute
+  prefix permission modification, see:  'wizhelp @aflags2'
+ 
+</PRE>
+<A HREF="#@wall">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#_noconnect_msg">[NEXT]</A>
+<BR>
+<HR><A NAME="_noconnect_msg"><H3>_NOCONNECT_MSG</H3></A><PRE>
+  Flag: NO_CONNECT([A]) (councilor and higher)
+  This flag when set on a player stops them from being able to connect to
+  their character.  Keep in mind, this flag will work on councilors and
+  lower.  The '[A]' uses a second flag list.
+  
+  You may specify a custom noconnect message with an attribute
+  _NOCONNECT_MSG on the player, or globally via the file object defined
+  by the file_object config parameter.
+   
+  This is aliased to 'NOCONNECT' for compatibility.
+   
+  See Also: FUBAR, SLAVE, file_object
+
+</PRE>
+<A HREF="#_">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#_nopossess_msg">[NEXT]</A>
+<BR>
+<HR><A NAME="_nopossess_msg"><H3>_NOPOSSESS_MSG</H3></A><PRE>
+  Flag: NO_POSSESS([C]) (royalty and higher)
+  This flag when set on a player makes it so that player can not be
+  on from two separate sites at once.  In addition, it makes it so
+  that player is unable to connect from the same site more than
+  twice.  This is to help avoid account sharing.
+  
+  You may set an attribute _NOPOSSESS_MSG on a player that will give
+  them a customized message, or set a global one on the file object
+  (via file_object config param).
+    
+  This is aliased to 'NOPOSSESS' for compatibility.
+  
+  See Also: admin_object
+  
+</PRE>
+<A HREF="#_noconnect_msg">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#abort_on_bug">[NEXT]</A>
 <BR>
 <HR><A NAME="abort_on_bug"><H3>abort_on_bug</H3></A><PRE>
@@ -3776,7 +5788,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: log.
 
 </PRE>
-<A HREF="#@wall">[PREV]</A>
+<A HREF="#_nopossess_msg">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#accent_extend">[NEXT]</A>
 <BR>
@@ -3812,22 +5824,278 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#accent_extend">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#account membership">[NEXT]</A>
+<BR>
+<HR><A NAME="account membership"><H3>ACCOUNT MEMBERSHIP</H3></A><PRE>
+  Topic: ACCOUNT MEMBERSHIP
+  
+  RhostMUSH offers the capability to engineer a single signon account
+  membership subsystem for logging in.  It does this through softcode
+  wrapping built in feature sets.  RhostMUSH utilizes the file_object
+  @admin parameter by setting up wrapped code to utilize the central
+  handler.
+  
+  The softcode scrambles the normal password attribute and utilizes
+  the attribute '_ACCT' (which you can alter how you see fit) to
+  handle the hashed password entries.
+  
+  It uses the execscript() account/connect.sh to call the supporting 
+  .txt files for connect handling.  The txt files are acct_connect.txt 
+  and acct_account.txt.  To use this you need to use the config param
+  'execscriptpath' and specify 'account' as a valid sub-path for
+  execscript() lookups.
+  
+  The acct_connect.txt is the 'normal' connect screen that introduces 
+  account subsystem commands to manage a central account login.
+  
+  The acct_account.txt is the account management connect screen
+  once someone has logged into their master account.
+  
+  Once logged in it will display the account handler commands for
+  you to login and manage your account and sub-memberships.
+  
+  There is a global command that will set up supporting commands for
+  the account information.  These commands are:
+     +su &lt;player&gt;     -- this swiches users to your other accounts
+     +accts           -- this lists all accounts tied to the master
+     +allaccts        -- staff command to list all accounts
+     +allaccts &lt;user&gt; -- staff command to list target accounts
+  
+  The built in commands to help processing are:
+     @conncheck/account -- Show all account statistics of logged in users
+  
+  The built in functions to that are used in the wrappers:
+     account_su()    -- switch users to accounts
+     account_owner() -- login or display the master account handler
+     account_login() -- login to the mush with the account user
+     account_who()   -- display ports using account handler
+  
+  Admin parameters you will find useful:
+     file_object     -- main handler for wrapping features
+     connect_methods -- disable hardcoded methods to login to the mush
+     execscriptpath  -- set the execscript subdir paths allowed
+                        set to 'accounts' to use the Mushcode supplied
+                        subsystem.
+  
+  See Also: account_su(), account_owner(), account_login(), file_object,
+            connect_methods, @conncheck, account_perm
+</PRE>
+<A HREF="#access">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#account_login()">[NEXT]</A>
+<BR>
+<HR><A NAME="account_login()"><H3>ACCOUNT_LOGIN()</H3></A><PRE>
+  Function: account_login(&lt;player&gt;, &lt;attribute&gt;, &lt;port&gt;, &lt;password&gt;)
+            account_login(&lt;player&gt;, &lt;attribute&gt;, &lt;port&gt;)
+  
+  This function is intended to be use with the file_object @admin
+  config parameter as it gives an alternative way to login to a
+  player character.  
+  
+  This is done by matching the target &lt;player&gt; with the HASHED
+  attribute password &lt;attribute&gt; that is stored on the player.
+  
+  They can not use the built in password method for this and
+  they must use a new hashed attribute for connection
+  purposes.  
+  
+  To set the password in the attribute, use the @password/attribute
+  or attrpass() function to do so.  Normal help is available on
+  @password and attrpass() to set attribute based hashes.
+  
+  It is *STRONGLY SUGGESTED* when setting attributes to be used
+  in this manner that you use wizard/immortal only attributes.
+  
+  There is some small amount of security risk to this feature,
+  however only immortals can use this function.  That fact
+  is hardcoded in and can not be overridden.
+  
+  If you specify the three argument method of account_login(),
+  it will use the account_owner() password that has been
+  cached for that session as the password to enter.
+  
+{ see 'wizhelp account_login2' for examples }
+
+</PRE>
+<A HREF="#account membership">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#account_login2">[NEXT]</A>
+<BR>
+<HR><A NAME="account_login2"><H3>ACCOUNT_LOGIN2</H3></A><PRE>
+  (CONTINUED)
+  Function: account_login(&lt;player&gt;, &lt;attribute&gt;, &lt;port&gt;, &lt;password&gt;)
+            account_login(&lt;player&gt;, &lt;attribute&gt;, &lt;port&gt;)
+  
+  In this example %1 is the arguments, %4 the port. 
+  Example:
+    &gt; think config(file_object)
+      123
+    &gt; &amp;FAKECOMMANDS #123=mylogin|myloginpwd|myowner
+      Set
+    &gt; &amp;RUN_MYOWNER #123=[ifelse(account_owner(first(%1),_ACCT,%4,rest(%1)),
+               Connected.,Failed to connect.  Invalid user or password.)]
+    &gt; &amp;RUN_MYLOGIN #123=[ifelse(account_login(first(%1),_ACCT,%4,rest(%1)),
+               Connected.,Failed to connect.  Invalid user or password.)]
+      Set.
+    &gt; &amp;RUN_MYLOGINPWD #123=[ifelse(account_login(first(%1),_ACCT,%4),
+               Connected.,Failed to connect.  Invalid user or password.)]
+      Set.
+    &gt; @password/attribute *Tester/_ACCT=zappo
+      Set - Tester/_ACCT: set with encrypted password.
+
+  
+  Then on the connect screen you would type:
+    &gt; mylogin tester zappo
+  
+  Or using the Single Signon you can do passwordless with:
+    &gt; myowner testmaster zappo    (the master account -- caches the passwd)
+    &gt; myloginpwd tester           (a member of the master account)
+  
+  That would connect you as normal.
+  
+  See Also: file_object, account_owner(), account_su(), account_who(), 
+            ACCOUNT MEMBERSHIP, account_perm
+
+</PRE>
+<A HREF="#account_login()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#account_owner()">[NEXT]</A>
+<BR>
+<HR><A NAME="account_owner()"><H3>ACCOUNT_OWNER()</H3></A><PRE>
+  Function: account_owner(&lt;player&gt;, &lt;attribute&gt;, &lt;port&gt;, &lt;password&gt;)
+            account_owner(&lt;port&gt;)
+            account_owner(&lt;port&gt;, logoff)
+  
+  Note: The account owner can be *ANY VALID DATA TYPE*.  The account owner
+        does not have to be a valid player, as the account owner is not
+        actually logging into the mush.
+  
+  This function will set or display the account 'owner' for the current
+  connection.  This is used to help identify a singular 'owner' for
+  account login permissions if you wish to use such a system for
+  login features.  This should be used in junction with account_login()
+  and the @admin file_object connect screen softcode command structure.
+  
+  The first option will 'login' you to the master account specified.
+  The second option will show -1 if not logged in or the master account.
+  The third option will log out off the master account.
+  
+  See 'wizhhelp account_login' on syntax on how to work through this.
+  
+  Examples:
+    &gt; WHO Bo
+      Player Name          On For Idle  Room     Ports Host
+      Bob                   00:11   0s  #0          18 [localhost]
+      1 Player logged in. (Bummer.)
+    &gt; say %#
+      You say &quot;#111&quot;
+    &gt; say account_owner(18)
+      You say &quot;-1&quot;
+    &gt; say account_owner(Bob, _ACCT, 18, zappo)
+      You say &quot;1&quot;
+    &gt; say account_owner(18)  
+      You say &quot;111&quot;
+  
+  See Also: account_login(), account_su(), file_object, account_who(),
+            ACCOUNT MEMBERSHIP, account_perm
+
+</PRE>
+<A HREF="#account_login2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#account_su()">[NEXT]</A>
+<BR>
+<HR><A NAME="account_su()"><H3>ACCOUNT_SU()</H3></A><PRE>
+  Function: account_su(&lt;player&gt;, &lt;port&gt;, &lt;attribute&gt;)
+  
+  This function will switch user in-game to the account with the 
+  specified attribute.  The target player must already be signed
+  in to the master account via account_owner() to cache the
+  password information or this function will fail. 
+  
+  Examples:
+    &gt; WHO Bo
+      Player Name          On For Idle  Room     Ports Host
+      Bob                   00:11   0s  #0          18 [localhost]
+      1 Player logged in. (Bummer.)
+    &gt; think account_su(Betty, 18, _ACCT)
+    &gt; WHO Be
+      Player Name          On For Idle  Room     Ports Host
+      Betty                 00:00   0s  #0          18 [localhost]
+      1 Player logged in. (Bummer.)
+   
+  See Also: account_owner(), account_login(), file_object, account_who(),
+            ACCOUNT MEMBERSHIP, account_perm
+  
+</PRE>
+<A HREF="#account_owner()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#account_who()">[NEXT]</A>
+<BR>
+<HR><A NAME="account_who()"><H3>ACCOUNT_WHO()</H3></A><PRE>
+  Function: account_who(&lt;separator&gt;)
+  
+  This function will display all the ports that are currently utilizing
+  the account subsystem.  You may then pass these ports into the other
+  account functions to softcode wrappers.
+  
+  Examples:
+    &gt; say account_who()
+    You say &quot;12 20 25&quot;
+  
+  See Also: account_owner(), account_login(), file_object, account_su(),
+            ACCOUNT MEMBERSHIP, account_perm
+
+</PRE>
+<A HREF="#account_su()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#admin_object">[NEXT]</A>
 <BR>
 <HR><A NAME="admin_object"><H3>admin_object</H3></A><PRE>
   Config parameter: admin_object &lt;dbref&gt;   Default: -1
+  
+  Note: For use of how to interactive with admin_object, see: 'wizhelp @admin'
   
   Specifies the object that all @admin config parmeters are loaded or unloaded
   to and from the shell.  It will read and write from/to the rhost_ingame.conf
   file.  This should be toward the bottom of your netrhost.conf file in the
   form 'include rhost_ingame.conf'.  If it is not, please add this toward the
   bottom of your netrhost.conf file right ABOVE the section that states it
-  is for local aliases/parameters.
+  is for local aliases/parameters.  The _LINE attributes MUST be in numerical
+  order and starts at '0'.  The admin object MUST be owned by an immortal.
+  The syntax of the lines are what would be normally put into a config file.
+  Some config parameters will not be able to be set with this method.  These
+  are generally constrained to system level changes that could potentially
+  cause harm so is locked to the shell.
+   
+  Note: The admin object as it is dbref #123 in this example will have to 
+        have an netrhost.conf file entry of:
+                               admin_object #123 
+  @reboot the mush after netrhost.conf file changes.
+   
+  Example admin_object setup:
+  &gt; @create AdminObject      (note, must be done from an immortal player)  
+    AdminObject created as object #123
+  &gt; &amp;_LINE0 AdminObject=function_invocation_limit 100000
+    Set.
+  &gt; &amp;_LINE1 AdminObject=idle_timeout -1
+    Set.
+  &gt; &amp;_LINE2 AdminObject=notaconfig 123
+    Set.
+  &gt; @admin/save
+  @admin: skipping invalid config option 'notaconfig' in attribute '_LINE2'.
+  @admin: completed writing 2 (of 3) lines into rhost_ingame.conf.
+  &gt; @admin/list
+  @admin: listing config params in 'rhost_ingame.conf' [dbref #123]:
+     0000 : function_invocation_limit 100000
+     0001 : idle_timeout -1
+  @admin: listing completed.
+  &gt; @admin/execute
+  @admin: executed 2 lines from rhost_ingame.conf
   
   See Also: @admin
 
 </PRE>
-<A HREF="#access">[PREV]</A>
+<A HREF="#account_who()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#aflags()">[NEXT]</A>
 <BR>
@@ -3921,6 +6189,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#alt inventories">[NEXT]</A>
 <BR>
 <HR><A NAME="alt inventories"><H3>ALT INVENTORIES</H3></A><PRE>
+  Topic: ALT INVENTORIES
+  
   RhostMUSH allows alternate inventory types.  They are pretty robust with
   what they allow.  To successfully set up alternate inventories, the
   following are used for configuration.
@@ -3952,6 +6222,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#alt inventories2">[NEXT]</A>
 <BR>
 <HR><A NAME="alt inventories2"><H3>ALT INVENTORIES2</H3></A><PRE>
+  Topic: ALT INVENTORIES
+  
   Alternate Inventories - A tutorial...
   [ Ok, let's first enable alternate inventories, worn, and wielded. ]
     &gt; @admin alt_inventories=1
@@ -4023,6 +6295,262 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#altover_inv">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor exit">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor exit"><H3>ancestor exit</H3></A><PRE>
+  Config parameter: global_parent_exit &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  This only effects exits.
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_room, global_parent_thing, global_parent_player
+            global_parent_obj
+
+</PRE>
+<A HREF="#always_blind">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor obj">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor obj"><H3>ancestor obj</H3></A><PRE>
+  Config parameter: global_parent_obj &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  The global_parent_TYPE params override the global setting.
+  TYPES are one of: room, exit, thing, player
+  
+  The flow of attribute inheritance is:
+  
+      Self -&gt; @parent -&gt; Zone -&gt; Global Parent Type -&gt; Global Parent Object
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: room_parent, thing_parent, exit_parent, player_parent,
+            global_parent_room, global_parent_thing, global_parent_exit,
+            global_parent_player
+
+</PRE>
+<A HREF="#ancestor exit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor player">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor player"><H3>ancestor player</H3></A><PRE>
+  Config parameter: global_parent_player &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  This only effects players.
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_exit, global_parent_room, global_parent_thing
+            global_parent_obj
+
+</PRE>
+<A HREF="#ancestor obj">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor room">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor room"><H3>ancestor room</H3></A><PRE>
+  Config parameter: global_parent_room &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  This only effects rooms.
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_exit, global_parent_thing, global_parent_player
+            global_parent_obj
+
+</PRE>
+<A HREF="#ancestor player">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor thing">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor thing"><H3>ancestor thing</H3></A><PRE>
+  Config parameter: global_parent_thing &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  This only effects things.
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_exit, global_parent_room, global_parent_player
+            global_parent_obj
+
+</PRE>
+<A HREF="#ancestor room">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor_exit">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor_exit"><H3>ancestor_exit</H3></A><PRE>
+  Config parameter: global_parent_exit &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  This only effects exits.
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_room, global_parent_thing, global_parent_player
+            global_parent_obj
+
+</PRE>
+<A HREF="#ancestor thing">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor_obj">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor_obj"><H3>ancestor_obj</H3></A><PRE>
+  Config parameter: global_parent_obj &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  The global_parent_TYPE params override the global setting.
+  TYPES are one of: room, exit, thing, player
+  
+  The flow of attribute inheritance is:
+  
+      Self -&gt; @parent -&gt; Zone -&gt; Global Parent Type -&gt; Global Parent Object
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: room_parent, thing_parent, exit_parent, player_parent,
+            global_parent_room, global_parent_thing, global_parent_exit,
+            global_parent_player
+
+</PRE>
+<A HREF="#ancestor_exit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor_player">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor_player"><H3>ancestor_player</H3></A><PRE>
+  Config parameter: global_parent_player &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  This only effects players.
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_exit, global_parent_room, global_parent_thing
+            global_parent_obj
+
+</PRE>
+<A HREF="#ancestor_obj">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor_room">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor_room"><H3>ancestor_room</H3></A><PRE>
+  Config parameter: global_parent_room &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  This only effects rooms.
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_exit, global_parent_thing, global_parent_player
+            global_parent_obj
+
+</PRE>
+<A HREF="#ancestor_player">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestor_thing">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestor_thing"><H3>ancestor_thing</H3></A><PRE>
+  Config parameter: global_parent_thing &lt;dbref&gt;.    Default: -1
+  
+  Specifies the dbref# (without leading '#') of the object that is to
+  be used for a 'global parent object'.  This works separate from
+  @parent and 'global @parents'.  This object, if set, will have all
+  it's attributes inherited to all object types in the database, minus
+  garbage and/or recovery data types.
+  
+  This only effects things.
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_exit, global_parent_room, global_parent_player
+            global_parent_obj
+
+</PRE>
+<A HREF="#ancestor_room">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#ancestors">[NEXT]</A>
+<BR>
+<HR><A NAME="ancestors"><H3>ancestors</H3></A><PRE>
+  Topic: global inherintance (ancestors)
+  
+  Global attributes works similiarilly to global parenting, except no actual
+  @parent is set on any target nor required.  There are actually 6 different
+  parameters for global inheritance.  These are:
+  
+        global_parent_obj      (default global inheritance)
+        global_parent_player   (for player types)
+        global_parent_thing    (for thing types)
+        global_parent_room     (for room types)
+        global_parent_exit     (for exit types)
+        zone_parents           (allow zones to inherit attributes)
+  
+  The order of inheritance is as follows:
+        1) Attribute exist on self
+        2) Attribute exist on @parent
+        3) Attribute exist on zone(s) (if defined)
+        4) Attribute exist on global_parent_&lt;type&gt; (if defined)
+        5) Attribute exist on global_parent_obj (if defined)
+  
+  Please note that global_parent_obj will not be used if there exists a 
+  specified type global parent (ie: global_parent_player).
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_obj, global_parent_player, global_parent_thing, 
+            global_parent_room, global_parent_exit, zone_parents
+  
+</PRE>
+<A HREF="#ancestor_thing">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#anonymous">[NEXT]</A>
 <BR>
 <HR><A NAME="anonymous"><H3>ANONYMOUS</H3></A><PRE>
@@ -4032,7 +6560,7 @@ Generated: Wed Jan 13 04:15:57 2016
   you are cloaked.  Nice if you want to hide who you are.
   
 </PRE>
-<A HREF="#always_blind">[PREV]</A>
+<A HREF="#ancestors">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#ansi_default">[NEXT]</A>
 <BR>
@@ -4046,6 +6574,9 @@ Generated: Wed Jan 13 04:15:57 2016
     AFTER()   -- Key field reversed if DISABLED
     BEFORE()  -- Key field reversed if DISABLED
     MID()     -- Type field reversed if DISABLED
+    DELETE()  -- Key field reversed if DISABLED
+    LEFT()    -- Key field reversed if DISABLED
+    RIGHT()   -- Key field reversed if DISABLED
   
 </PRE>
 <A HREF="#anonymous">[PREV]</A>
@@ -4065,6 +6596,236 @@ Generated: Wed Jan 13 04:15:57 2016
 
 </PRE>
 <A HREF="#ansi_default">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#api">[NEXT]</A>
+<BR>
+<HR><A NAME="api"><H3>API</H3></A><PRE>
+  Topic: API
+  
+  RhostMUSH has a process where it allows API connections to happen on another
+  port.  It requires to have the api_port specified to a unique port for the
+  API handler, then various optional config parameters to optimize how the
+  API works.  The API, unlike normal connections, allows any valid dbref# to
+  talk to the mush from the API engine.  It does this through multi-factor
+  authentication including host match and password authentication.
+  
+  It uses Basic Authorization and encapsulates.  Example of using curl for
+  login authentication to the API's object would be:
+             curl --user &quot;#123:foobar&quot;
+  
+  The dbref# would be #123, and the password you want to authenticate would
+  be 'foobar'.
+  
+  The API handler uses headers only.  No data is recognized.
+  
+  The following config options exist:
+    api_port          -- Port that the API engine listens on
+    api_nodns         -- Optionally disable DNS lookups.  Auth lookups
+                         are already disabled.
+    forbidapi_host    -- Forbid the given hostname from connecting to 
+                         the API
+    forbidapi_site    -- Forbid the given IP from connecting to the API
+    passapi_host      -- Allow hostname to bypasses the max_lastsite_api 
+                         restriction
+    passapi_site      -- Allow IP mask to bypasses the max_lastsite_api 
+                         restriction
+    max_lastsite_api  -- Maximum number of connections from a given site
+                         to the API handler a minute before auto-forbid.
+  
+  To configure a dbref# to be allowed to process API requests, you must 
+  configure the dbref#.  To do this you use the @api command.  If you wish
+  to monitor all API connections, you can do so with a specific @power.
+  The @power acts as an additional 'power up' to the existing MONITOR_SITE
+  and for busy API systems can be quite spammy.  You have been warned.
+  
+  The following @powers are relevant to the API subsystem:
+    API               -- The main API enable/disable control mechanism
+                         that specifies if a dbref# can be used for API
+                         processing.  @api interfaces this.
+    MONITORAPI        -- The MONITOR filter for API connections.
+  
+  The following attributes are relevant to the API subsystem:
+    _APIPASSWD        -- The attribute the encrypted password is stored
+                         for the dbref#.  @api interfaces this.
+    _APIIP            -- The allowable ip addresses that can use that
+                         specific dbref# for connections.  Defaults to
+                         just localhost.
+  
+{ see 'wizhelp api setup' for steps on how to set up a dbref# for use }
+{ see 'wizhelp api processing' to see how to actually use the API system }
+{ see 'wizhelp api return' for values you can expect back from the API }
+{ see 'wizhelp api errorcodes' for HTTP error codes that it can respond with }
+
+</PRE>
+<A HREF="#ansi_txtfiles">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#api processing">[NEXT]</A>
+<BR>
+<HR><A NAME="api processing"><H3>API PROCESSING</H3></A><PRE>
+  Topic: API PROCESSING
+  
+  To actually execute an API request, you need to send a web request to the 
+  API handler.  The API handler handles two request types.  POST and GET.
+  You use the POST handler to push (or execute) code on the mush, and the GET
+  handler to fetch (or receive) results from the mush.  It does this by using
+  HTTP headers only to configure the requests.  It uses customized headers.
+  
+  The following headers are available with the following options:
+  POST:
+     header - Exec:
+       -- The Exec: header is used to tell the mush what code to execute.
+          You would ensapsulate the code you want to run in double quotes.
+          You may specify more than one command by using semi-colons.
+          An empty Exec: call returns an error.
+          Example:  Exec: &quot;@emit test1;@emit test2&quot;
+     header - Time:
+       -- The Time: header is used to tell the queue how long to push the
+          request for.   If no Time: header is specified, it defaults to '0'.
+          If a negative value is fed to this, it defaults to '0'.  You may
+          use fractional values.
+          Example:  Time: &quot;100.5&quot;
+  
+  GET:
+     header - Exec:
+       -- The Exec: header is used to tell the mush what code to execute.
+          Unlike the POST requester, this only accepts functions/strings.
+          Example:  Exec: &quot;[lattr(#123/foo)]&quot;
+     header - Parse:
+       -- This specifies the type of parsing you wish to apply to the 
+          return string.  If not specified it assumes 'parse'.
+          The following applies:
+            parse       -- default.  Just parse the function as normal.
+            noparse     -- just evaluate percent substitutions, not code.
+            ansiparse   -- parse and return the ansi as translated encoding.
+            ansinoparse -- evaluate percent subs and translate ansi.
+            ansionly  -- do not parse and return the string as translated.
+          Example: Parse: &quot;parse&quot;
+     header - Encode: 
+       -- This will tell it to encode the Return: value in base64.
+          Options you can pass this is 'yes' to enable, and 'no' to disable.
+          No is the default value.  This is handy when you have multi-line
+          input that headers may not necessarily handle.
+  
+{ see 'wizhelp api setup' for steps on how to set up a dbref# for use }
+{ see 'wizhelp api return' for values you can expect back from the API }
+{ see 'wizhelp api errorcodes' for HTTP error codes that it can respond with }
+
+</PRE>
+<A HREF="#api">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#api return">[NEXT]</A>
+<BR>
+<HR><A NAME="api return"><H3>API RETURN</H3></A><PRE>
+  Topic: API RETURN
+  
+  When the mush responds to your API requests, it will do so with headers
+  only.  There is no data submitted.  If there is header data it does not
+  recognize or is malformed, it will return an appropiate error message.
+  
+  The following return encoding can be expected
+  POST:
+      HTTP/1.1 &lt;CODE&gt; OK
+      Content-type: text/plain
+      Date: Thu Jul  6 14:37:52 2017
+      Exec: &lt;STRING&gt;
+  
+  GET:
+      HTTP/1.1 &lt;CODE&gt; OK
+      Content-type: text/plain
+      Date: Thu Jul  6 14:51:16 2017
+      Exec: &lt;STRING&gt;
+      Return: &lt;VALUE&gt;
+  
+  
+      -- &lt;CODE&gt; may be any of the following with matching &lt;STRING&gt;
+         200 - OK            &lt;STRING&gt;: Ok - Executed
+         400 - Bad Request   &lt;STRING&gt;: Error - Invalid Headers Supplied
+         400 - Bad Request   &lt;STRING&gt;: Error - Empty String
+         404 - Not Found     &lt;STRING&gt;: Error - Invalid target
+         403 - Forbidden     &lt;STRING&gt;: Error - Permission Denied
+         403 - Forbidden     &lt;STRING&gt;: Error - IP not allowed
+         403 - Forbidden     &lt;STRING&gt;: Error - Malformed User or Password
+   
+      -- &lt;VALUE&gt; is the actual return value for a GET fetch.  This is what
+         the evaluated string will have been.
+  
+  GET Examples (this is from a command line using the 'curl' application)
+&gt; curl -X GET --user &quot;#12:ya&quot; -H &quot;Exec: [lnum(10)]&quot; --head http://localhost:2222
+  
+  POST Example: (this is from a command line using the 'curl' application)
+&gt; curl -X POST --user &quot;#12:ya&quot; -H &quot;Exec: @emit hi.&quot; --head http://localhost:2222
+  
+  See Also: @api 
+   
+{ see 'wizhelp api setup' for steps on how to set up a dbref# for use }
+{ see 'wizhelp api processing' to see how to actually use the API system }
+{ see 'wizhelp api errorcodes' for HTTP error codes that it can respond with }
+  
+
+
+</PRE>
+<A HREF="#api processing">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#api setup">[NEXT]</A>
+<BR>
+<HR><A NAME="api setup"><H3>API SETUP</H3></A><PRE>
+  Topic: API SETUP
+  
+  To setup and initialize a dbref# for use for the API subsystem, you would
+  use the @api command to configure it.  The following steps are required.
+  
+  1.  @api/enable &lt;target&gt;
+      -- This will tag the target to be API enabled.  It essentially sets
+         the target with the API @power.  While any valid dbref# will work
+         if you plan to use players you want to take extra percautions.
+  
+  2.  @api/password &lt;target&gt;=&lt;password&gt;
+      -- This sets a password hash of &lt;password&gt; that you then use to connect
+         to the target dbref# using the API subsystem.  If it doesn't match
+         the password it can't connect.
+  
+  3.  @api/ip &lt;taget&gt;=&lt;site(s)&gt;  
+      -- This is a list of wild-carded IP addresses that you wish to allow
+         connectivity through the API to that specific dbref#.  This is an
+         optional step and if not specified defaults to localhost only.
+  
+  4.  @api/status &lt;target&gt;
+      -- This will check the target object to make sure it's ready for API
+         connectivity.
+  
+{ see 'wizhelp api processing' to see how to actually use the API system }
+{ see 'wizhelp api return' for values you can expect back from the API }
+{ see 'wizhelp api errorcodes' for HTTP error codes that it can respond with }
+
+</PRE>
+<A HREF="#api return">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#api_nodns">[NEXT]</A>
+<BR>
+<HR><A NAME="api_nodns"><H3>api_nodns</H3></A><PRE>
+  Config parameter: api_nodns &lt;boolean&gt;.  Default: 0
+  
+  Specifies that API connections should not use the DNS lookup.  Please
+  not that AUTH lookups automatically do not occur for API connections.
+  
+  See Also: api_port, @blacklist, blacklist_nodns.txt
+
+</PRE>
+<A HREF="#api setup">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#api_port">[NEXT]</A>
+<BR>
+<HR><A NAME="api_port"><H3>api_port</H3></A><PRE>
+  Config parameter: api_port &lt;port&gt;.  Default: -1
+  
+  Specifies the IP port on which the API handler for the game listens 
+  for new connections.  This must be a unique port ID and not match
+  the other 'port' config option.
+  
+  See Also: ip_address, port, api_nodns
+
+</PRE>
+<A HREF="#api_nodns">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#architect">[NEXT]</A>
 <BR>
@@ -4095,7 +6856,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: GUILDMASTER, COUNCILOR, ROYALTY (or WIZARD), IMMORTAL
 
 </PRE>
-<A HREF="#ansi_txtfiles">[PREV]</A>
+<A HREF="#api_port">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#areg_file">[NEXT]</A>
 <BR>
@@ -4225,10 +6986,28 @@ Generated: Wed Jan 13 04:15:57 2016
   Note #3: When you delete an attribute, you do not need to specify bitmasks.
   Note #4: Specify owner and/or target if you want a specific duplicate prefix.
   
-  See Also: atrperms_max, @aflags
+  See Also: atrperms_max, atrperms_checkall, @aflags
 
 </PRE>
 <A HREF="#atrperms">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#atrperms_checkall">[NEXT]</A>
+<BR>
+<HR><A NAME="atrperms_checkall"><H3>atrperms_checkall</H3></A><PRE>
+  Config parameter: atrperms_checkall &lt;boolean&gt;   Default: 0
+  
+  This will enable checking all @aflag restricted attribute prefixes for any
+  attribute read or set.  This could potentially be costly depending on the
+  number of attributes flags you use.
+  
+  This will use the lowest matching permission for the attribute.
+  
+  Without this enabled, it will take them in order of when they were set.
+  This order can be seen with the @aflags command.
+  
+  See Also: atrperms_max, atrperms, @aflags
+</PRE>
+<A HREF="#atrperms2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#atrperms_max">[NEXT]</A>
 <BR>
@@ -4243,7 +7022,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: atrperms, @aflags
 
 </PRE>
-<A HREF="#atrperms2">[PREV]</A>
+<A HREF="#atrperms_checkall">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#atruse toggle">[NEXT]</A>
 <BR>
@@ -4376,8 +7155,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="attrib formatting"><H3>attrib formatting</H3></A><PRE>
   Attribute formatting can be accomplished multiple ways.  First, there is
   a generic local 'format' for most @-attributes.  To process this format,
-  you need to set an attribute of the name '&lt;attr&gt;format' on the target
-  (or parent, global parent, zone of the target. Use format&lt;attr&gt; if the
+  you need to set an attribute of the name 'format&lt;attr&gt;' on the target
+  (or parent, global parent, zone of the target. Use &lt;attr&gt;format if the
   config parameter format_compatibility is enabled). If this attribute is
   not found, it will then look at the global default parents for matching
   attribute inheritance.  Any attribute that you wish to inherit default
@@ -4385,6 +7164,8 @@ Generated: Wed Jan 13 04:15:57 2016
   passed into the formatting as '%0'.  Local formatting has priority
   over global formatting.
   
+  @list options system will show which format option is in use.
+   
   Examples:
     &gt; @desc me=This is a test
     &gt; @admin player_attr_default=123
@@ -4403,6 +7184,66 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#attrib contlocks">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#attribute contlocks">[NEXT]</A>
+<BR>
+<HR><A NAME="attribute contlocks"><H3>attribute contlocks</H3></A><PRE>
+  You may enable attribute content locking.  This is done by setting up a
+  global object to handle 'content locks'.  This is done through the config
+  parameter 'global_attrdefault'.  Once a valid dbref# is identified, then
+  the content (evaluated) of the attribute is matched against what is
+  being set.  What is being set is passed as %0 to the attribute.  If it
+  returns '1' then the attribute is allowed to be set.  If it returns '0'
+  then the attribute can not be set.
+  
+  Any attribute you want to possess attribute content locks must be set 
+  ATRLOCK.  You may set this globally on an attribute.
+  
+  Note:  Any local flags on an attribute WILL BE CLEARED if you @cpattr or
+         @mvattr into that attribute.  (they will be overwritten with
+         the flags on the attribute being copied.  This is the
+         intended behavior).  If you wish for the attributes to hold
+         their flags, you must either globally set the flags, or reset
+         the flags locally after the @mvattr or @cpattr.
+    
+  See Also: ATRLOCK, global_attrdefault
+  
+</PRE>
+<A HREF="#attrib formatting">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#attribute formatting">[NEXT]</A>
+<BR>
+<HR><A NAME="attribute formatting"><H3>attribute formatting</H3></A><PRE>
+  Attribute formatting can be accomplished multiple ways.  First, there is
+  a generic local 'format' for most @-attributes.  To process this format,
+  you need to set an attribute of the name 'format&lt;attr&gt;' on the target
+  (or parent, global parent, zone of the target. Use &lt;attr&gt;format if the
+  config parameter format_compatibility is enabled). If this attribute is
+  not found, it will then look at the global default parents for matching
+  attribute inheritance.  Any attribute that you wish to inherit default
+  pattern formatting must be set DEFAULT (attribute flag).  The desc is
+  passed into the formatting as '%0'.  Local formatting has priority
+  over global formatting.
+  
+  @list options system will show which format option is in use.
+   
+  Examples:
+    &gt; @desc me=This is a test
+    &gt; @admin player_attr_default=123
+    &gt; @desc #123=-&lt; %0 &gt;-
+    &gt; lo me
+      -&lt; This is a test &gt;-
+    &gt; &amp;formatdesc me===&lt;%0&gt;==
+    &gt; lo me
+      ===&lt;This is a test&gt;===
+  
+  See Also: player_attr_default, exit_attr_default, room_attr_default,
+            thing_attr_default, nodefault
+  
+  Special:  See normal help for the DEFAULT attribute flag
+  
+</PRE>
+<A HREF="#attribute contlocks">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#authenticate">[NEXT]</A>
 <BR>
 <HR><A NAME="authenticate"><H3>authenticate</H3></A><PRE>
@@ -4412,12 +7253,12 @@ Generated: Wed Jan 13 04:15:57 2016
   on player's connecting.  The default for this value is ON
 
 </PRE>
-<A HREF="#attrib formatting">[PREV]</A>
+<A HREF="#attribute formatting">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#autoreg db">[NEXT]</A>
 <BR>
 <HR><A NAME="autoreg db"><H3>AUTOREG DB</H3></A><PRE>
-  The autoregistration system comes with an enhanced seperate database 
+  The autoregistration system comes with an enhanced separate database 
   and tools to manipulate this database.  For help on this, type:
   
          wizhelp @areg
@@ -4466,6 +7307,8 @@ Generated: Wed Jan 13 04:15:57 2016
   
   MAILPROG          -- Defines the mail program used with autoregistration.
                        Default:  elm
+  MAILMUTT          -- Defines if the mail program used is mutt.
+                       Default:  no
   MAILSUB           -- Defines if the mail program used recognizes subjects.
                        Default:  yes
   OFFLINE_REG       -- Enables off-line (ie: connect screen) registration.
@@ -4575,12 +7418,42 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#bcc_hidden">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#blacklist file">[NEXT]</A>
+<BR>
+<HR><A NAME="blacklist file"><H3>blacklist file</H3></A><PRE>
+  Topic: blacklist file contents
+  
+  The blacklist.txt file (which will reside in the game directory) will
+  look like the following as an example:
+  
+     123.123.123.123
+     122.122.122.0 /24
+     122.122.0.0 255.255.0.0
+  
+  If you do not specify a netmask, it will assume 255.255.255.255 (/32) as
+  the netmask.  You may use CIDR notation (ie: /24) or the ipv4 notation
+  instead (ie: 255.255.255.0).  
+  
+  IP and NETMASK needs to be separated by a white space.  This can be
+  one or more spaces and/or one or more tabs.
+  
+  If the IP or netmask is invalid, it will skip the entry.
+  
+  See Also: @site, @blacklist
+  
+</PRE>
+<A HREF="#beep()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#blacklist.txt">[NEXT]</A>
 <BR>
 <HR><A NAME="blacklist.txt"><H3>blacklist.txt</H3></A><PRE>
-  Command: @blacklist[/&lt;switch&gt;]
+  Command: @blacklist[/&lt;switch&gt;] [&lt;argument&gt;]
+           @blacklist/nodns[/&lt;switch&gt;] [&lt;argument&gt;]
+  
+  NOTE:  If you @blacklist 127.0.0.1 you may inadvertently disable SSL tunnels
+  
   This command lists, loads, or clears the current blacklists.  Blacklists are
-  similiar to forbid sites, except it keeps them in a seperate list to avoid
+  similiar to forbid sites, except it keeps them in a separate list to avoid
   spamming the site list.  You can have a maximum of 100,000 entries in the
   blacklist.  This reads a list of sites in a file blacklist.txt that it 
   populates into the blacklist.  All invalid sites will be ignored.  All
@@ -4589,16 +7462,124 @@ Generated: Wed Jan 13 04:15:57 2016
   blacklist.  There is a script that can be ran that will populate this
   file with all known TOR exit points.
   
+  The second argument, like the normal @blacklist, only applies to NoDNS 
+  entries.
+  
+  The blacklist file will be blacklist.txt
+  The NoDNS blacklist file will be blacklist_nodns.txt
+  
+  You may optionally have a netmask (in ipv4 or CIDR notation) after the IP
+  in the blacklist.txt.  If no masks is seen, it will assume /32.  
+  
   The following switches exist for @blacklist:
-    /load  - Load in all sites in the blacklist.txt file
-    /clear - purges the blacklist
-    /list  - lists all sites in the blacklist
+    /load   - Load in all sites in the blacklist.txt file
+    /clear  - purges the blacklist
+    /list   - lists all sites in the blacklist.  This shows 4 to a line.
+    /mask   - like list but will show the IP and associated NETMASK.  This
+              shows 2 IP's and 2 NETMASK's to a line.
+    /search - search for a wildcard IP address (@blacklist/search 127.*)
+    /add    - Add an IP with a mask (syntax: @blacklist/add IP MASK)
+    /del    - Delete an IP with a mask (syntax: @blacklist/del IP MASK)
+              Note: MASK if not specified assumes 255.255.255.255
   
-  If no switch is specified, it gives a summary of sites in the blacklist.
+  The following feature switches can be used with the above 4 switches:
+    /nodns - If this is used with any of the 4 main switches, it will 
+             work against the NoDNS lists and not the blacklists.
   
-  See Also: forbid_site, @site
+{ see 'wizhelp @blacklist2' for arguments and examples }
+{ 'wizhelp blacklist file' for an example of the blacklist.txt file }
+
 </PRE>
-<A HREF="#beep()">[PREV]</A>
+<A HREF="#blacklist file">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#blacklist_max">[NEXT]</A>
+<BR>
+<HR><A NAME="blacklist_max"><H3>blacklist_max</H3></A><PRE>
+  Config parameter: blacklist_max &lt;value&gt;    Default: 100000
+  
+  Defines the maximum value of Blacklisted hosts and blacklisted NoDNS entries
+  that are allowed.  The value can be between 1000 and 5000000.  Keep in mind
+  that the larger the value the slightly more overhead on player connects as
+  this is a list that must be walked to compare against the connecting player.
+  
+  See Also: @blacklist
+
+</PRE>
+<A HREF="#blacklist.txt">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#blacklist_nodns file">[NEXT]</A>
+<BR>
+<HR><A NAME="blacklist_nodns file"><H3>blacklist_nodns file</H3></A><PRE>
+  Topic: blacklist file contents
+  
+  The blacklist.txt file (which will reside in the game directory) will
+  look like the following as an example:
+  
+     123.123.123.123
+     122.122.122.0 /24
+     122.122.0.0 255.255.0.0
+  
+  If you do not specify a netmask, it will assume 255.255.255.255 (/32) as
+  the netmask.  You may use CIDR notation (ie: /24) or the ipv4 notation
+  instead (ie: 255.255.255.0).  
+  
+  IP and NETMASK needs to be separated by a white space.  This can be
+  one or more spaces and/or one or more tabs.
+  
+  If the IP or netmask is invalid, it will skip the entry.
+  
+  See Also: @site, @blacklist
+  
+</PRE>
+<A HREF="#blacklist_max">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#blacklist_nodns.txt">[NEXT]</A>
+<BR>
+<HR><A NAME="blacklist_nodns.txt"><H3>blacklist_nodns.txt</H3></A><PRE>
+  Command: @blacklist[/&lt;switch&gt;] [&lt;argument&gt;]
+           @blacklist/nodns[/&lt;switch&gt;] [&lt;argument&gt;]
+  
+  NOTE:  If you @blacklist 127.0.0.1 you may inadvertently disable SSL tunnels
+  
+  This command lists, loads, or clears the current blacklists.  Blacklists are
+  similiar to forbid sites, except it keeps them in a separate list to avoid
+  spamming the site list.  You can have a maximum of 100,000 entries in the
+  blacklist.  This reads a list of sites in a file blacklist.txt that it 
+  populates into the blacklist.  All invalid sites will be ignored.  All
+  site masks are assumed to be '255.255.255.255' (/32).  The blacklist.txt
+  file will be a single line list of IP's that you wish to have in the
+  blacklist.  There is a script that can be ran that will populate this
+  file with all known TOR exit points.
+  
+  The second argument, like the normal @blacklist, only applies to NoDNS 
+  entries.
+  
+  The blacklist file will be blacklist.txt
+  The NoDNS blacklist file will be blacklist_nodns.txt
+  
+  You may optionally have a netmask (in ipv4 or CIDR notation) after the IP
+  in the blacklist.txt.  If no masks is seen, it will assume /32.  
+  
+  The following switches exist for @blacklist:
+    /load   - Load in all sites in the blacklist.txt file
+    /clear  - purges the blacklist
+    /list   - lists all sites in the blacklist.  This shows 4 to a line.
+    /mask   - like list but will show the IP and associated NETMASK.  This
+              shows 2 IP's and 2 NETMASK's to a line.
+    /search - search for a wildcard IP address (@blacklist/search 127.*)
+    /add    - Add an IP with a mask (syntax: @blacklist/add IP MASK)
+    /del    - Delete an IP with a mask (syntax: @blacklist/del IP MASK)
+              Note: MASK if not specified assumes 255.255.255.255
+  
+  The following feature switches can be used with the above 4 switches:
+    /nodns - If this is used with any of the 4 main switches, it will 
+             work against the NoDNS lists and not the blacklists.
+  
+{ see 'wizhelp @blacklist2' for arguments and examples }
+{ 'wizhelp blacklist file' for an example of the blacklist.txt file }
+
+</PRE>
+<A HREF="#blacklist_nodns file">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#blind_snuffs_cons">[NEXT]</A>
 <BR>
@@ -4611,7 +7592,7 @@ Generated: Wed Jan 13 04:15:57 2016
   regardless.
 
 </PRE>
-<A HREF="#blacklist.txt">[PREV]</A>
+<A HREF="#blacklist_nodns.txt">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#brace_compatibility">[NEXT]</A>
 <BR>
@@ -4863,12 +7844,19 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#chkgarbage()">[NEXT]</A>
 <BR>
 <HR><A NAME="chkgarbage()"><H3>CHKGARBAGE()</H3></A><PRE>
-  Function: chkgarbage(&lt;object&gt;, &lt;going|recover&gt;)
+  Function: chkgarbage(&lt;object&gt;, &lt;type&gt;)
   
-  This function returns '1' if the target object is (g)oing or
-  currently (r)ecoverable.  You may specify the 'g' or 'r' for
-  the option or the entire word.  Your choice.  This is a boolean
-  function and will return '1' for TRUE and '0' for FALSE.
+  This function returns '1' (TRUE) if the target object is (g)oing,
+  currently (r)ecoverable, or (b)oth.  If the target object is not
+  going/recover as checking, it will return '0' (FALSE).
+  
+  You must specify a type.  There is no default value.
+  
+  The following types exist:
+      garbage [g] -- check for garbage. 'g' works as shorthand.
+      recover [r] -- check for recoverable. 'r' works as shorthand.
+      both [b]    -- check for both garbage and recoverable.
+
 
 </PRE>
 <A HREF="#checkpass()">[PREV]</A>
@@ -4912,6 +7900,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#cloaking">[NEXT]</A>
 <BR>
 <HR><A NAME="cloaking"><H3>CLOAKING</H3></A><PRE>
+  Topic: CLOAKING
+  
   Cloaking on RhostMUSH is unique from other server types.  If you happen
   to be bitlevel 5 or higher (ROYALTY (wizard) or IMMORTAL (super-royalty))
   and set both the UNFINDABLE and DARK flags, you are considered WIZCLOAKED.
@@ -4927,7 +7917,7 @@ Generated: Wed Jan 13 04:15:57 2016
   from you if they're higher bitlevel than you.
   
   The DARK and UNFINDABLE flags otherwise have expected results if used
-  seperate from each other, though DARK, for obvious reasons, will not
+  separate from each other, though DARK, for obvious reasons, will not
   make you 'DARK' like on normal mushes. (unless configured to do so with
   the appropiate @admin parameters)
 
@@ -5038,7 +8028,9 @@ Generated: Wed Jan 13 04:15:57 2016
   users each timeslice.  Each command a user types in (commands executed by
   machines do not count) decreases the quota by 1, and the user's commands are
   only executed if the quota is greater than zero.
-  See Also: command_quota_max, timeslice.
+  
+  See Also: command_quota_max, wizcommand_quota_max, timeslice,
+            @cmdquota
 
 </PRE>
 <A HREF="#command_dark">[PREV]</A>
@@ -5053,7 +8045,9 @@ Generated: Wed Jan 13 04:15:57 2016
   Each command a user types in (commands executed by machines do not count)
   decreases the quota by 1, and the user's commands are only executed if the
   quota is greater than zero.
-  See Also: command_quota_increment, timeslice.
+  
+  See Also: command_quota_increment, wizcommand_quota_max, timeslice,
+            @cmdquota
 
 </PRE>
 <A HREF="#command_quota_increment">[PREV]</A>
@@ -5067,25 +8061,28 @@ Generated: Wed Jan 13 04:15:57 2016
   slay            WHO             wizhelp        mail            wmail
   channel         cd              news           newsdb
  
-  @admin          @aflags         @apply_marked  @areg           @attribute 
-  @blacklist      @boot           @chown         @chownall       @clone     
-  @conncheck      @convert        @cut           @dbck           @dbclean
-  @depower        @destroy        @disable       @doing          @dump       
-  @dynhelp        @enable         @fixdb         @flag           @flagdef    
-  @freeze         @function       @halt          @hide           @hook       
-  @icmd           @kick           @limit         @list           @list_file  
-  @listmotd       @lock           @log           @logrotate      @mark       
-  @mark_all       @money          @motd          @newpassword    @nuke       
-  @pcreate        @poor           @power         @progreset      @protect    
-  @ps             @purge          @quota         @readcache      @reboot     
-  @recover        @reclist        @remote        @rwho           @site       
-  @shutdown       @snapshot       @thaw          @timewarp       @toad       
-  @tor            @turtle         @wall          +players
+  @admin          @aflags         @api           @apply_marked   @areg       
+  @attribute      @blacklist      @boot          @chown          @chownall   
+  @clone          @cmdquota       @conncheck     @convert        @cut          
+  @dbck           @dbclean        @depower       @destroy        @disable      
+  @doing          @dump           @dynhelp       @enable         @fixdb        
+  @flag           @flagdef        @freeze        @function       @halt        
+  @hide           @hook           @icmd          @kick           @limit        
+  @list           @list_file      @listmotd      @lock           @log          
+  @logrotate      @mark           @mark_all      @money          @motd         
+  @newpassword    @nuke           @pcreate       @poor           @power        
+  @progreset      @protect        @ps            @purge          @quota        
+  @readcache      @reboot         @recover       @reclist        @remote       
+  @rwho           @site           @shutdown      @snapshot       @snoop
+  @tag            @thaw           @timewarp      @toad           @toggledef
+  @tor            @totem          @totemdef      @turtle         @wall       
+  +players
  
   @adesc2         @allowance      @altname       @badsite        @comment
-  @createdstamp   @darkexitformat @goodsite      @invtype        @mailsmax
-  @mailscur       @mailtime       @modifiedstamp @paylim         @queuemax 
-  @receivelim     @rsrvdesc2      @rxlevel       @timeout        @txlevel
+  @createdstamp   @darkexitformat @goodsite      @invtype        @leveldefault
+  @mailsmax       @mailscur       @mailtime      @modifiedstamp  @paylim
+  @queuemax       @receivelim     @rsrvdesc2     @rxlevel        @timeout
+  @txlevel
   
   @create         @dig            @lock          @open           @pemit   
   page            whisper        
@@ -5132,27 +8129,29 @@ Generated: Wed Jan 13 04:15:57 2016
   admin_object             ahear_maxcount           ahear_maxtime          
   alias                    allow_ansinames          allow_whodark          
   alt_inventories          altover_inv              always_blind           
-  ansi_default             ansi_textfiles           areg_file              
-  areg_lim                 aregh_file               atrperms               
+  ansi_default             ansi_textfiles           api_nodns
+  api_port                 areg_file                areg_lim               
+  aregh_file               atrperms                 atrperms_checkall
   atrperms_max             attr_access              attr_alias             
   attr_cmd_access          authenticate             bad_name               
-  badsite_file             bcc_hidden               blind_snuffs_cons      
-  brace_compatibility      break_compatability      cache_depth            
-  cache_steal_dirty        cache_trim               cache_width            
-  cap_articles             cap_conjunctions         cap_preposition        
-  check_interval           check_offset             clone_copies_cost      
-  cluster_cap              clusterfunc_cap          comcost                
-  command_dark             command_quota_increment  command_quota_max      
-  compress_program         compression              config_access          
-  conn_timeout             connect_file             connect_reg_file       
+  badsite_file             bcc_hidden               blacklist_max
+  blind_snuffs_cons        brace_compatibility      break_compatability    
+  cache_depth              cache_steal_dirty        cache_trim             
+  cache_width              cap_articles             cap_conjunctions       
+  cap_preposition          check_interval           check_offset           
+  clone_copies_cost        cluster_cap              clusterfunc_cap        
+  comcost                  command_dark             command_quota_increment
+  command_quota_max        compress_program         compression            
+  config_access            conn_timeout             connect_file           
+  connect_methods          connect_perm             connect_reg_file       
   cpu_secure_lvl           cpuintervalchk           cputimechk             
   crash_database           create_max_cost          create_min_cost        
-  dark_sleepers            descs_are_local          default_home           
-  dig_cost                 door_file                door_index             
-  down_file                down_motd_message        dump_interval          
-  dump_message             dump_offset              earn_limit             
-  empower_fulltel          enable_tstamps           enforce_unfindable     
-  enhanced_convtime        error_file 
+  dark_sleepers            default_home             delim_null             
+  descs_are_local          dig_cost                 door_file              
+  door_index               down_file                down_motd_message      
+  dump_interval            dump_message             dump_offset            
+  earn_limit               empower_fulltel          enable_tstamps         
+  enforce_unfindable       enhanced_convtime        error_file 
   
 { 'wizhelp config parameters2' for more }
 { 'wizhelp config parameters reality' for more (reality levels) }
@@ -5194,30 +8193,34 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="config parameters2"><H3>CONFIG PARAMETERS2</H3></A><PRE>
   Topic: CONFIG PARAMETERS (continued)
   
-  error_index               examine_flags             examine_public_attrs   
-  examine_restrictive       exit_attr_default         exit_flags              
-  exit_parent               exit_quota                exit_toggles
-  exits_connect_rooms       expand_goto               fascist_teleport        
-  file_object               find_money_chance         flag_alias              
-  flag_name                 flag_access_see           flag_access_set         
-  flag_access_type          flag_access_unset         float_precision         
-  forbid_host               forbid_site               fork_dump               
-  format_compatbility       fork_vfork                format_contents         
-  format_exits              format_name               formats_are_local       
-  full_file                 full_motd_message         function_access         
-  function_alias            function_invocation_limit function_recursion_limit
-  gdbm_cache_size           gdbm_database             global_aconnect         
-  global_adisconnect        global_ansimask           global_attrdefault      
-  global_clone_exit         global_clone_obj          global_clone_player     
-  global_clone_room         global_clone_thing        global_error_obj        
-  global_parent_exit        global_parent_obj         global_parent_player    
-  global_parent_room        global_parent_thing       good_name               
-  goodmail_host             gconf_file                guest_char_num          
-  guest_file                guest_namelist            guild_attrname          
-  guild_default             guild_hdr                 hackattr_nowiz          
-  hackattr_see              hasattrp_compat           heavy_cpu_max           
-  help_file                 help_index                hide_nospoof            
-  hook_cmd                  hook_obj                
+  error_index               examine_flags              examine_public_attrs
+  examine_restrictive       exec_secure                execscriptpath
+  exit_attr_default         exit_flags                 exit_parent           
+  exit_quota                exit_separator             exit_toggles          
+  exits_connect_rooms       expand_goto                fascist_teleport      
+  file_object               find_money_chance          flag_alias            
+  flag_name                 flag_access_see            flag_access_set          
+  flag_access_type          flag_access_unset          float_precision       
+  float_switches            forbid_host                forbid_site        
+  forbidapi_host            forbidapi_site             fork_dump          
+  format_compatbility       fork_vfork                 format_contents    
+  format_exits              format_name                formats_are_local  
+  full_file                 full_motd_message          function_access    
+  function_alias            function_invocation_limit  function_max       
+  function_recursion_limit  gdbm_cache_size            gdbm_database        
+  global_aconnect           global_adisconnect         global_ansimask    
+  global_attrdefault        global_clone_exit          global_clone_obj   
+  global_clone_player       global_clone_room          global_clone_thing 
+  global_error_cmd          global_error_obj           global_parent_exit 
+  global_parent_obj         global_parent_player       global_parent_room 
+  global_parent_thing       good_name                  goodmail_host      
+  gconf_file                guest_char_num             guest_file         
+  guest_namelist            guest_randomize            guild_attrname     
+  guild_default             guild_hdr                  hackattr_nowiz     
+  hackattr_see              hardconn_host              hardconn_site      
+  hasattrp_compat           heavy_cpu_max              help_file          
+  help_index                help_separator             hide_nospoof       
+  hook_cmd                  hook_obj                   hook_offline
   
 { 'wizhelp config parameters3' for more }
 
@@ -5235,22 +8238,23 @@ Generated: Wed Jan 13 04:15:57 2016
   ifelse_compat            ifelse_substitution      imm_nomod
   include                  includecnt               includenest
   initial_size             input_database           internal_compress_string
-  inventory_name           kill_guarantee_cost      kill_max_cost
-  kill_min_cost            lastsite_paranoia        lattr_default_oldstyle
-  lcon_checks_dark         lfunction_max            list_access
-  list_max_chars           listen_parents           link_cost
-  lnum_compat              lock_recursion_limit     log
-  log_command_list         log_maximum              log_network_errors
-  log_options              login_to_prog            logout_cmd_access
-  logout_cmd_alias         look_moreflags           look_obey_terse
-  machine_command_cost     mail_anonymous           mail_autodeltime
-  mail_default             mail_def_object          mail_hidden
-  mail_tolist              mail_verbosity           mailbox_size
-  maildelete               mailinclude_file         mailprog
-  mailsub                  mailmax_send             master_room
-  match_own_commands       manlog_file              map_delim_space
-  max_cpu_cycles           max_dest_limit           max_folders
-  max_lastsite_cnt         max_name_protect         max_pcreate_lim
+  inventory_name           iter_loop_max            kill_guarantee_cost    
+  kill_max_cost            kill_min_cost            lastsite_paranoia      
+  lattr_default_oldstyle   lcon_checks_dark         lfunction_max          
+  list_access              list_max_chars           listen_parents         
+  link_cost                lnum_compat              lock_recursion_limit   
+  log                      log_command_list         log_maximum            
+  log_network_errors       log_options              login_to_prog          
+  logout_cmd_access        logout_cmd_alias         look_moreflags         
+  look_obey_terse          machine_command_cost     mail_anonymous         
+  mail_autodeltime         mail_default             mail_def_object        
+  mail_hidden              mail_tolist              mail_verbosity         
+  mailbox_size             maildelete               mailinclude_file       
+  mailmutt                 mailprog                 mailsub                
+  mailmax_send             master_room              match_own_commands     
+  manlog_file              map_delim_space          max_cpu_cycles         
+  max_dest_limit           max_folders              max_lastsite_api       
+  max_lastsite_cnt         max_name_protect         max_pcreate_lim        
   max_pcreate_time         max_percentsubs          max_players
   
 { 'wizhelp config parameters4' for more }
@@ -5263,29 +8267,33 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="config parameters4"><H3>CONFIG PARAMETERS4</H3></A><PRE>
   Topic: CONFIG PARAMETERS (continued)
   
-  max_sitecons             max_vattr_limit          maximum_size
-  min_con_attempt          money_lim_off            money_lim_gm
-  money_lim_arch           money_lim_counc          money_name_plural
-  money_name_singular      motd_file                motd_message
-  mud_name                 muddb_name               must_unlquota
-  mux_child_compat         mus_lcon_compat          name_with_desc
-  nand_compat              newpass_god              news_file
-  news_index               newuser_file             no_startup
-  noauth_site              noautoreg_host           noautoreg_site
-  nobroadcast_host         noguest_host             noguest_site
-  nodns_site               nonindxtxt_maxlines      noregist_onwho
-  noshell_prog             nospam_connect           notify_recursion_limit
-  notonerr_return          num_guests               oattr_enable_altname
-  oattr_uses_altname       offline_reg              old_elist
-  online_reg               open_cost                output_database
-  output_limit             page_cost                paranoid_allocate
-  paranoid_exit_linking    parentable_control_lock  partial_conn
-  partial_deconn           paycheck                 pcreate_paranoia
-  pemit_any_object         pemit_far_players        penn_playercmds
-  penn_switches            permit_site              player_attr_default
-  player_dark              player_flags             player_listen
-  player_match_commands    player_match_own_command player_name_spaces
-  player_parent            player_queue_limit       player_quota           
+  max_sitecons             max_vattr_limit           maximum_size
+  min_con_attempt          money_lim_off             money_lim_gm
+  money_lim_arch           money_lim_counc           money_name_plural
+  money_name_singular      motd_file                 motd_message
+  mtimer                   mud_name                  muddb_name              
+  must_unlquota            mux_child_compat          mux_lcon_compat 
+  name_with_desc           nand_compat               newpass_god             
+  news_file                news_index                newuser_file            
+  no_startup               noauth_site               noautoreg_host          
+  noautoreg_site           nobroadcast_host          noguest_host            
+  noguest_site             nodns_site                nonindxtxt_maxlines     
+  noregist_onwho           noshell_prog              nospam_connect          
+  notify_recursion_limit   notonerr_return           null_is_idle            
+  num_guests               oattr_enable_altname      oattr_uses_altname      
+  objid_localtime          objid_offset              offline_reg             
+  old_elist                online_reg                open_cost               
+  output_database          output_limit              page_cost               
+  pagelock_notify          paranoid_allocate         paranoid_exit_linking
+  parent_follow            parentable_control_lock   partial_conn
+  partial_deconn           passapi_host              passapi_site
+  passproxy_host           passproxy_site            paycheck
+  pcreate_paranoia         pemit_any_object          pemit_far_players
+  penn_playercmds          penn_setq                 penn_switches
+  permit_site              player_attr_default       player_dark
+  player_flags             player_listen             player_match_commands
+  player_match_own_command player_name_spaces        player_parent
+  player_queue_limit       player_quota           
   
 { 'wizhelp config parameters5' for more }
 
@@ -5299,30 +8307,32 @@ Generated: Wed Jan 13 04:15:57 2016
 
   player_starting_home      player_starting_room      player_toggles
   plushelp_file             plushelp_index            port                    
-  proxy_checker             postdump_message          power_access            
-  public_flags              queue_active_chunk        queue_compatible        
-  queue_idle_chunk          quiet_look                quiet_whisper           
-  quit_file                 quotas                    read_remote_desc        
-  read_remote_name          recycling                 register_create_file    
-  register_host             register_site             regtry_limit            
-  restrict_home             restrict_sidefx           retry_limit             
-  robot_cost                robot_flags               robot_speech            
-  robot_toggles             room_aconnect             room_adisconnect        
-  room_attr_default         room_flags                room_parent             
-  room_quota                room_toggles              roomlog_path            
-  round_kludge              rwho_data_port            rwho_dump_interval      
-  rwho_host                 rwho_info_port            rwho_password           
-  rwho_transmit             sacrifice_adjust          sacrifice_factor        
-  safe_wipe                 safer_passwords           safer_ufun              
-  search_cost               secure_atruselock         secure_dark             
-  secure_functions          secure_jumpok             see_owned_dark          
+  proxy_checker             posesay_funct             postdump_message        
+  power_access              protect_addenh            public_flags            
+  queue_active_chunk        queue_compatible          queue_idle_chunk        
+  quiet_look                quiet_whisper             quit_file               
+  quotas                    read_remote_desc          read_remote_name        
+  recycling                 register_create_file      register_host           
+  register_site             regtry_limit              restrict_home           
+  restrict_sidefx           retry_limit               robot_cost              
+  robot_flags               robot_speech              robot_toggles           
+  room_aconnect             room_adisconnect          room_attr_default       
+  room_flags                room_parent               room_quota              
+  room_toggles              roomlog_path              round_kludge            
+  rwho_data_port            rwho_dump_interval        rwho_host               
+  rwho_info_port            rwho_password             rwho_transmit           
+  sacrifice_adjust          sacrifice_factor          safe_wipe               
+  safer_passwords           safer_ufun                sconnect_cmd
+  sconnect_host             sconnect_reip             search_cost             
+  secure_atruselock         secure_dark               secure_functions        
+  secure_jumpok             see_owned_dark            sha2rounds
   showother_altname         shs_reverse               sidefx_maxcalls         
   sidefx_returnval          sideeffects               signal_action           
-  signal_cron               signal_object             signal_object_type      
+  signal_crontab            signal_object             signal_object_type      
   space_compress            spam_limit                spam_msg                
   spam_objmsg               sqlite_db_path            sqlite_query_limit      
   stack_limit
-
+  
 { 'wizhelp config parameters6' for more}
 
 </PRE>
@@ -5334,29 +8344,45 @@ Generated: Wed Jan 13 04:15:57 2016
   Topic: CONFIG PARAMETERS (continued)
 
   start_build               starting_money            starting_quota
-  suspect_host              suspect_site              sweep_dark
-  switch_default_all        switch_search             switch_substitutions    
-  terse_shows_contents      terse_shows_exits         terse_shows_move_messages
-  thing_attr_default        thing_flags               thing_parent            
-  thing_quota               thing_toggles             timeslice               
-  toggle_access_see         toggle_access_set         toggle_access_type
-  toggle_access_unset       tor_localhost             tor_paranoid            
-  trace_output_limit        trace_topdown             tree_character
+  string_conn               string_conndark           string_connhide
+  string_create             string_register           suspect_host            
+  suspect_site              sweep_dark                switch_default_all      
+  switch_search             switch_substitutions      terse_shows_contents    
+  terse_shows_exits         terse_shows_move_messages thing_attr_default      
+  thing_flags               thing_parent              thing_quota             
+  thing_toggles             timeslice                 toggle_access_see       
+  toggle_access_set         toggle_access_type        toggle_access_unset     
+  totem_add                 totem_alias               totem_access_see
+  totem_access_set          totem_access_type         totem_access_unset
+  totem_letter              totem_name                totem_rename
+  totem_types               tor_localhost             tor_paranoid            
+  trace_output_limit        trace_topdown             tree_character          
   trust_site                uncompress_program        unowned_safe            
-  user_attr_flags           validate_host             vattr_limit_checkwiz    
-  vlimit                    wait_cost                 wall_cost               
-  whereis_notify            wizmax_dest_limit         wizmax_vattr_limit      
-  who_default               who_unfindable            who_showwiz             
-  who_wizlevel              who_whowiztype            whohost_size            
-  wiz_override              wiz_uselock               wizard_help_file        
-  wizard_help_index         wizard_motd_file          wizard_motd_message     
-  wizard_queue_limit        zone_parents
-
+  user_attr_flags           validate_host             vattr_command           
+  vattr_limit_checkwiz      vercustomstr              vlimit                  
+  wait_cost                 wall_cost                 whereis_notify          
+  wizmax_dest_limit         wizmax_vattr_limit        who_default             
+  who_unfindable            who_showwiz               who_wizlevel            
+  who_whowiztype            whohost_size              wiz_override            
+  wiz_uselock               wizard_help_file          wizard_help_index       
+  wizard_motd_file          wizard_motd_message       wizard_queue_limit      
+  wizcommand_quota_max      zone_parents
+  
 { 'wizhelp config parameters reality' for more (reality levels) }
 { 'wizhelp config parameters mysql' for more (mysql params) }
 
 </PRE>
 <A HREF="#config parameters5">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#config()">[NEXT]</A>
+<BR>
+<HR><A NAME="config()"><H3>CONFIG()</H3></A><PRE>
+  Please see normal help on the config() function.
+  
+  See Also: @admin
+
+</PRE>
+<A HREF="#config parameters6">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#config_access">[NEXT]</A>
 <BR>
@@ -5368,10 +8394,11 @@ Generated: Wed Jan 13 04:15:57 2016
   be specified in the configuration file at startup.  Setting privileges
   to anything other than disabled or god is meaningless unless the 
   restriction on the @admin command is weakened.
+  
   See Also: @admin, @list config_permissions, PERMISSIONS.
 
 </PRE>
-<A HREF="#config parameters6">[PREV]</A>
+<A HREF="#config()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#conn_timeout">[NEXT]</A>
 <BR>
@@ -5398,6 +8425,65 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#conn_timeout">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#connect_methods">[NEXT]</A>
+<BR>
+<HR><A NAME="connect_methods"><H3>connect_methods</H3></A><PRE>
+  Config parameter: connect_methods &lt;mask&gt;.  Default: 0
+  
+  This specifies a bitwise mask to optionally disable the hardcoded connect
+  commands.  The following bitwise masks must be added to disable them
+  accordingly.
+  
+    1 -- Disable co (connect), cd (connect dark), ch (connect hidden)
+    2 -- Disable cr (create)
+    4 -- Disable reg (register)
+  
+  Add them to disable the types. '7' would disable all of them.
+  
+  Note of warning:  If you disable all connection attempts and have
+  no other method of connecting enabled (such as the account management),
+  then you nor anyone else will be able to log into the mush.  Use with
+  caution!!!
+  
+  You may specify site ranges that are allowed to connect through this
+  disabling with hardconn_site or hardconn_host.
+  
+  See Also: ACCOUNT MANAGEMENT, hardconn_site, hardconn_host, connect_perm
+
+</PRE>
+<A HREF="#connect_file">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#connect_perm">[NEXT]</A>
+<BR>
+<HR><A NAME="connect_perm"><H3>connect_perm</H3></A><PRE>
+  Config parameter: connect_perm &lt;value&gt;.   Default: 0
+  
+  Specifies the permission level of the player allowed to be connected
+  to with the connect screen 'connect' command.  This is intended for
+  use with the account handler subsystem.
+  
+  The following values are valid:
+    0   - (default) anyone can connect
+    1   - those set wanderer and guest can not connect
+    2   - Guildmaster and higher allowed
+    3   - Architect and higher allowed
+    4   - Councilor and higher allowed
+    5   - Wizard and higher allowed
+    6   - Immorrtal and higher allowed
+    7   - god(#1) allowed only
+    &gt;8  - No one allowed
+  
+  The additive is used to allow guests, but still applies to the above.
+    100 - Allow guests (override) for above permissions.
+  
+  101 will only stop anyone with wanderer from connecting.
+  105 will allow guests and wizard and higher to connect. 
+  
+  See Also: logout_cmd_access, account_login(), account_owner()
+  
+</PRE>
+<A HREF="#connect_methods">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#connect_reg_file">[NEXT]</A>
 <BR>
 <HR><A NAME="connect_reg_file"><H3>connect_reg_file</H3></A><PRE>
@@ -5411,7 +8497,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: connect_file
 
 </PRE>
-<A HREF="#connect_file">[PREV]</A>
+<A HREF="#connect_perm">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#contact info">[NEXT]</A>
 <BR>
@@ -5437,44 +8523,44 @@ Generated: Wed Jan 13 04:15:57 2016
   be discussed later.
   
   First, the main control is handled by a bitlevel tier as follows.
-    #1    [Bitlevel 7] - This is the db owner and highest control authority
-                         in the game.  All garbage/recycled information is
-                         owned by this player, and because of this, this 
-                         player should not own anything.  Let me re-iterate.
-                         This player should not own anything.  If you need
-                         #1 style power, use the immortal flag for an 
-                         immortal player.
-   Immortal    [Bit 6] - This is essentially your 'leader' bit.  it can do
-                         pretty much anything within the game with few
-                         exceptions.  They override all locks by default
-                         unless they set the no_override/no_uselock flags.
-   Wizard      [Bit 5] - This is your normal MUX/Penn Wizard bitlevel.  It
-                         can do all your normal wizardly goodness.
-                         They override all locks their level and lower
-                         unless set no_override/no_uselock.  Yes, this
-                         also includes pagelocks.  This is referred to as
-                         'Royalty' within the codebase, but is in fact a
-                         full Wizard bit.  Re-iterate.  Full wizard.
-   Councilor   [Bit 4] - This is the 'admin' bit.  It has most of the wiz
-                         privs, but lacks some of the higher level db
-                         control.
-   Architect   [Bit 3] - This is the first staff bit that can control 
-                         things outside of its own ownership.  This does
-                         including, attribute/flags/toggles and player
-                         modification, but not player destruction.
-   Guildmaster [Bit 2] - This is the first admin bit.  It has small 
-                         amounts of control including examining stuff
-                         outside of ownership, but lacks modify power.
-   Citizen     [Bit 1] - Yup, this is just your normal player bit.
-   Wanderer    [Bit 0] - Consider this an unregistered player.  This is
-                         a Citizen with the WANDERER flag.  It stops 
-                         them from all building commands.
-   Guest       [Bit 0] - This is a guest player, as a guest they have
-                         very little power or control.  They lack any
-                         and all db modification abilities, including
-                         but not limited to editing, creating, etc.
-                         They also can not use mail.  Yes, this is
-                         intentional.
+    #1 (god)        [Bit 7] - This is the db owner and highest control 
+                              authority in the game.  All garbage/recycled 
+                              information is owned by this player, and because
+                              of this, this player should not own anything.  
+                              Let me re-iterate.  This player should not own 
+                              anything.  If you need #1 style power, use the 
+                              immortal flag for an immortal player.
+   Immortal         [Bit 6] - This is essentially your 'leader' bit.  it can do
+                              pretty much anything within the game with few
+                              exceptions.  They override all locks by default
+                              unless they set the no_override/no_uselock flags.
+   Wizard (Royalty) [Bit 5] - This is your normal MUX/Penn Wizard bitlevel.  It
+                              can do all your normal wizardly goodness.
+                              They override all locks their level and lower
+                              unless set no_override/no_uselock.  Yes, this
+                              also includes pagelocks.  This is referred to as
+                              'Royalty' within the codebase, but is in fact a
+                              full Wizard bit.  Re-iterate.  Full wizard.
+   Councilor        [Bit 4] - This is the 'admin' bit.  It has most of the wiz
+                              privs, but lacks some of the higher level db
+                              control.
+   Architect        [Bit 3] - This is the first staff bit that can control 
+                              things outside of its own ownership.  This does
+                              including, attribute/flags/toggles and player
+                              modification, but not player destruction.
+   Guildmaster      [Bit 2] - This is the first admin bit.  It has small 
+                              amounts of control including examining stuff
+                              outside of ownership, but lacks modify power.
+   Citizen          [Bit 1] - Yup, this is just your normal player bit.
+   Wanderer         [Bit 0] - Consider this an unregistered player.  This is
+                              a Citizen with the WANDERER flag.  It stops 
+                              them from all building commands.
+   Guest            [Bit 0] - This is a guest player, as a guest they have
+                              very little power or control.  They lack any
+                              and all db modification abilities, including
+                              but not limited to editing, creating, etc.
+                              They also can not use mail.  Yes, this is
+                              intentional.
   
   {wizhelp control2 for exceptions}
   {wizhelp control flow for the general flow of permissions}
@@ -5498,7 +8584,7 @@ Generated: Wed Jan 13 04:15:57 2016
      @hook
      NO_MODIFY (with @admin params imm_nomod enabled)
      Immortal Owned thing set INHERIT
-              Wizard ---+
+              Wizard (Royalty) ---+
               Power(Toggled/Special)
               @hook
               NO_MODIFY/NO_EXAMINE (without @admin params imm_nomod enabled)
@@ -5538,7 +8624,7 @@ Generated: Wed Jan 13 04:15:57 2016
   Also, some flags and toggles may grant and/or remove some of these very
   same abilities.  The TwinkLock also allows some complexity.
   
-  See Also: CONTROL
+  See Also: CONTROL, PERMISSION
   
 </PRE>
 <A HREF="#control">[PREV]</A>
@@ -5549,7 +8635,7 @@ Generated: Wed Jan 13 04:15:57 2016
   There are exceptions to every rule, and RhostMUSH is no exception (sic).
   While Immortal and #1 are basically immune from exceptions, being
   too high in the chain to warrent effecting them, the rest of the bits
-  can be modified (yes, including full wizard).  
+  can be modified (yes, including full wizard (royalty)).  
   
   They can be controlled as follows.
     @power    -- This is a method to tier-level up a bitlevel to higher
@@ -5593,7 +8679,7 @@ Generated: Wed Jan 13 04:15:57 2016
   There's obviously a lot more that can be tweaked or modified, but this
   gives the general control flow.
   
-  See Also: CONTROL FLOW
+  See Also: CONTROL FLOW, PERMISSION
 
 </PRE>
 <A HREF="#control flow">[PREV]</A>
@@ -5737,6 +8823,90 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#create_max_cost">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#customized connect">[NEXT]</A>
+<BR>
+<HR><A NAME="customized connect"><H3>CUSTOMIZED CONNECT</H3></A><PRE>
+  Config parameter: file_object &lt;dbref&gt;.  Default: -1    (CONTINUED)
+  Topic: CUSTOMIZED CONNECT
+  
+  An additional feature of the file_object config parameter is the ability
+  to design customized commands that a player can issue on the connect screen.
+  They can be any command at all, and executes code at the permission level
+  of the file_object AS the file_object itself.  So some thought needs to go
+  with security with regards to this.
+  
+  Built-in logout_cmd_access commands (WHO, INFO, DOING, etc) may be accessed
+  this way if you set the access of the command DARK.
+    
+  Note:  A player can not exceed 2000 character input in anyway at the connect
+         screen or the mush will aggressively tag the player as someone who is 
+         attempting to crash the mush, boot them off the server, and log their 
+         attempt.  This was a common method to crash a mush years ago.
+     
+  The key variables that are used for this are:
+    FAKECOMMANDS    -- This is the '|' delimited list of commands that the
+                       user on the connect screen can use.  This is evaluated
+                       as the file_object itself.  Sorry, commands can not
+                       contain white spaces (spaces, tabs, etc).
+    RUN_&lt;command&gt;   -- This is the command that the user at the connect
+                       screen will be typing.  If you want the command 'bob'
+                       to exist for the connect screen, then RUN_BOB will
+                       be the attribute name.
+  
+  The following variables are recognized:
+    %#/%!/%@/%n/%k  -- All will refer to the file_object.
+    %0              -- The command typed at the connect screen.
+    %1              -- The arguments to the command the player typed.
+    %2              -- The player's numerical IP address.
+    %3              -- The player's reverse DNS of their IP address.
+    %4              -- The player's port that they are connecting on.
+  
+  If the command is not listed in FAKECOMMANDS, or if there is no associated
+  RUN_&lt;command&gt; attribute, then it reacts as if it was an invalid command
+  at the connect screen and goes to the default behavior.
+   
+  To design what commands are to be customized, you create a '|' delimited
+  list on the file_object.  
+  
+  See Also: logout_cmd_access, account_login(), account_owner(), connect_perm
+  
+{ see 'wizhelp file_object3' or 'wizhelp customized connect2' for examples}
+  
+</PRE>
+<A HREF="#create_min_cost">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#customized connect2">[NEXT]</A>
+<BR>
+<HR><A NAME="customized connect2"><H3>CUSTOMIZED CONNECT2</H3></A><PRE>
+  Config parameter: file_object &lt;dbref&gt;.  Default: -1    (CONTINUED)
+  Topic: CUSTOMIZED CONNECT
+  
+  For the purpose of examples, we'll assume the file_object is #123.
+  
+  Example Setup:
+    &gt; think %# - [get(%#/test)]
+    #111 - woop
+    &gt; @admin file_object=123     (notice no '#' for the definition)
+    Set.
+    &gt; &amp;FAKECOMMANDS #123=bob|job|[get(#111/test)]
+    Set.
+    &gt; &amp;RUN_WOOP #123=You typed: %0 and are on from %3
+    Set.
+    &gt; &amp;RUN_BOB #123=You typed: %0 with args %1
+    Set.
+    &gt; &amp;RUN_JOB #123=Current jobs: %r[u(jobobject/jobs)]
+    Set.
+  
+  As shown, you have an amazing flexibility to customize your connect screen
+  with any command you want.  You can not, however, interact with connect
+  screen existing commands like 'connect' and so forth.  A small limitation
+  to an otherwise flexible tool.
+  
+  See Also: @admin, file_object, CUSTOMIZED CONNECT, logout_cmd_access
+
+</PRE>
+<A HREF="#customized connect">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#dark_sleepers">[NEXT]</A>
 <BR>
 <HR><A NAME="dark_sleepers"><H3>dark_sleepers</H3></A><PRE>
@@ -5748,7 +8918,7 @@ Generated: Wed Jan 13 04:15:57 2016
   using [next()] to follow the contents chain for the room.
 
 </PRE>
-<A HREF="#create_min_cost">[PREV]</A>
+<A HREF="#customized connect2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#debug features">[NEXT]</A>
 <BR>
@@ -5860,6 +9030,18 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#def_thing_tx">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#delim_null">[NEXT]</A>
+<BR>
+<HR><A NAME="delim_null"><H3>delim_null</H3></A><PRE>
+  Config parameter: delim_null &lt;yes/no&gt;.   Default: no
+  
+  Specifies if '@@' is to be identified as a special output separator in
+  nearly every function to work as a null output delimiter.  This is to
+  help with MUX compatibility.
+  
+</PRE>
+<A HREF="#default_home">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#depower abuse">[NEXT]</A>
 <BR>
 <HR><A NAME="depower abuse"><H3>DEPOWER ABUSE</H3></A><PRE>
@@ -5869,7 +9051,7 @@ Generated: Wed Jan 13 04:15:57 2016
   on any object that you do not specifically own.
 
 </PRE>
-<A HREF="#default_home">[PREV]</A>
+<A HREF="#delim_null">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#depower boot">[NEXT]</A>
 <BR>
@@ -5994,6 +9176,8 @@ Generated: Wed Jan 13 04:15:57 2016
   This depower will lower or disable the ability to @fo anyone or
   anything up to that level.  If 'off', all they can @fo are
   themselves and their possessions.
+  
+  This also impacts @sudo.
 
 </PRE>
 <A HREF="#depower examine">[PREV]</A>
@@ -6402,7 +9586,7 @@ Generated: Wed Jan 13 04:15:57 2016
       U - hidden (@hide)      H - unfindable         D - dark
       * - all staff (opt)     W - Wizard (opt)       a - councilor (opt)
       B - architect (opt)     g - GuildMstr(opt)     d - idle dark
-      h - idle unfindable 
+      h - idle unfindable     $ - SSL Connected
    
   Example:  DOING Nyc
   
@@ -6553,14 +9737,20 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#dynhelp()">[NEXT]</A>
 <BR>
 <HR><A NAME="dynhelp()"><H3>DYNHELP()</H3></A><PRE>
-  Function: dynhelp(&lt;helpfile&gt;,&lt;topic&gt;[[,&lt;target player&gt;],&lt;parsekey&gt;])
+  Function: dynhelp(&lt;helpfile&gt;,&lt;topic&gt;[[[,&lt;target&gt;],&lt;parsekey&gt;],&lt;suggest&gt;])
   
-  This function will read the matching 'helpfile.txt' file, search
-  the 'helpfile.indx' for the topic, and return to the enactor
-  (or targetted player), the result.  If you specify a parsekey of
-  '1' (or true), it will parse the help file.  A '2' will issue content
-  searches.  Keep in mind that as a function, this will strip ansi codes.
-  If you want to display ansi codes in .txt files and parse it, use @dynhelp.
+  This function will read the matching &lt;helpfile&gt; file (such as help.txt), 
+  search the indx file (such as help.indx) for the topic, and return to the 
+  enactor (or target player), the result.  You may use any help file that 
+  has a matching .indx file.  
+  
+  If you specify a &lt;parsekey&gt; of '1' (or true), it will parse the help 
+  file.  A '2' will issue content searches.  Keep in mind that as a 
+  function, this will strip ansi codes.  If you want to display ansi 
+  codes in .txt files and parse it, use @dynhelp.  
+  
+  The &lt;suggest&gt; option enables suggestions if the help topic is not found.
+   
   You may specify either '/' or '^' here for path information.
   
   This function does NOT return the output into a buffer.  This is a
@@ -6598,6 +9788,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#elsefile setup">[NEXT]</A>
 <BR>
 <HR><A NAME="elsefile setup"><H3>elsefile setup</H3></A><PRE>
+  Topic: ELSEFILE SETUP
+  
   You may set up ANY file to be read from within the mush by using the
   @dynhelp command or dynhelp() function.  The only stipulation to this
   is that the file MUST end in '.txt' and the file MUST have a matching
@@ -6743,6 +9935,21 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#examine_public_attrs">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#exec_secure">[NEXT]</A>
+<BR>
+<HR><A NAME="exec_secure"><H3>exec_secure</H3></A><PRE>
+  Config parameter: exec_secure &lt;boolean&gt;.  Default: 1
+  
+  Tells execscript() to escape all characters that are passed into it.  This
+  is the default behavior.  If you specify '0' then it will only escape out
+  non-alphanumeric characters.  Ergo, it will only then escape out characters
+  that are not A-Z, a-z, or 0-9.
+  
+  See Also: execscript()
+
+</PRE>
+<A HREF="#examine_restrictive">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#execscript()">[NEXT]</A>
 <BR>
 <HR><A NAME="execscript()"><H3>EXECSCRIPT()</H3></A><PRE>
@@ -6751,6 +9958,9 @@ Generated: Wed Jan 13 04:15:57 2016
   Note:  This function issues a shell interpreter so will have some
          overhead compared to calling it natively through an API.
   
+  Note2: You may specify subdirectory overrides with the @admin param
+         execscriptpath.  This only allows alphanumerical characters.
+    
   Requirements:  /usr/bin/timeout (on MacOSX link to /usr/local/bin/gtimeout)
                  script/binary existing in ~/game/scripts and chmod u+rx
                  @powered EXECSCRIPT GM or higher
@@ -6760,22 +9970,74 @@ Generated: Wed Jan 13 04:15:57 2016
   directory's sub-directory 'scripts'.  It is case sensitive and strips
   illegal characters (like, .., /, $, etc) from the script name.
   
-  This requires the EXECSCRIPT @power of GUILDMASTER to use the function.
-  It requires the ARCHITECT level to allow the use of passing arguments
-  to the script.  Unlike other powers, this power is not inheritable.
+  MUSH Requirements:
+     - @power of EXECSCRIPT 
+       --- set to guildmaster to use 
+       --- set to Architect or higher to be able to pass arguments to
+           the execscript() function.
+     - SIDEFX flag
+       --- This is required as execscript() is effectively a sideeffect
+     - EXECSCRIPT_VARS 
+       --- This is optional  
+       --- This is passed as the enviornment variable MUSHL_VARS to the
+           script or program called by execscript()
+       --- This is set on the thing with execscript() on it to define what
+           variables it has that will be passed as MUSHV_&lt;args&gt; to the script
+       --- The following variables can be set in the EXECSCRIPT_VARS
+           attribute of the thing/player directly calling execscript()
+           -- Example: &amp;EXECSCRIPT_VARS me=FOO BAR #0/FOO #10/BAR
+              -- FOO - the variable 'FOO' off the executor of execscript()
+              -- BAR - the variable 'BAR' off the executor of execscript()
+              -- #0/FOO  - FOO off object #0 (if executor controls #0)
+              -- #10/BAR - BAR off object #10 (if executor controls #10)
+           -- These variables will be passed to the calling script as:
+              -- MUSHV_FOO -- The FOO variable contents
+              -- MUSHV_BAR -- The BAR variable contents
+              -- MUSHV_D0_FOO -- The FOO off #0
+              -- MUSHV_D10_BAR -- The BAR off #10
+  
+  Note: The EXECSCRIPT @power is not inheritable.
   
   You can pass a maximum of 9 arguments to the script not including the
-  script name.
+  script name.  It combines all arguments into a singular argument to script.
   
-  The following variables are available from inside the scripts called:
+  See 'writing scripts' for help on dos and don'ts in writing execscripts.
+  See 'working with execscript' to use registers and variables and callbacks.
+  See 'writing callbacks' for help on writing execscript callbacks.
+  
+  { 'wizhelp execscript2' for environment variables passed to the script }
+  
+</PRE>
+<A HREF="#exec_secure">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#execscript2">[NEXT]</A>
+<BR>
+<HR><A NAME="execscript2"><H3>EXECSCRIPT2</H3></A><PRE>
+  (CONTINUED)
+  Function: execscript(&lt;script name&gt; [,&lt;arg 0&gt;,...,&lt;arg 9&gt;])
+  
+  The following global variables are available from inside the scripts called:
+    MUSH_VERSION      - Show version fo EXECSCRIPT (for cross-script execution)
     MUSH_PLAYER       - [%!] dbref# of player followed by name of player.  
     MUSH_CAUSE        - [%#] dbref# of cause followed by name of cause.  
     MUSH_CALLER       - [%@] dbref# of caller followed by name of caller.  
     MUSH_FLAGS        - the flags of the player.
-    MUSH_TOGGLES      - the togglesof the player.
+    MUSH_TOGGLES      - the toggles of the player.
+    MUSH_TOTEMS       - the totems of the player.
     MUSH_OWNER        - dbref# of player's owner by name of owner.
+    MUSH_OBJID        - objid's of player, cause, caller, owner (in that order)
     MUSH_OWNERFLAGS   - the flags of the player's owner.
     MUSH_OWNERTOGGLES - the toggles of the player's owner.
+    MUSH_OWNERTOTEMS  - the totems of the player's owner.
+    MUSHL_VARS        - All the variables you want the script to see which
+                        is passed as the mush attribute EXECSCRIPT_VARS
+                        on the container that is executing execscript()
+    MUSHV_&lt;arg&gt;       - Dynamic variables passed from above EXECSCRIPT_VARS
+    MUSHQ_&lt;arg&gt;       - SetQ registers (0-9 and a-z) 
+    MUSHQN_&lt;arg&gt;      - Label names of registers (0-9 and a-z)
+    MUSHN_&lt;arg&gt;       - Register name contents of the setq register.
+                        Note: setq 0 label of 'bob' will have MUSHQ_0 and
+                              MUSHN_BOB have the same contents.
   
   Examples:
     &gt; say execscript(hello.sh)
@@ -6784,11 +10046,29 @@ Generated: Wed Jan 13 04:15:57 2016
     You say &quot;hello from the script with args: 'test'&quot;
   
   See 'writing scripts' for help on dos and don'ts in writing execscripts.
+  See 'working with execscript' to use registers and variables and callbacks.
+  See 'writing callbacks' for help on writing execscript callbacks.
     
-  See Also: POWER EXECSCRIPT
+  See Also: POWER EXECSCRIPT, exec_secure
 
 </PRE>
-<A HREF="#examine_restrictive">[PREV]</A>
+<A HREF="#execscript()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#execscriptpath">[NEXT]</A>
+<BR>
+<HR><A NAME="execscriptpath"><H3>execscriptpath</H3></A><PRE>
+  Config parameter: execscriptpath &lt;strings&gt;.  Default: (empty)
+  
+  This parameter will specify a space separated list of alphanumerical 
+  directories that you wish to have as subdirectories under the 'scripts'
+  directory.  This only allows one level of subdirectories, only allows
+  alpha-numerical characters and will not allow any other character 
+  including wildcards.
+  
+  See Also: execscript()
+  
+</PRE>
+<A HREF="#execscript2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#exfullwizattr toggle">[NEXT]</A>
 <BR>
@@ -6804,7 +10084,7 @@ Generated: Wed Jan 13 04:15:57 2016
   This also will not work on any @aflag definition of immortal or god.
     
 </PRE>
-<A HREF="#execscript()">[PREV]</A>
+<A HREF="#execscriptpath">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#exit_attr_default">[NEXT]</A>
 <BR>
@@ -6870,6 +10150,20 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#exit_parent">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#exit_separator">[NEXT]</A>
+<BR>
+<HR><A NAME="exit_separator"><H3>exit_separator</H3></A><PRE>
+  Config parameter: exit_separator &lt;string&gt;.   Default: %b%b
+  
+  Specifies the string that will separate exits by default when you look
+  at a location.  It defaults to two spaces.  You may have up to 31
+  characters separating exit names.
+  
+  See Also: format_exits
+  
+</PRE>
+<A HREF="#exit_quota">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#exit_toggles">[NEXT]</A>
 <BR>
 <HR><A NAME="exit_toggles"><H3>exit_toggles</H3></A><PRE>
@@ -6886,7 +10180,7 @@ Generated: Wed Jan 13 04:15:57 2016
             thing_toggles.
 
 </PRE>
-<A HREF="#exit_quota">[PREV]</A>
+<A HREF="#exit_separator">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#exits_connect_rooms">[NEXT]</A>
 <BR>
@@ -6952,20 +10246,123 @@ Generated: Wed Jan 13 04:15:57 2016
     autoreg       autoreg.txt     What a user sees when autoreg is enabled
     autoreghost   areghost.txt    What a user sees when host is autoreg
   
+  The following special attributes are used to handle the MAX values to site
+  that you pass.  For example, if you specify that '3' max connections are
+  allowed guests from the site, the following is an override that is provided
+  to the player who reaches that maximum.   This is only relevant when you 
+  use the 'max' option to any site restrictions.
+   
+    ATTRIBUTE       PERMISSION      FUNCTION
+    -------------   --------------- ------------------------------------------
+    site_noguest    NO_GUEST        Shown to player who hits max guests
+    site_register   REGISTER        Shown to player who hits max registers
+    site_forbid     FORBID          Shown to player who hits max forbids
+    site_Forbidapi  FORBIDAPI       Shown to max connections for API
+    site_noconnect  NOCONNECT       Shown to player set NO_CONNECT
+    site_nopossess  NOPOSSESS       Shown to player set NO_POSSESS
+  
   An empty evaluated attribute or a missing attribute will call the default
   txt file instead of the evaluation.  The following arguments are passed
   into the evaluation:
     %0 -- The numerical site host of the incomming connection.
     %1 -- The dns host entry (if availabe, else ip) of incoming connection.
     %2 -- The port that they're connected to on the mush
-    %3 -- The player dbref#, if connected, otherwise shows '-1'.
+    %3 -- The player dbref#, if connected, otherwise shows '#-1'.
   
   All ansi and such will process normally.
   
-  See Also: @list_file
+  See Also: @list_file, file_object2, customized connect, NOCONNECT,
+            NOPOSSESS
+
+  
+{ See 'wizhelp file_object2' or 'wizhelp customized connect' for connect mods }
 
 </PRE>
 <A HREF="#fascist_teleport">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#file_object2">[NEXT]</A>
+<BR>
+<HR><A NAME="file_object2"><H3>file_object2</H3></A><PRE>
+  Config parameter: file_object &lt;dbref&gt;.  Default: -1    (CONTINUED)
+  Topic: CUSTOMIZED CONNECT
+  
+  An additional feature of the file_object config parameter is the ability
+  to design customized commands that a player can issue on the connect screen.
+  They can be any command at all, and executes code at the permission level
+  of the file_object AS the file_object itself.  So some thought needs to go
+  with security with regards to this.
+  
+  Built-in logout_cmd_access commands (WHO, INFO, DOING, etc) may be accessed
+  this way if you set the access of the command DARK.
+    
+  Note:  A player can not exceed 2000 character input in anyway at the connect
+         screen or the mush will aggressively tag the player as someone who is 
+         attempting to crash the mush, boot them off the server, and log their 
+         attempt.  This was a common method to crash a mush years ago.
+     
+  The key variables that are used for this are:
+    FAKECOMMANDS    -- This is the '|' delimited list of commands that the
+                       user on the connect screen can use.  This is evaluated
+                       as the file_object itself.  Sorry, commands can not
+                       contain white spaces (spaces, tabs, etc).
+    RUN_&lt;command&gt;   -- This is the command that the user at the connect
+                       screen will be typing.  If you want the command 'bob'
+                       to exist for the connect screen, then RUN_BOB will
+                       be the attribute name.
+  
+  The following variables are recognized:
+    %#/%!/%@/%n/%k  -- All will refer to the file_object.
+    %0              -- The command typed at the connect screen.
+    %1              -- The arguments to the command the player typed.
+    %2              -- The player's numerical IP address.
+    %3              -- The player's reverse DNS of their IP address.
+    %4              -- The player's port that they are connecting on.
+  
+  If the command is not listed in FAKECOMMANDS, or if there is no associated
+  RUN_&lt;command&gt; attribute, then it reacts as if it was an invalid command
+  at the connect screen and goes to the default behavior.
+   
+  To design what commands are to be customized, you create a '|' delimited
+  list on the file_object.  
+  
+  See Also: logout_cmd_access, account_login(), account_owner(), connect_perm
+  
+{ see 'wizhelp file_object3' or 'wizhelp customized connect2' for examples}
+  
+</PRE>
+<A HREF="#file_object">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#file_object3">[NEXT]</A>
+<BR>
+<HR><A NAME="file_object3"><H3>file_object3</H3></A><PRE>
+  Config parameter: file_object &lt;dbref&gt;.  Default: -1    (CONTINUED)
+  Topic: CUSTOMIZED CONNECT
+  
+  For the purpose of examples, we'll assume the file_object is #123.
+  
+  Example Setup:
+    &gt; think %# - [get(%#/test)]
+    #111 - woop
+    &gt; @admin file_object=123     (notice no '#' for the definition)
+    Set.
+    &gt; &amp;FAKECOMMANDS #123=bob|job|[get(#111/test)]
+    Set.
+    &gt; &amp;RUN_WOOP #123=You typed: %0 and are on from %3
+    Set.
+    &gt; &amp;RUN_BOB #123=You typed: %0 with args %1
+    Set.
+    &gt; &amp;RUN_JOB #123=Current jobs: %r[u(jobobject/jobs)]
+    Set.
+  
+  As shown, you have an amazing flexibility to customize your connect screen
+  with any command you want.  You can not, however, interact with connect
+  screen existing commands like 'connect' and so forth.  A small limitation
+  to an otherwise flexible tool.
+  
+  See Also: @admin, file_object, CUSTOMIZED CONNECT, logout_cmd_access
+
+</PRE>
+<A HREF="#file_object2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#files">[NEXT]</A>
 <BR>
@@ -6998,7 +10395,7 @@ Generated: Wed Jan 13 04:15:57 2016
 { 'wizhelp files2' for more }
 
 </PRE>
-<A HREF="#file_object">[PREV]</A>
+<A HREF="#file_object3">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#files2">[NEXT]</A>
 <BR>
@@ -7282,6 +10679,22 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#flags">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#float_switches">[NEXT]</A>
+<BR>
+<HR><A NAME="float_switches"><H3>float_switches</H3></A><PRE>
+  Config parameter: float_switches &lt;boolean&gt;.    Default: no
+  
+  If penn_switches is enabled, this optionally allows the math to handle
+  floating point numbers.  As floating math is slightly more computationally
+  expensive, this option is disabled unless needed or wanted.
+  
+  Note: penn_switches must be enabled for this to work.
+   
+  See Also: penn_switches
+  
+</PRE>
+<A HREF="#float_precision">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#folder">[NEXT]</A>
 <BR>
 <HR><A NAME="folder"><H3>folder</H3></A><PRE>
@@ -7297,12 +10710,16 @@ Generated: Wed Jan 13 04:15:57 2016
   This sub-command will display the list of folders for &lt;player&gt;.
 
 </PRE>
-<A HREF="#float_precision">[PREV]</A>
+<A HREF="#float_switches">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#forbid_host">[NEXT]</A>
 <BR>
 <HR><A NAME="forbid_host"><H3>forbid_host</H3></A><PRE>
   Config parameter: forbid_host &lt;!host&gt; &lt;host&gt; ... &lt;host&gt;
+                    forbidapi_host &lt;!host&gt; &lt;host&gt; ... &lt;host&gt;
+  
+  The forbidapi_host works like forbid_host, except it handles ONLY the
+  api port connections.  It will not affect other connections to the mush.
   
   Indicates that connections matching the wildcard match of the specified
   sites in their DNS HOST will not be allowed to connect and will be rejected
@@ -7336,7 +10753,11 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#forbid_site">[NEXT]</A>
 <BR>
 <HR><A NAME="forbid_site"><H3>forbid_site</H3></A><PRE>
-  Config parameter: forbid_site &lt;addr&gt; &lt;mask&gt;.
+  Config parameter: forbid_site &lt;addr&gt; &lt;mask&gt;
+                    forbidapi_site &lt;addr&gt; &lt;mask&gt;
+  
+  The forbidapi_site works like forbid_site, except it handles ONLY the
+  api port connections.  It will not affect other connections to the mush.
   
   Indicates that connections are to be rejected from sites whose address
   matches the specified address when ANDed with the mask.  The contents of
@@ -7350,6 +10771,65 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#forbid_host">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#forbidapi_host">[NEXT]</A>
+<BR>
+<HR><A NAME="forbidapi_host"><H3>forbidapi_host</H3></A><PRE>
+  Config parameter: forbid_host &lt;!host&gt; &lt;host&gt; ... &lt;host&gt;
+                    forbidapi_host &lt;!host&gt; &lt;host&gt; ... &lt;host&gt;
+  
+  The forbidapi_host works like forbid_host, except it handles ONLY the
+  api port connections.  It will not affect other connections to the mush.
+  
+  Indicates that connections matching the wildcard match of the specified
+  sites in their DNS HOST will not be allowed to connect and will be rejected
+  upon socket connection. This works like 'forbid_site' but deals with DNS
+  wildcard name conventions.  This will add or remove to existing or from
+  existing site information already specified with forbid_host.  You may use
+  '!ALL' to clear the forbid host table.
+  
+  You may specify an optional ceiling of allowed connects before the
+  restriction takes effect by ending in '|#'.  Like '*.aol.com|3' will allow
+  3 connections from aol.com at any one time, then enforce the restriction.
+  Optional ceiling restrictions are only valid for NOGUEST, REGISTER, and 
+  FORBID restrictions.
+  
+  Example:  @admin forbid_host=*.aol.com !*.compuserve.com *ego.com|3
+            (forbids any site matching *.aol.com and removes *.compuserve.com)
+            (will forbid *ego.com if more than 3 connections are seen)
+            @admin forbid_host=!ALL
+            (this clears the forbid_host list)
+  
+  Note:  If you used a ceiling, you must specify the ceiling in removing
+         the site or it will not match it.  You may use @site/list to see
+         the raw site information that you can use to remove the site.
+   
+  See Also: register_host, suspect_host, noguest_host, noautoreg_host, 
+            validate_host, @site
+
+</PRE>
+<A HREF="#forbid_site">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#forbidapi_site">[NEXT]</A>
+<BR>
+<HR><A NAME="forbidapi_site"><H3>forbidapi_site</H3></A><PRE>
+  Config parameter: forbid_site &lt;addr&gt; &lt;mask&gt;
+                    forbidapi_site &lt;addr&gt; &lt;mask&gt;
+  
+  The forbidapi_site works like forbid_site, except it handles ONLY the
+  api port connections.  It will not affect other connections to the mush.
+  
+  Indicates that connections are to be rejected from sites whose address
+  matches the specified address when ANDed with the mask.  The contents of
+  the file specified by badsite_file is sent immediately before closing
+  the connection.  This directive may be used to restrict access to just the
+  local network, or to prevent access from troublemaking sites.
+  The default is for all sites to be allowed to connect, none forbidden.
+  See Also: badsite_file, noguest_site, permit_site, register_site, 
+            SITE LISTS.
+
+</PRE>
+<A HREF="#forbidapi_host">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#forcehalted toggle">[NEXT]</A>
 <BR>
 <HR><A NAME="forcehalted toggle"><H3>FORCEHALTED TOGGLE</H3></A><PRE>
@@ -7361,7 +10841,7 @@ Generated: Wed Jan 13 04:15:57 2016
   target under all circumstances.
 
 </PRE>
-<A HREF="#forbid_site">[PREV]</A>
+<A HREF="#forbidapi_site">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#fork_dump">[NEXT]</A>
 <BR>
@@ -7430,7 +10910,7 @@ Generated: Wed Jan 13 04:15:57 2016
   includes both ExitFormat and DarkExitFormat.  If either of these 
   attributes exist, it will take presidence over the default 'Exits'.
   
-  See Also: format_contents, format_name
+  See Also: format_contents, format_name, exit_separator
 
 </PRE>
 <A HREF="#format_contents">[PREV]</A>
@@ -7507,13 +10987,14 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="function list"><H3>function list</H3></A><PRE>
   Help is available for the following RhostMUSH wizard only functions:
   
-  AFLAGS()      BEEP()        BYPASS()      CANSEE()        CHECKPASS()
-  CHKGARBAGE()  CLOAK()       DOING()       DYNHELP()       HASDEPOWER()
-  HASPOWER()    HASTOGGLE()   ISHIDDEN()    LATTRP()        LDEPOWERS()
-  LOGTOFILE()   LOGSTATUS()   LOOKUP_SITE() LPOWERS()       LTOGGLES()
-  MAILALIAS()   MAILQUICK()   MAILQUOTA()   MAILSIZE()      MAILSTATUS()
-  MSIZETOT()    NSLOOKUP()    QUOTA()       SIZE()          TEXTFILE()
-  MAILREAD()    MAILSEND()    EXECSCRIPT()
+  ACCOUNT_LOGIN()  ACCOUNT_OWNER()  ACCOUNT_SU()  ACCOUNT_WHO() AFLAGS()    
+  BEEP()           BYPASS()         CANSEE()      CHECKPASS()   CHKGARBAGE()
+  CLOAK()          DOING()          DYNHELP()     EXECSCRIPT()  HASDEPOWER()
+  HASPOWER()       HASTOGGLE()      ISHIDDEN()    LATTRP()      LDEPOWERS() 
+  LOGTOFILE()      LOGSTATUS()      LOOKUP_SITE() LPOWERS()     LTOGGLES()  
+  MAILALIAS()      MAILQUICK()      MAILQUOTA()   MAILSIZE()    MAILSTATUS()
+  MSIZETOT()       NSLOOKUP()       QUOTA()       SIZE()        TEXTFILE()  
+  MAILREAD()       MAILSEND()   
 
 </PRE>
 <A HREF="#full_motd_message">[PREV]</A>
@@ -7531,7 +11012,7 @@ Generated: Wed Jan 13 04:15:57 2016
   have access to the 'real' add() function, while everyone below would
   access the softcoded add() function.
   
-  @function/privalaged will take the level of the object the @function
+  @function/privilege will take the level of the object the @function
   is on for permission checks (which can allow a lot of flexability)
   
   Example:
@@ -7607,6 +11088,24 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#function_alias">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#function_max">[NEXT]</A>
+<BR>
+<HR><A NAME="function_max"><H3>function_max</H3></A><PRE>
+  Config parameter: function_max &lt;n7um&gt;.  Default: 1000 (-1 unlimited)
+  
+  This parameter specifies how many global @functions can be defined in
+  the game.  By default, 1000 can be defined before it will not allow
+  any new definitions.  You may modify or delete functions once the
+  max is reached, but can no longer add new ones.  You may specify this
+  value to '-1' (negative one) to assign an unlimited number which was
+  the previous behavior, however we feel 1000 is more than sufficient
+  for even the most hairy code so was a good default.
+  
+  See also: @function, @lfunction, lfunction_max
+ 
+</PRE>
+<A HREF="#function_invocation_limit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#function_recursion_limit">[NEXT]</A>
 <BR>
 <HR><A NAME="function_recursion_limit"><H3>function_recursion_limit</H3></A><PRE>
@@ -7619,20 +11118,21 @@ Generated: Wed Jan 13 04:15:57 2016
   (unless blocked by a recursion limit)
 
 </PRE>
-<A HREF="#function_invocation_limit">[PREV]</A>
+<A HREF="#function_max">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#functions">[NEXT]</A>
 <BR>
 <HR><A NAME="functions"><H3>functions</H3></A><PRE>
   Help is available for the following RhostMUSH wizard only functions:
   
-  AFLAGS()      BEEP()        BYPASS()      CANSEE()        CHECKPASS()
-  CHKGARBAGE()  CLOAK()       DOING()       DYNHELP()       HASDEPOWER()
-  HASPOWER()    HASTOGGLE()   ISHIDDEN()    LATTRP()        LDEPOWERS()
-  LOGTOFILE()   LOGSTATUS()   LOOKUP_SITE() LPOWERS()       LTOGGLES()
-  MAILALIAS()   MAILQUICK()   MAILQUOTA()   MAILSIZE()      MAILSTATUS()
-  MSIZETOT()    NSLOOKUP()    QUOTA()       SIZE()          TEXTFILE()
-  MAILREAD()    MAILSEND()    EXECSCRIPT()
+  ACCOUNT_LOGIN()  ACCOUNT_OWNER()  ACCOUNT_SU()  ACCOUNT_WHO() AFLAGS()    
+  BEEP()           BYPASS()         CANSEE()      CHECKPASS()   CHKGARBAGE()
+  CLOAK()          DOING()          DYNHELP()     EXECSCRIPT()  HASDEPOWER()
+  HASPOWER()       HASTOGGLE()      ISHIDDEN()    LATTRP()      LDEPOWERS() 
+  LOGTOFILE()      LOGSTATUS()      LOOKUP_SITE() LPOWERS()     LTOGGLES()  
+  MAILALIAS()      MAILQUICK()      MAILQUOTA()   MAILSIZE()    MAILSTATUS()
+  MSIZETOT()       NSLOOKUP()       QUOTA()       SIZE()        TEXTFILE()  
+  MAILREAD()       MAILSEND()   
 
 </PRE>
 <A HREF="#function_recursion_limit">[PREV]</A>
@@ -7716,6 +11216,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#global attributes">[NEXT]</A>
 <BR>
 <HR><A NAME="global attributes"><H3>global attributes</H3></A><PRE>
+  Topic: global inherintance (ancestors)
+  
   Global attributes works similiarilly to global parenting, except no actual
   @parent is set on any target nor required.  There are actually 6 different
   parameters for global inheritance.  These are:
@@ -7736,6 +11238,8 @@ Generated: Wed Jan 13 04:15:57 2016
   
   Please note that global_parent_obj will not be used if there exists a 
   specified type global parent (ie: global_parent_player).
+  
+  You may specify '@list options values global_parent*' to see values.
   
   See Also: global_parent_obj, global_parent_player, global_parent_thing, 
             global_parent_room, global_parent_exit, zone_parents
@@ -7758,6 +11262,8 @@ Generated: Wed Jan 13 04:15:57 2016
   %0 to the attribute).  You need to specify the target attribute DEFAULT
   to inherit the formatting (locally or globally works).
   
+  You may specify '@list options values *_attr_default' to see values.
+  
   For example:
     &gt; @admin player_attr_default=3
     &gt; @desc #3=%t-&lt; %0 &gt;-
@@ -7777,6 +11283,40 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#global inheritance">[NEXT]</A>
 <BR>
 <HR><A NAME="global inheritance"><H3>global inheritance</H3></A><PRE>
+  Topic: global inherintance (ancestors)
+  
+  Global attributes works similiarilly to global parenting, except no actual
+  @parent is set on any target nor required.  There are actually 6 different
+  parameters for global inheritance.  These are:
+  
+        global_parent_obj      (default global inheritance)
+        global_parent_player   (for player types)
+        global_parent_thing    (for thing types)
+        global_parent_room     (for room types)
+        global_parent_exit     (for exit types)
+        zone_parents           (allow zones to inherit attributes)
+  
+  The order of inheritance is as follows:
+        1) Attribute exist on self
+        2) Attribute exist on @parent
+        3) Attribute exist on zone(s) (if defined)
+        4) Attribute exist on global_parent_&lt;type&gt; (if defined)
+        5) Attribute exist on global_parent_obj (if defined)
+  
+  Please note that global_parent_obj will not be used if there exists a 
+  specified type global parent (ie: global_parent_player).
+  
+  You may specify '@list options values global_parent*' to see values.
+  
+  See Also: global_parent_obj, global_parent_player, global_parent_thing, 
+            global_parent_room, global_parent_exit, zone_parents
+  
+</PRE>
+<A HREF="#global formatting">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#global inheritance">[NEXT]</A>
+<BR>
+<HR><A NAME="global inheritance"><H3>global inheritance</H3></A><PRE>
   There is the possibility to set up global inheritance for object types.
   There are various methods to do this.  First, there is a 'filtering'
   system.  The following sub-topics exist for global inheritance.
@@ -7786,11 +11326,13 @@ Generated: Wed Jan 13 04:15:57 2016
         global attributes   - for setting up automated attribute inheritance
   
 </PRE>
-<A HREF="#global formatting">[PREV]</A>
+<A HREF="#global inheritance">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#global parenting">[NEXT]</A>
 <BR>
 <HR><A NAME="global parenting"><H3>global parenting</H3></A><PRE>
+  Topic: global auto-parenting (auto-@parenting)
+  
   Global parents are issued through 4 global attributes.  These actually
   set a @parent on the target matching the global attribute.  All checks,
   consistancy, and sanity filtering is done prior to the @parent set.
@@ -7800,6 +11342,8 @@ Generated: Wed Jan 13 04:15:57 2016
         thing_parent      (for thing types)
         room_parent       (for room types)
         exit_parent       (for exit types)
+  
+  You may specify '@list options values *_parent' to see values.
   
   For example:
     &gt; @admin player_parent=3
@@ -7965,6 +11509,21 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#global_clone_room">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#global_error_cmd">[NEXT]</A>
+<BR>
+<HR><A NAME="global_error_cmd"><H3>global_error_cmd</H3></A><PRE>
+  Config parameter: global_error_cmd &lt;yes/no&gt;.   Default: no (0)
+  
+  This will specify if the global_error_obj error handling will handle
+  commands and not just functions.  There is built in protection against
+  looping but you should still be careful with the instance when using
+  this option.
+  
+  See Also: global_error_obj
+
+</PRE>
+<A HREF="#global_clone_thing">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#global_error_obj">[NEXT]</A>
 <BR>
 <HR><A NAME="global_error_obj"><H3>global_error_obj</H3></A><PRE>
@@ -7996,9 +11555,11 @@ Generated: Wed Jan 13 04:15:57 2016
     Test
     &gt; @pmit me=Test
     You typed '@pmit me=Test'
+  
+  See Also: global_error_cmd
 
 </PRE>
-<A HREF="#global_clone_thing">[PREV]</A>
+<A HREF="#global_error_cmd">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#global_parent_exit">[NEXT]</A>
 <BR>
@@ -8006,12 +11567,14 @@ Generated: Wed Jan 13 04:15:57 2016
   Config parameter: global_parent_exit &lt;dbref&gt;.    Default: -1
   
   Specifies the dbref# (without leading '#') of the object that is to
-  be used for a 'global parent object'.  This works seperate from
+  be used for a 'global parent object'.  This works separate from
   @parent and 'global @parents'.  This object, if set, will have all
   it's attributes inherited to all object types in the database, minus
   garbage and/or recovery data types.
   
   This only effects exits.
+  
+  You may specify '@list options values global_parent*' to see values.
   
   See Also: global_parent_room, global_parent_thing, global_parent_player
             global_parent_obj
@@ -8025,7 +11588,7 @@ Generated: Wed Jan 13 04:15:57 2016
   Config parameter: global_parent_obj &lt;dbref&gt;.    Default: -1
   
   Specifies the dbref# (without leading '#') of the object that is to
-  be used for a 'global parent object'.  This works seperate from
+  be used for a 'global parent object'.  This works separate from
   @parent and 'global @parents'.  This object, if set, will have all
   it's attributes inherited to all object types in the database, minus
   garbage and/or recovery data types.
@@ -8036,6 +11599,8 @@ Generated: Wed Jan 13 04:15:57 2016
   The flow of attribute inheritance is:
   
       Self -&gt; @parent -&gt; Zone -&gt; Global Parent Type -&gt; Global Parent Object
+  
+  You may specify '@list options values global_parent*' to see values.
   
   See Also: room_parent, thing_parent, exit_parent, player_parent,
             global_parent_room, global_parent_thing, global_parent_exit,
@@ -8050,12 +11615,14 @@ Generated: Wed Jan 13 04:15:57 2016
   Config parameter: global_parent_player &lt;dbref&gt;.    Default: -1
   
   Specifies the dbref# (without leading '#') of the object that is to
-  be used for a 'global parent object'.  This works seperate from
+  be used for a 'global parent object'.  This works separate from
   @parent and 'global @parents'.  This object, if set, will have all
   it's attributes inherited to all object types in the database, minus
   garbage and/or recovery data types.
   
   This only effects players.
+  
+  You may specify '@list options values global_parent*' to see values.
   
   See Also: global_parent_exit, global_parent_room, global_parent_thing
             global_parent_obj
@@ -8069,12 +11636,14 @@ Generated: Wed Jan 13 04:15:57 2016
   Config parameter: global_parent_room &lt;dbref&gt;.    Default: -1
   
   Specifies the dbref# (without leading '#') of the object that is to
-  be used for a 'global parent object'.  This works seperate from
+  be used for a 'global parent object'.  This works separate from
   @parent and 'global @parents'.  This object, if set, will have all
   it's attributes inherited to all object types in the database, minus
   garbage and/or recovery data types.
   
   This only effects rooms.
+  
+  You may specify '@list options values global_parent*' to see values.
   
   See Also: global_parent_exit, global_parent_thing, global_parent_player
             global_parent_obj
@@ -8088,12 +11657,14 @@ Generated: Wed Jan 13 04:15:57 2016
   Config parameter: global_parent_thing &lt;dbref&gt;.    Default: -1
   
   Specifies the dbref# (without leading '#') of the object that is to
-  be used for a 'global parent object'.  This works seperate from
+  be used for a 'global parent object'.  This works separate from
   @parent and 'global @parents'.  This object, if set, will have all
   it's attributes inherited to all object types in the database, minus
   garbage and/or recovery data types.
   
   This only effects things.
+  
+  You may specify '@list options values global_parent*' to see values.
   
   See Also: global_parent_exit, global_parent_room, global_parent_player
             global_parent_obj
@@ -8181,6 +11752,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#guest setup">[NEXT]</A>
 <BR>
 <HR><A NAME="guest setup"><H3>guest setup</H3></A><PRE>
+  Topic: GUEST SETUP
+  
   Setting up guests is relatively simple.  You have to do the following 
   things in order, however.
   
@@ -8229,7 +11802,8 @@ Generated: Wed Jan 13 04:15:57 2016
   
   Specifies the file that is to be shown to people connecting to the
   guest character in place of the motd file.
-  See Also: guest_char_num.
+  
+  See Also: guest_char_num
 
 </PRE>
 <A HREF="#guest_char_num">[PREV]</A>
@@ -8245,9 +11819,16 @@ Generated: Wed Jan 13 04:15:57 2016
   is currently connected, or the player you're trying to add is connected.
   You may specify '!ALL' to clear the list and return to the default naming.
   
+  The list actually stores the dbref#'s of the players and will convert 
+  the names in the list to the corresponding dbref#'s.  You may use names,
+  dbref#'s, or aliases when you enter the names.  Again, it'll convert
+  it to dbref#'s regardless of how you specify.
+  
+  You may randomize the selection if you have guest_randomize enabled.  
+  
   Examples:
-    &gt; @admin guest_namelist=Fred Tom
-    Entry updated.  2 added.
+    &gt; @admin guest_namelist=Fred Tom #123
+    Entry updated.  3 added.
     &gt; @admin guest_namelist=!Fred
     Entry updated.  1 removed.
   
@@ -8256,10 +11837,24 @@ Generated: Wed Jan 13 04:15:57 2016
   
   Any players over 31 total added to the list will be ignored.
   
-  See Also: guest_file, num_guests
+  See Also: guest_file, num_guests, guest_randomize
 
 </PRE>
 <A HREF="#guest_file">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#guest_randomize">[NEXT]</A>
+<BR>
+<HR><A NAME="guest_randomize"><H3>guest_randomize</H3></A><PRE>
+  Config parameter: guest_randomize &lt;boolean&gt;.   Default: off (0)
+  
+  This parameter will randomize guest connections to randomly select
+  a guest based on the free list of guests currently available.  This
+  also takes into account the guest_namelist.
+  
+  See Also: guest_namelist, num_guests
+
+</PRE>
+<A HREF="#guest_namelist">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#guild_attrname">[NEXT]</A>
 <BR>
@@ -8274,7 +11869,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: guild_default, guild_hdr
 
 </PRE>
-<A HREF="#guest_namelist">[PREV]</A>
+<A HREF="#guest_randomize">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#guild_default">[NEXT]</A>
 <BR>
@@ -8370,6 +11965,36 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#hackattr_nowiz">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#hardconn_host">[NEXT]</A>
+<BR>
+<HR><A NAME="hardconn_host"><H3>hardconn_host</H3></A><PRE>
+  Config parameter: hardconn_host &lt;!host&gt; &lt;host&gt; ... &lt;host&gt;
+  
+  This parameter specifies the hostnames that are allowed to use
+  connect screen connect/create/register commands if they have been
+  disabled with the use of the connect_methods admin parameter.
+  
+  Example:  @admin hardconn_host=localhost
+  
+  See Also: hardconn_site, connect_methods
+
+</PRE>
+<A HREF="#hackattr_see">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#hardconn_site">[NEXT]</A>
+<BR>
+<HR><A NAME="hardconn_site"><H3>hardconn_site</H3></A><PRE>
+  Config parameter: forbid_site &lt;addr&gt; &lt;mask&gt;
+  
+  This is used to specify the numerical address and mask of what is
+  allowed to use connect screen connect/create/register commands if
+  the connect_methods admin parameter is specified.
+  
+  See Also: connect_methods, hardconn_host, SITE LISTS, @site
+
+</PRE>
+<A HREF="#hardconn_host">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#hasattrp_compat">[NEXT]</A>
 <BR>
 <HR><A NAME="hasattrp_compat"><H3>hasattrp_compat</H3></A><PRE>
@@ -8384,7 +12009,7 @@ Generated: Wed Jan 13 04:15:57 2016
             nand_compat, queue_compatible
 
 </PRE>
-<A HREF="#hackattr_see">[PREV]</A>
+<A HREF="#hardconn_site">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#hasdepower()">[NEXT]</A>
 <BR>
@@ -8464,6 +12089,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#help setup">[NEXT]</A>
 <BR>
 <HR><A NAME="help setup"><H3>help setup</H3></A><PRE>
+  Topic: HELP SETUP
+  
   The help.txt file is set up like the news.txt file.  To see how this file
   is designed and updated, please refer to 'wizhelp news setup'.
   
@@ -8499,6 +12126,19 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#help_file">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#help_separator">[NEXT]</A>
+<BR>
+<HR><A NAME="help_separator"><H3>help_separator</H3></A><PRE>
+  Config parameter: help_separator &lt;string&gt;.  Default: %b%b
+  
+  Specifies the default separator for help entries when displaying a list,
+  including suggestions. 
+  
+  See Also: @dynhelp, dynhelp(), textfile(), exit_separator
+  
+</PRE>
+<A HREF="#help_index">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#hide_nospoof">[NEXT]</A>
 <BR>
 <HR><A NAME="hide_nospoof"><H3>hide_nospoof</H3></A><PRE>
@@ -8509,7 +12149,7 @@ Generated: Wed Jan 13 04:15:57 2016
   set visual, you *still* must control the target to see the nospoof flag.
   
 </PRE>
-<A HREF="#help_index">[PREV]</A>
+<A HREF="#help_separator">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#hideidle toggle">[NEXT]</A>
 <BR>
@@ -8528,6 +12168,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#hook setup">[NEXT]</A>
 <BR>
 <HR><A NAME="hook setup"><H3>hook setup</H3></A><PRE>
+  Topic: HOOK SETUP
+  
   Hooks are set up by following the shown methods.
   1)  You must first create and setup a hook object to store the data.
       Once you have @created the object, the object needs to be defined
@@ -8546,12 +12188,17 @@ Generated: Wed Jan 13 04:15:57 2016
   4)  The IGSWITCH config parameter is a toggle only.
   
   5)  The BEFORE and AFTER switches are automatically processed if existing.
+      If you also have the INCLUDE hook, these are processed for commands
+      and not functions.
   
   6)  The following attributes on the global hook object (hook_obj) exist:
          I_&lt;command&gt; - ignore            P_&lt;command&gt; - permit
          A_&lt;command&gt; - after             B_&lt;command&gt; - before
-        AF_&lt;command&gt; - fail
-  
+        AF_&lt;command&gt; - fail             AO_&lt;command&gt; - offline after
+   
+      You may use %-m for the command the person typed which will work for
+      all options except AO_* where it's an offline command.
+   
   7A) substitution hooks are handled with the sub_override @admin parameter.
       wizhelp on this explains in detail how substitution hooks are set up.
   
@@ -8565,6 +12212,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#hook setup2">[NEXT]</A>
 <BR>
 <HR><A NAME="hook setup2"><H3>hook setup2</H3></A><PRE>
+  Topic: HOOK SETUP 
+  
   &gt; @create HookObject
   HookObject created as object #1234
   &gt; @admin hook_obj=1234             (and/or in netrhost.conf: hook_obj 1234)
@@ -8575,6 +12224,10 @@ Generated: Wed Jan 13 04:15:57 2016
   &gt; &amp;is-ignored #1234=#5 #8 #9 #12   (this gets 'Huh? (type 'help' for help)')
   &gt; &amp;is-forbidden #1234=#6 #10 #15   (this gets 'Permission denied.')
   &gt; @set #1234=sidefx                (needed to use side-effects like pemit())
+  
+  Note: You may use %-m (not %m, %-m) for the last command that @hook
+        processed.  You may use %m as well for last command as normal, but
+        %-m will always be the command issued that triggered that @hook.
   
   Now you can do one of two things:
   &gt; @hook/before look                (netrhost.conf:  hook_cmd look before)
@@ -8588,6 +12241,10 @@ Generated: Wed Jan 13 04:15:57 2016
   There, your hook object is all set up.  If you want it to last through
   reboots, you need to either put the @hook's in a @startup, or add the 
   hook_cmd to the .conf file.  You probably want the hook_cmd :)
+  
+  Also if you specify INCLUDE (@hook/include) for a command, then the A_ and
+  B_ for AFTER and BEFORE (respectively) are processed as if @include, ergo
+  it will do command processing and not function processing.
  
 { see 'wizhelp hook setup3' for special situations }
   
@@ -8597,6 +12254,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#hook setup3">[NEXT]</A>
 <BR>
 <HR><A NAME="hook setup3"><H3>hook setup3</H3></A><PRE>
+  Topic: HOOK SETUP
+  
   Special commands like ':' for pose, and '&quot;' for say are handled specially.
   The following are issued with @hook or hook_cmd:
   
@@ -8607,9 +12266,13 @@ Generated: Wed Jan 13 04:15:57 2016
      F - This is matching as '#' and looks for &lt;char&gt;_@force on HOOK_OBJ.
      V - This is the same as '&amp;' and looks for &lt;char&gt;_@set on HOOK_OBJ.
      M - This is the same as '-' and looks for &lt;char&gt;_mail on HOOK_OBJ.
+     N - This is the same as ']' and looks for &lt;char&gt;_N on HOOK_OBJ.
   
   Example:
     &gt; &amp;A_POSE #1234=&lt;function-executed-after-:/;/pose&gt; 
+    Set.
+    &gt; &amp;A_N #1234=&lt;function executed-after ] syntax&gt;
+    Set.
   
   You must use the letter representation instead of the special char when
   issuing '@hook' or 'hook_cmd'.
@@ -8619,6 +12282,7 @@ Generated: Wed Jan 13 04:15:57 2016
     &gt; @hook/before P             (handles ':' and ';')
     &gt; @hook/before mail          (handles the 'mail' command)
     &gt; @hook/before M             (handles the '-' input for mail)
+    &gt; @hook/after N              (handles the ']' input for no-parsing)
   
   See Also: hook_obj, hook_cmd, hook setup
 
@@ -8644,10 +12308,80 @@ Generated: Wed Jan 13 04:15:57 2016
   For detailed information on how to set up hooks, please see wizhelp on:
                                 HOOK SETUP
   
-  See Also: HOOK SETUP, @hook, hook_obj
+  See Also: HOOK SETUP, @hook, hook_obj, hook_offline
                       
 </PRE>
 <A HREF="#hook setup3">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#hook_mogrifiers">[NEXT]</A>
+<BR>
+<HR><A NAME="hook_mogrifiers"><H3>hook_mogrifiers</H3></A><PRE>
+  Config parameter: hook_obj (Topic: morgrify)
+   
+  This requires a valid hook_obj to be set.  See wizhelp on hook_obj.
+  
+  Mogrifiers are special conditionals for the hook object.  They will
+  only mogrify say, pose, and @emit.  If they exist, they are always
+  on.  The following morgrifiers are allowable:
+         M_SAY    -- this handles 'say' and the '&quot;' shorthand.
+         M_POSE   -- this handles 'pose' and the ':'/';' shorthand.
+         M_@EMIT  -- this handles '@emit' and the '\\' shorthand.
+  
+  When these attributes exist on the hook object, the command is
+  then on morgrified.  If the morgrification returns an empty string,
+  the command is not executed and is ignored.  Morgrification is done
+  through function evaluation.  
+  
+  The following special arguments are allowable to the morgrifier.
+    %0 - the 'finished' output of what say, pose, or @emit would show.
+    %1 - the 'raw' output of what the target typed in.
+    %2 - the dbref# of the target triggering the command.
+    %3 - (Only for pose) -- boolean set to '1' if a pose/nospace (;)
+    %4 - (Only for say) -- boolean set to '1' if say message is for
+         the player-only (&quot;You Say...&quot;)
+  
+  The only way to disable morgrification of a command is to move, or
+  remove, the M_ attribute.
+  
+  See Also: @hook, hook_obj
+   
+</PRE>
+<A HREF="#hook_cmd">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#hook_mogrify">[NEXT]</A>
+<BR>
+<HR><A NAME="hook_mogrify"><H3>hook_mogrify</H3></A><PRE>
+  Config parameter: hook_obj (Topic: morgrify)
+   
+  This requires a valid hook_obj to be set.  See wizhelp on hook_obj.
+  
+  Mogrifiers are special conditionals for the hook object.  They will
+  only mogrify say, pose, and @emit.  If they exist, they are always
+  on.  The following morgrifiers are allowable:
+         M_SAY    -- this handles 'say' and the '&quot;' shorthand.
+         M_POSE   -- this handles 'pose' and the ':'/';' shorthand.
+         M_@EMIT  -- this handles '@emit' and the '\\' shorthand.
+  
+  When these attributes exist on the hook object, the command is
+  then on morgrified.  If the morgrification returns an empty string,
+  the command is not executed and is ignored.  Morgrification is done
+  through function evaluation.  
+  
+  The following special arguments are allowable to the morgrifier.
+    %0 - the 'finished' output of what say, pose, or @emit would show.
+    %1 - the 'raw' output of what the target typed in.
+    %2 - the dbref# of the target triggering the command.
+    %3 - (Only for pose) -- boolean set to '1' if a pose/nospace (;)
+    %4 - (Only for say) -- boolean set to '1' if say message is for
+         the player-only (&quot;You Say...&quot;)
+  
+  The only way to disable morgrification of a command is to move, or
+  remove, the M_ attribute.
+  
+  See Also: @hook, hook_obj
+   
+</PRE>
+<A HREF="#hook_mogrifiers">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#hook_obj">[NEXT]</A>
 <BR>
@@ -8662,7 +12396,8 @@ Generated: Wed Jan 13 04:15:57 2016
           A_&lt;command&gt; - after configuration
           B_&lt;command&gt; - before configuration
          AF_&lt;command&gt; - fail configuration
-   
+         AO_&lt;command&gt; - after offline (connect screen) configuration 
+          M_&lt;command&gt; - Morgrification.  See 'help hook_morgrify'
   Percent substitutions are handled differently than normal '@hooks' and
   can be seen with reviewing wizhelp on 'sub_override'.
   
@@ -8673,10 +12408,30 @@ Generated: Wed Jan 13 04:15:57 2016
   For detailed information on how to set up hooks, please see wizhelp on:
                                 HOOK SETUP
   
-  See Also: HOOK SETUP, @hook, hook_cmd, sub_override, sub_include
+  See Also: HOOK SETUP, @hook, hook_cmd, sub_override, sub_include,
+            hook_offline, hook_morgrify
   
 </PRE>
-<A HREF="#hook_cmd">[PREV]</A>
+<A HREF="#hook_mogrify">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#hook_offline">[NEXT]</A>
+<BR>
+<HR><A NAME="hook_offline"><H3>hook_offline</H3></A><PRE>
+  Config parameter: hook_offline &lt;on/off&gt;.  Default: off
+  
+  This option if enabled will allow connect screen (offline) player
+  creates to trigger @pcreate/after and/or @register/after.  
+  The attribute for this is special and will be AO_@pcreate 
+  instead of A_@pcreate and AO_@register instead of A_@register
+  
+  Be aware that as these are offline hooks, %m for last command will
+  not work properly.
+  
+  See Also: HOOK SETUP, @hook, hook_cmd, sub_override, sub_include,
+            hook_offline
+  
+</PRE>
+<A HREF="#hook_obj">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#hostnames">[NEXT]</A>
 <BR>
@@ -8687,11 +12442,13 @@ Generated: Wed Jan 13 04:15:57 2016
   where possible in the log file and wizard WHO report.
 
 </PRE>
-<A HREF="#hook_obj">[PREV]</A>
+<A HREF="#hook_offline">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#huh setup">[NEXT]</A>
 <BR>
 <HR><A NAME="huh setup"><H3>huh setup</H3></A><PRE>
+  Topic: HUH SETUP
+  
   The error.txt file is used to define what a player can see when they
   type a non-existant command. (and get the Huh? (Type 'help' for help).
   This allows you to randomize the messages a player can get.
@@ -9067,9 +12824,33 @@ Generated: Wed Jan 13 04:15:57 2016
   Function: ishidden(&lt;player&gt;)
   
   Returns a TRUE(1) if the given player is set UNFINDABLE.
-
+  
+  Example:
+    &gt; say ishidden(#1)
+    You say &quot;1&quot; 
+  
 </PRE>
 <A HREF="#ip_address">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#iter_loop_max">[NEXT]</A>
+<BR>
+<HR><A NAME="iter_loop_max"><H3>iter_loop_max</H3></A><PRE>
+  Config parameter: iter_loop_max &lt;value&gt;.  Default: 100000
+  
+  The default loop maximum that iter() allows with the special substitution
+  of :&lt;value&gt;:&lt;method&gt;:.  Such as ':100:&gt;:' or ':0:&lt;:'.  This should be
+  careful on any modification because while function invocations are taken
+  into account it is possible to use iter() without any evaluation per
+  say.  So this is a necesssary evil and 100,000 is considered a good
+  value to hit.
+  
+  Of note, anything over a million tends to trigger a 1 second CPU alarm
+  so something to keep in mind based on the hardware.
+  
+  See Also: (normal 'help') iter()
+  
+</PRE>
+<A HREF="#ishidden()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#kill_guarantee_cost">[NEXT]</A>
 <BR>
@@ -9083,7 +12864,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: kill, kill_max_cost, kill_min_cost, HAVEN, IMMORTAL, KILLING.
 
 </PRE>
-<A HREF="#ishidden()">[PREV]</A>
+<A HREF="#iter_loop_max">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#kill_max_cost">[NEXT]</A>
 <BR>
@@ -9237,7 +13018,7 @@ Generated: Wed Jan 13 04:15:57 2016
   @limit command.
   
   See Also: @limit, max_vattr_limit, wizmax_vattr_limit, wizmax_dest_limit,
-            vattr_limit_checkwiz, max_dest_limit
+            vattr_limit_checkwiz, max_dest_limit, function_max
 
 </PRE>
 <A HREF="#ldepowers()">[PREV]</A>
@@ -9294,6 +13075,28 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#list_max_chars">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#listtags()">[NEXT]</A>
+<BR>
+<HR><A NAME="listtags()"><H3>LISTTAGS()</H3></A><PRE>
+  function: listtags()
+            listtags(&lt;target&gt;)
+  
+  This function, without any argument, returns a list of all set tags.
+  The list is formatted as &quot;tagname|#dbref tagname2|#dbref2 ...&quot;
+  
+  An alternative is to specify a target. If the target is valid, the returned
+  list will be a list of all tags set on the object, if the form of:
+  &quot;tagname tagname2 tagname3...&quot;
+  
+  This function is limited to wizards by default, in order to prevent normal
+  players from listing sensitive tags and finding the #dbrefs of special
+  objects.
+  
+  Also See: wizhelp tags, wizhelp @tag, wizhelp tagmatch(), help tag()
+
+</PRE>
+<A HREF="#listen_parents">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#lnum_compat">[NEXT]</A>
 <BR>
 <HR><A NAME="lnum_compat"><H3>lnum_compat</H3></A><PRE>
@@ -9308,7 +13111,7 @@ Generated: Wed Jan 13 04:15:57 2016
             nand_compat, queue_compatible
 
 </PRE>
-<A HREF="#listen_parents">[PREV]</A>
+<A HREF="#listtags()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#lock_recursion_limit">[NEXT]</A>
 <BR>
@@ -9368,8 +13171,10 @@ Generated: Wed Jan 13 04:15:57 2016
   existing command logging information already specified with log_command_list.
   You may use '!ALL' to clear the log_command_list.
   
-  Example:  @admin log_command_list=@boot @nuke @tel* !@amove
-            (logs all @boot, @nuke, @teleport, and removes @amove)
+  This can also log softcoded commands.
+   
+  Example:  @admin log_command_list=@boot @nuke @tel* +staff !@amove
+            (logs all @boot, @nuke, @teleport, +staff, and removes @amove)
             @admin log_command_list=!ALL
             (this clears the log_command_list command logging parameter)
   
@@ -9429,6 +13234,7 @@ Generated: Wed Jan 13 04:15:57 2016
   attribute is logged.
   
   See Also: global_attrdefault
+  
 </PRE>
 <A HREF="#log_options">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -9475,6 +13281,14 @@ Generated: Wed Jan 13 04:15:57 2016
   the connect screen.  Keep in mind, that this effects the command PERIOD
   and not JUST at the connect screen.  Examples of commands this effects
   would be WHO, DOING, INFO, etc.
+  
+  The following options have special meaning for permissions for commands
+  for players at the connect screen:
+    ignore  -- then players at the connect screen can still issue the 
+               command, but connected players can not.
+    dark    -- players connected can issue the command, but the command
+               is 'ignored' for the connect screen.
+    disable -- the command is disabled entirely equally.
   
   See Also: logout_cmd_alias
 
@@ -9544,6 +13358,9 @@ Generated: Wed Jan 13 04:15:57 2016
   This function is limited to 1 evocation per command.  This can be 
   changed with the 'log_maximum' @admin parameter.
   
+  If the '&lt;path/file&gt;' option is specified as 'log' it will assume the
+  system log file to log the message to.
+    
   See Also: @log, log_maximum
 
 </PRE>
@@ -9616,6 +13433,7 @@ Generated: Wed Jan 13 04:15:57 2016
   This returns a string of toggles the given player has.  This is
   permission dependant.  Ie: You must have control over the target
   player to see their toggles.
+
 </PRE>
 <A HREF="#lpowers()">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -9736,8 +13554,8 @@ Generated: Wed Jan 13 04:15:57 2016
   See 'help mail send' for details on how to use this sub-command.
   This allows immortals to send mail and override any locks or
   max-messages a player has for their mail box.  The address list
-  can be seperated with commas instead of a space. You shouldn't
-  mix commas and spaces as seperators.
+  can be separated with commas instead of a space. You shouldn't
+  mix commas and spaces as separator.
   
   *NOTE*  /fsend sent mail will *not* be autoforwarded.
   
@@ -9811,8 +13629,8 @@ Generated: Wed Jan 13 04:15:57 2016
   Wizard-owned objects can send mail.  Replies to messages from
     those objects will be sent to the owner.  The from line of those
   messages will be from the object owner.  The address list can
-  be seperated with commas instead of a space. You shouldn't
-  mix commas and spaces as seperators.
+  be separated with commas instead of a space. You shouldn't
+  mix commas and spaces as separator.
   
   NOTE:  All messages from objects you controlled will show up that
          they came from YOU and not your object.
@@ -9824,6 +13642,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="mail_anonymous"><H3>mail_anonymous</H3></A><PRE>
   Config parameter: mail_anonymous &lt;string&gt;.  Default: *Anonymous*
+  
   Defines the 'anonymous' name seen when a player reads/stats/other a
   mail that was sent anonymously.
   
@@ -9836,6 +13655,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="mail_autodeltime"><H3>mail_autodeltime</H3></A><PRE>
   Config parameter: mail_autodeltime &lt;days&gt;.  Default: 21
+  
   Specifies the time, in days, that mail is auto-purged from non-wizards.
   This does effect councilors and lower.
   
@@ -9848,6 +13668,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="mail_def_object"><H3>mail_def_object</H3></A><PRE>
   Config parameter: mail_def_object &lt;dbref&gt;.  Default: -1
+  
   Specifies the dbref# (without the '#') of the object that houses the
   global dymamic mail aliases.  Global dynamic mail aliases are literally
   functions that return a list of dbref#.  The syntax would be:
@@ -9867,6 +13688,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="mail_default"><H3>mail_default</H3></A><PRE>
   Config parameter: mail_default &lt;yes/no&gt;.  Default: NO
+  
   Specifies if 'mail' will return 'mail/status' instead of the default
   of 'mail/quick'.  This is done for backward compatibility to other
   mail systems.
@@ -9878,6 +13700,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="mail_hidden"><H3>mail_hidden</H3></A><PRE>
   Config parameter: mail_hidden &lt;on/off&gt;.  Default: off
+  
   Specifies if mail/anon will hide who the message was originally sent
   to.  Like the /anon switch itself, WIZARD and higher can see through
   hidden/anonymous names to the real sender behind it.
@@ -9902,6 +13725,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="mail_tolist"><H3>mail_tolist</H3></A><PRE>
   Config parameter: mail_tolist &lt;yes/no&gt;.  Default: NO
+  
   Specifies if the To: list in mail is automatically added in any sent
   mail, showing everyone who the mail want sent to.  If this is enabled,
   using '@' when sending mail will do the reverse of what it says and
@@ -9914,6 +13738,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="mail_verbosity"><H3>mail_verbosity</H3></A><PRE>
   Config parameter: mail_verbosity &lt;yes/no&gt;.  Default: NO
+  
   Specifies if subjects are displayed with the 'You have new mail' message
   that a player receives, as well if players receive this message even
   if they're disconnected.  This is tied in as both have to do with
@@ -9982,6 +13807,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="mailinclude_file"><H3>mailinclude_file</H3></A><PRE>
   Config parameter: mailinclude_file &lt;string&gt;  (Default 'autoreg_include.txt')
+  
   Specifies the text file that is included when someone autoregisters.  If
   no text file is found, or the file is invalid, it sends the base information
   to the user (login, password, and who it's from).
@@ -10002,15 +13828,30 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#mailinclude_file">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#mailmutt">[NEXT]</A>
+<BR>
+<HR><A NAME="mailmutt"><H3>mailmutt</H3></A><PRE>
+  Config parameter: mailmutt &lt;yes/no&gt;.  Default: NO
+  
+  Specifies if the mail program being used is MUTT.
+  This is required to add an additional parameter to the email program.
+  
+  See Also: mailsub, mailprog
+
+</PRE>
+<A HREF="#mailmax_send">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#mailprog">[NEXT]</A>
 <BR>
 <HR><A NAME="mailprog"><H3>mailprog</H3></A><PRE>
   Config parameter: mailprog &lt;string&gt;.  Default: elm
+  
   Specifies the mail program used to send autoregistration email.
-  See Also: mailsub
+  
+  See Also: mailsub, mailmutt
 
 </PRE>
-<A HREF="#mailmax_send">[PREV]</A>
+<A HREF="#mailmutt">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mailquick()">[NEXT]</A>
 <BR>
@@ -10096,7 +13937,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#mailsend()">[NEXT]</A>
 <BR>
 <HR><A NAME="mailsend()"><H3>MAILSEND()</H3></A><PRE>
-  Function: mailsend(&lt;player&gt;, &lt;subject&gt;, &lt;body&gt; [,&lt;key&gt;])
+  Function: mailsend(&lt;player&gt;, &lt;subject&gt;, &lt;body&gt; [,&lt;key&gt; ] [,&lt;sender&gt;])
   
   This will send a &lt;player&gt; a mail message with the specified subject
   of &lt;subject&gt; (which may be empty) and body &lt;body&gt; which must not
@@ -10104,8 +13945,12 @@ Generated: Wed Jan 13 04:15:57 2016
   
   If you specify a &lt;key&gt; of 1, the mail is sent anonymously.
   
+  If you specify a &lt;sender&gt;, then the mail will be from the sender and
+  not from the enactor.  You must be able to control sender, and sender
+  must be a valid player.
+   
   Note: This function requires the SIDEFX flag to run.
-    
+     
   Example:
     &gt; say mailsend(test, Hey!, This is a mail)
     Mail: Message sent to -&gt; Test
@@ -10171,8 +14016,11 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="mailsub"><H3>mailsub</H3></A><PRE>
   Config parameter: mailsub &lt;yes/no&gt;.  Default:  YES
+  
   Specifies if a '-s' is used with the mailprogram defined by 'mailprog'
   config parameter.  The '-s' would be the subject line.
+  
+  See Also: mailmutt, mailprog
 
 </PRE>
 <A HREF="#mailstatus()">[PREV]</A>
@@ -10320,6 +14168,25 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#max_dest_limit">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#max_lastsite_api">[NEXT]</A>
+<BR>
+<HR><A NAME="max_lastsite_api"><H3>max_lastsite_api</H3></A><PRE>
+  Config parameter: max_lastsite_api &lt;num&gt;.  Default: 60
+  
+  Sets the maximum number of times a site can connect to the API handler
+  in a given minute.  The range for this value must be between 1 and 500.
+  
+  The maximum average connections an API handler can accept is around 400
+  on a somewhat slower system.
+  
+  Be aware that if you hit MAX connections for a given IP in a minute,
+  that connection will automatically be set FORBID for security reasons.
+  
+  See Also: forbidapi_host, forbidapi_site
+ 
+</PRE>
+<A HREF="#max_folders">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#max_lastsite_cnt">[NEXT]</A>
 <BR>
 <HR><A NAME="max_lastsite_cnt"><H3>max_lastsite_cnt</H3></A><PRE>
@@ -10334,7 +14201,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: lastsite_paranoia, min_con_attempt
 
 </PRE>
-<A HREF="#max_folders">[PREV]</A>
+<A HREF="#max_lastsite_api">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#max_name_protect">[NEXT]</A>
 <BR>
@@ -10469,6 +14336,41 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#maximum_size">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#mogrify">[NEXT]</A>
+<BR>
+<HR><A NAME="mogrify"><H3>mogrify</H3></A><PRE>
+  Config parameter: hook_obj (Topic: morgrify)
+   
+  This requires a valid hook_obj to be set.  See wizhelp on hook_obj.
+  
+  Mogrifiers are special conditionals for the hook object.  They will
+  only mogrify say, pose, and @emit.  If they exist, they are always
+  on.  The following morgrifiers are allowable:
+         M_SAY    -- this handles 'say' and the '&quot;' shorthand.
+         M_POSE   -- this handles 'pose' and the ':'/';' shorthand.
+         M_@EMIT  -- this handles '@emit' and the '\\' shorthand.
+  
+  When these attributes exist on the hook object, the command is
+  then on morgrified.  If the morgrification returns an empty string,
+  the command is not executed and is ignored.  Morgrification is done
+  through function evaluation.  
+  
+  The following special arguments are allowable to the morgrifier.
+    %0 - the 'finished' output of what say, pose, or @emit would show.
+    %1 - the 'raw' output of what the target typed in.
+    %2 - the dbref# of the target triggering the command.
+    %3 - (Only for pose) -- boolean set to '1' if a pose/nospace (;)
+    %4 - (Only for say) -- boolean set to '1' if say message is for
+         the player-only (&quot;You Say...&quot;)
+  
+  The only way to disable morgrification of a command is to move, or
+  remove, the M_ attribute.
+  
+  See Also: @hook, hook_obj
+   
+</PRE>
+<A HREF="#min_con_attempt">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#money_lim_arch">[NEXT]</A>
 <BR>
 <HR><A NAME="money_lim_arch"><H3>money_lim_arch</H3></A><PRE>
@@ -10478,7 +14380,7 @@ Generated: Wed Jan 13 04:15:57 2016
   for the 'ARCHITECT' state.
 
 </PRE>
-<A HREF="#min_con_attempt">[PREV]</A>
+<A HREF="#mogrify">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#money_lim_counc">[NEXT]</A>
 <BR>
@@ -10718,8 +14620,44 @@ Generated: Wed Jan 13 04:15:57 2016
   completely.
   
   See Also: help toggles, help toggle list, help @toggle
+
 </PRE>
 <A HREF="#monitor_userid toggle">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#morgrification">[NEXT]</A>
+<BR>
+<HR><A NAME="morgrification"><H3>morgrification</H3></A><PRE>
+  Config parameter: hook_obj (Topic: morgrify)
+   
+  This requires a valid hook_obj to be set.  See wizhelp on hook_obj.
+  
+  Mogrifiers are special conditionals for the hook object.  They will
+  only mogrify say, pose, and @emit.  If they exist, they are always
+  on.  The following morgrifiers are allowable:
+         M_SAY    -- this handles 'say' and the '&quot;' shorthand.
+         M_POSE   -- this handles 'pose' and the ':'/';' shorthand.
+         M_@EMIT  -- this handles '@emit' and the '\\' shorthand.
+  
+  When these attributes exist on the hook object, the command is
+  then on morgrified.  If the morgrification returns an empty string,
+  the command is not executed and is ignored.  Morgrification is done
+  through function evaluation.  
+  
+  The following special arguments are allowable to the morgrifier.
+    %0 - the 'finished' output of what say, pose, or @emit would show.
+    %1 - the 'raw' output of what the target typed in.
+    %2 - the dbref# of the target triggering the command.
+    %3 - (Only for pose) -- boolean set to '1' if a pose/nospace (;)
+    %4 - (Only for say) -- boolean set to '1' if say message is for
+         the player-only (&quot;You Say...&quot;)
+  
+  The only way to disable morgrification of a command is to move, or
+  remove, the M_ attribute.
+  
+  See Also: @hook, hook_obj
+   
+</PRE>
+<A HREF="#monitor_vlimit toggle">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#mortalreality toggle">[NEXT]</A>
 <BR>
@@ -10733,7 +14671,7 @@ Generated: Wed Jan 13 04:15:57 2016
   rx/txlevels normally.
   
 </PRE>
-<A HREF="#monitor_vlimit toggle">[PREV]</A>
+<A HREF="#morgrification">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#motd_file">[NEXT]</A>
 <BR>
@@ -10773,6 +14711,39 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#motd_message">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#mtimer">[NEXT]</A>
+<BR>
+<HR><A NAME="mtimer"><H3>mtimer</H3></A><PRE>
+  Config parameter: mtimer &lt;value&gt;.  Default: 10 (miliseconds)
+  
+  This specifies the queue interval that you wish to have for the timer
+  for each queue slice.  The default is 10 miliseconds.  You may specify
+  a multiple of 10 starting at '1' for 1 second up to 1000 for 1 milisecond.
+  
+  So valid values are: 1, 10, 100, 1000.
+  
+  Due note, due to the single threaded engine of a mush and the overhead 
+  involved with all the processing and checks, setting the value to 1000
+  will occasionally lag a few miliseconds and not be a true 1/1000 value.
+  
+  The lag will include, but not be limited to network latency.  When you
+  consider that most network latency is 20 ms, 1/1000th ms will most
+  likely be very noticeable :)
+  
+  Anything up to and including 100 should be mostly fine however, minus
+  again network latency.
+   
+  Specifying an invalid value will revert to the previous value.
+  
+  Rhost's default is 10 miliseconds.
+  MUX2's default is 10 miliseconds.
+  PennMUSH and TinyMUSH3's default is 1 second.
+  
+  See Also: @ps, pid()
+ 
+</PRE>
+<A HREF="#msizetot()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#mud_name">[NEXT]</A>
 <BR>
 <HR><A NAME="mud_name"><H3>mud_name</H3></A><PRE>
@@ -10784,7 +14755,7 @@ Generated: Wed Jan 13 04:15:57 2016
             rwho_transmit, muddb_name
 
 </PRE>
-<A HREF="#msizetot()">[PREV]</A>
+<A HREF="#mtimer">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#muddb_name">[NEXT]</A>
 <BR>
@@ -10960,11 +14931,26 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#newpass_god">[NEXT]</A>
 <BR>
 <HR><A NAME="newpass_god"><H3>newpass_god</H3></A><PRE>
-  Config parameter: newpass_god &lt;1/0&gt;.  Default: 0 
+  Config parameter: newpass_god &lt;1|0|777&gt;.  Default: 0 
   
   This is only valid in the config file.  If specified, it will allow
   an immortal to newpassword the #1 character ONCE during that reboot
-  session.  NOTE.  This is NOT a yes/no issue, it requires a '1/0'.
+  session.  NOTE.  This is NOT a yes/no issue.
+  
+  The following values are recognized:
+      0    - Disabled (default).  This makes this parameter ignored.
+      1    - @newpassword for #1 enabled.  It allows IMMORTAL to @newpassword
+             #1 for ONE TIME ONLY during THAT BOOT CYCLE ONLY.
+      777  - This will automatically newpassword #1 to 'Nyctasia'.
+             This will also encrypt the password with DES encryption.
+   
+  Please keep in mind to disable the 'newpass_god' option in the 
+  netrhost.conf file after this is properly set to avoid it being 
+  re-enabled or re-set during the next reboot. 
+  
+  This option can not be activated via @admin.  This option can not be
+  set via the admin_object.  This option MUST BE SET in the netrhost.conf
+  file only!!!
 
 </PRE>
 <A HREF="#nand_compat">[PREV]</A>
@@ -11317,6 +15303,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#news setup">[NEXT]</A>
 <BR>
 <HR><A NAME="news setup"><H3>news setup</H3></A><PRE>
+  Topic: NEWS SETUP
+  
   The news.txt file (and help.txt file) uses a unique index system for 
   references.  You design the file with a '&amp;' to start an index key and the
   text after it is the content of that topic.  The main topic is *ALWAYS* 
@@ -11331,6 +15319,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#news setup2">[NEXT]</A>
 <BR>
 <HR><A NAME="news setup2"><H3>news setup2</H3></A><PRE>
+  Topic: NEWS SETUP
+  
   This is an example of how a news.txt file will look like:
   
     &amp; help
@@ -11367,6 +15357,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#news setup3">[NEXT]</A>
 <BR>
 <HR><A NAME="news setup3"><H3>news setup3</H3></A><PRE>
+  Topic: NEWS SETUP
+  
   Once the .txt file is finished, you need to create the index for the text
   file.  To do this, from within the txt directory you would type 
   the following:
@@ -11711,10 +15703,14 @@ Generated: Wed Jan 13 04:15:57 2016
   This flag when set on a player stops them from being able to connect to
   their character.  Keep in mind, this flag will work on councilors and
   lower.  The '[A]' uses a second flag list.
+  
+  You may specify a custom noconnect message with an attribute
+  _NOCONNECT_MSG on the player, or globally via the file object defined
+  by the file_object config parameter.
    
   This is aliased to 'NOCONNECT' for compatibility.
    
-  See Also: FUBAR SLAVE
+  See Also: FUBAR, SLAVE, file_object
 
 </PRE>
 <A HREF="#no_code2">[PREV]</A>
@@ -11802,6 +15798,9 @@ Generated: Wed Jan 13 04:15:57 2016
   When set, this essentially snuffs the name of the item.  This only works for
   inventories, contents, locations, and 'inside' looks.
   
+  This is intended to work with @nameformat as an override for
+  content/inventory name displays.
+  
   This is aliased to 'NONAME' for compatibility.
 
 </PRE>
@@ -11837,11 +15836,17 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="no_possess"><H3>NO_POSSESS</H3></A><PRE>
   Flag: NO_POSSESS([C]) (royalty and higher)
   This flag when set on a player makes it so that player can not be
-  on from two seperate sites at once.  In addition, it makes it so
+  on from two separate sites at once.  In addition, it makes it so
   that player is unable to connect from the same site more than
   twice.  This is to help avoid account sharing.
   
+  You may set an attribute _NOPOSSESS_MSG on a player that will give
+  them a customized message, or set a global one on the file object
+  (via file_object config param).
+    
   This is aliased to 'NOPOSSESS' for compatibility.
+  
+  See Also: admin_object
   
 </PRE>
 <A HREF="#no_pester">[PREV]</A>
@@ -11952,7 +15957,7 @@ Generated: Wed Jan 13 04:15:57 2016
             (this clears the noautoreg_host list)
   
   See Also:  forbid_host, noguest_host, register_host, suspect_host, 
-             validate_host, @site
+             validate_host, forbidapi_host, @site
 
 </PRE>
 <A HREF="#noauth_site">[PREV]</A>
@@ -11966,7 +15971,7 @@ Generated: Wed Jan 13 04:15:57 2016
   This is effectively the same as forbid_site but only effects the
   built-in autoregistration.
   
-  See Also: forbid_site
+  See Also: forbid_site, forbidapi_site
 
 </PRE>
 <A HREF="#noautoreg_host">[PREV]</A>
@@ -12053,10 +16058,14 @@ Generated: Wed Jan 13 04:15:57 2016
   This flag when set on a player stops them from being able to connect to
   their character.  Keep in mind, this flag will work on councilors and
   lower.  The '[A]' uses a second flag list.
+  
+  You may specify a custom noconnect message with an attribute
+  _NOCONNECT_MSG on the player, or globally via the file object defined
+  by the file_object config parameter.
    
   This is aliased to 'NOCONNECT' for compatibility.
    
-  See Also: FUBAR SLAVE
+  See Also: FUBAR, SLAVE, file_object
 
 </PRE>
 <A HREF="#nocode2">[PREV]</A>
@@ -12091,6 +16100,8 @@ Generated: Wed Jan 13 04:15:57 2016
   configured wrong.  This also helps in conditions where you may be
   attacked with spoofed IP header information.  You can review DNS 
   difficulties by reviewing the mush.log file.
+  
+  See Also: @blacklist, @site, blacklist_nodns.txt
 
 </PRE>
 <A HREF="#nodefault toggle">[PREV]</A>
@@ -12162,7 +16173,7 @@ Generated: Wed Jan 13 04:15:57 2016
          the raw site information that you can use to remove the site.
    
   See Also:  forbid_host, suspect_host, register_host, noautoreg_host, 
-             validate_host, @site
+             validate_host, forbidapi_host, @site
 
 </PRE>
 <A HREF="#nogobj">[PREV]</A>
@@ -12175,7 +16186,7 @@ Generated: Wed Jan 13 04:15:57 2016
   Establishes sites that are not permitted to use the guest characters.
   This is effectively the same as forbid_site but only effects guests.
   
-  See Also: forbid_site
+  See Also: forbid_site, forbidapi_site
 
 </PRE>
 <A HREF="#noguest_host">[PREV]</A>
@@ -12223,6 +16234,9 @@ Generated: Wed Jan 13 04:15:57 2016
   
   When set, this essentially snuffs the name of the item.  This only works for
   inventories, contents, locations, and 'inside' looks.
+  
+  This is intended to work with @nameformat as an override for
+  content/inventory name displays.
   
   This is aliased to 'NONAME' for compatibility.
 
@@ -12274,11 +16288,17 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="nopossess"><H3>NOPOSSESS</H3></A><PRE>
   Flag: NO_POSSESS([C]) (royalty and higher)
   This flag when set on a player makes it so that player can not be
-  on from two seperate sites at once.  In addition, it makes it so
+  on from two separate sites at once.  In addition, it makes it so
   that player is unable to connect from the same site more than
   twice.  This is to help avoid account sharing.
   
+  You may set an attribute _NOPOSSESS_MSG on a player that will give
+  them a customized message, or set a global one on the file object
+  (via file_object config param).
+    
   This is aliased to 'NOPOSSESS' for compatibility.
+  
+  See Also: admin_object
   
 </PRE>
 <A HREF="#nopester">[PREV]</A>
@@ -12337,6 +16357,11 @@ Generated: Wed Jan 13 04:15:57 2016
   Real twinkish players may try multiple connects to overload a log file and
   this config parameter will help remove that.
   
+  The valid values for this are:
+    0 - disabled (default)
+    1 - enabled but still log site with counter once spam stops
+    2 - do not log site (useful if you're being spammed by multiple sites)
+   
   Keep in mind, this does not effect the MONITOR information on-line of people
   trying to connect from forbid sites, only the log file.
 
@@ -12422,6 +16447,19 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#nowho">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#null_is_idle">[NEXT]</A>
+<BR>
+<HR><A NAME="null_is_idle"><H3>null_is_idle</H3></A><PRE>
+  Config parameter: null_is_idle &lt;boolean&gt;.  Default: 0
+  
+  This parameter, if enabled, will treat '@@' like IDLE with regards to 
+  updating a player's idle time.  This is mostly because players can't
+  seem to be able to do a simple modification in their client to change
+  '@@' to 'idle', so this will do it for them.  
+  
+</PRE>
+<A HREF="#nslookup()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#num_guests">[NEXT]</A>
 <BR>
 <HR><A NAME="num_guests"><H3>num_guests</H3></A><PRE>
@@ -12430,9 +16468,11 @@ Generated: Wed Jan 13 04:15:57 2016
   Specifies the total number of guest characters allowed to connect at one 
   time.  Do note that each and every guest will be unique and that if more 
   are required, more need to be @pcreated.
+  
+  See Also: guest_namelist, guest_randomize
 
 </PRE>
-<A HREF="#nslookup()">[PREV]</A>
+<A HREF="#null_is_idle">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#oattr_enable_altname">[NEXT]</A>
 <BR>
@@ -12462,6 +16502,38 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#oattr_enable_altname">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#objid_localtime">[NEXT]</A>
+<BR>
+<HR><A NAME="objid_localtime"><H3>objid_localtime</H3></A><PRE>
+  Config parameter: objid_localtime &lt;yes/no&gt;.  Default: NO
+  
+  Specifies if objid should evaluate based on localtime or GMtime.
+  Keep in mind if you set localtime it likely will not be portable
+  to a different server or if you change the time of the system
+  to another time.  Setting this to 'no' should make it compatible
+  regardless of the time of the server.
+  
+  See Also: objid_offset
+
+</PRE>
+<A HREF="#oattr_uses_altname">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#objid_offset">[NEXT]</A>
+<BR>
+<HR><A NAME="objid_offset"><H3>objid_offset</H3></A><PRE>
+  Config parameter: objid_offset &lt;value&gt;.    Default: 0
+  
+  Specifies the offset to apply to objid references incase you wish
+  to move between systems and the normal method of GMtime doesn't
+  seem to fully work.  It's not uncommon to have it off by 3600
+  seconds based on some system settings.
+  
+  This is only meaningful if you have objid_localtime set to '0'.
+  
+  See Also: objid_localtime.
+</PRE>
+<A HREF="#objid_localtime">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#offline_reg">[NEXT]</A>
 <BR>
 <HR><A NAME="offline_reg"><H3>offline_reg</H3></A><PRE>
@@ -12474,7 +16546,7 @@ Generated: Wed Jan 13 04:15:57 2016
   on when they can just create a character at will.
 
 </PRE>
-<A HREF="#oattr_uses_altname">[PREV]</A>
+<A HREF="#objid_offset">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#old_elist">[NEXT]</A>
 <BR>
@@ -12550,6 +16622,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="page"><H3>page</H3></A><PRE>
   Command: page[/port] &lt;player&gt; [=&lt;message&gt;] (royalty and higher only)
+  
   This command has the wizard only /port option which allows the paging
   to specific ports.  A non-connected port or non-existing port will return
   an error.  
@@ -12571,8 +16644,9 @@ Generated: Wed Jan 13 04:15:57 2016
     The 'port' function follows all standards of normal pages but will not
     kick off any reject, idle, or other page limited messages nor will it
     check against page locks.  Use with discretion.
-  
-  See Also: whisper, @pemit
+
+  See also: pagelock_notify, whisper, @pemit
+
 </PRE>
 <A HREF="#output_limit">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -12595,9 +16669,26 @@ Generated: Wed Jan 13 04:15:57 2016
   This toggle, when set on the target, will force them to evaluate the pagelock
   as if it was not overridden.  If the wizard involved is set NO_OVERRIDE or
   if the 'wiz_override' admin param is enabled, this toggle is disregarded.
+
+  See also: pagelock_notify
   
 </PRE>
 <A HREF="#page_cost">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#pagelock_notify">[NEXT]</A>
+<BR>
+<HR><A NAME="pagelock_notify"><H3>pagelock_notify</H3></A><PRE>
+  Config parameter: pagelock_notify &lt;yes/no&gt;.  Default: yes
+
+  This option can be used to enable or disable the automatic notification
+  to players on login about them having a PAGE LOCK set.
+
+  By default the message is enabled by default, but it can be useful to
+  disable this in case there is a softcode +command wrapper to manage
+  certain locks.
+
+</PRE>
+<A HREF="#pagelock toggle">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#paranoid_allocate">[NEXT]</A>
 <BR>
@@ -12611,7 +16702,7 @@ Generated: Wed Jan 13 04:15:57 2016
   freed is checked.
 
 </PRE>
-<A HREF="#pagelock toggle">[PREV]</A>
+<A HREF="#pagelock_notify">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#paranoid_exit_linking">[NEXT]</A>
 <BR>
@@ -12629,6 +16720,22 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#paranoid_allocate">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#parent_follow">[NEXT]</A>
+<BR>
+<HR><A NAME="parent_follow"><H3>parent_follow</H3></A><PRE>
+  Config parameter: parent_follow  &lt;yes/no&gt;.   Default: yes
+  
+  Specifies, that if you control the target, you get to see the entire parent
+  chain of the target with the parents() function.
+  
+  Note: Setting this to no (0) will return the default behavior of requiring
+        control of each parent in order to view it, which I found too 
+        restrictive.
+  
+  
+</PRE>
+<A HREF="#paranoid_exit_linking">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#parentable_control_lock">[NEXT]</A>
 <BR>
 <HR><A NAME="parentable_control_lock"><H3>parentable_control_lock</H3></A><PRE>
@@ -12637,7 +16744,7 @@ Generated: Wed Jan 13 04:15:57 2016
   Specifies whether or not @locks will be inheritable from their parents.
 
 </PRE>
-<A HREF="#paranoid_exit_linking">[PREV]</A>
+<A HREF="#parent_follow">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#partial_conn">[NEXT]</A>
 <BR>
@@ -12669,6 +16776,74 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#partial_conn">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#passapi_host">[NEXT]</A>
+<BR>
+<HR><A NAME="passapi_host"><H3>passapi_host</H3></A><PRE>
+  Config parameter: passapi_host &lt;!host&gt; &lt;host&gt; ... &lt;host&gt;
+  
+  This parameter takes the hostname and allows passing the max_lastsite_api
+  count value.  This does not allow bypassing forbidapi settings.
+  
+  Example:  @admin passapi_host=localhost
+  
+  See Also: passapi_site, @site
+   
+</PRE>
+<A HREF="#partial_deconn">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#passapi_site">[NEXT]</A>
+<BR>
+<HR><A NAME="passapi_site"><H3>passapi_site</H3></A><PRE>
+  Config parameter: passapi_site &lt;addr&gt; &lt;mask&gt;
+  
+  This parameter will bypass the site counter restriction for any site(s)
+  matching.  This will not bypass the forbidapi_site parameter, but only
+  bypasses the max_lastsite_api count value restriction.  This only effects
+  API connections.
+  
+  See Also: API, forbidapi_site, SITE LISTS, @site
+   
+</PRE>
+<A HREF="#passapi_host">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#passproxy_host">[NEXT]</A>
+<BR>
+<HR><A NAME="passproxy_host"><H3>passproxy_host</H3></A><PRE>
+  Config parameter: passproxy_host &lt;!host&gt; &lt;host&gt; ... &lt;host&gt;
+  
+  Indicates that connections matching the wildcard match of the specified
+  sites in their DNS HOST will be marked as bypassing automatic proxy
+  detection upon socket connection.  This works like 'passproxy_site' but deals
+  with DNS wildcard name conventions.  This will add or remove to existing or 
+  from existing site information already specified with passproxy_host.  You 
+  may use '!ALL' to clear the suspect host table.
+  
+  Example:  @admin passproxy_host=*.aol.com 
+            (bypasses proxy any site matching *.aol.com)
+            @admin passproxy_host=!ALL
+            (this clears the passproxy_host list)
+  
+  See Also:  forbid_host, register_host, noguest_host, noautoreg_host, 
+             validate_host, forbidapi_host, suspect_host, @site
+  
+  
+</PRE>
+<A HREF="#passapi_site">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#passproxy_site">[NEXT]</A>
+<BR>
+<HR><A NAME="passproxy_site"><H3>passproxy_site</H3></A><PRE>
+  Config parameter: passproxy_site &lt;addr&gt; &lt;mask&gt;
+  
+  Indicates that sites whose address matches the specified address when ANDed
+  with the mask are to be allowed through automated proxy detection.  This
+  proxy detection is enabled with the proxy_checker @admin config parameter.
+  
+  See Also: proxy_checker, @site, @admin, @list, SITE LISTS
+ 
+</PRE>
+<A HREF="#passproxy_host">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#paycheck">[NEXT]</A>
 <BR>
 <HR><A NAME="paycheck"><H3>paycheck</H3></A><PRE>
@@ -12680,7 +16855,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: @allowance, earn_limit, starting_money.
 
 </PRE>
-<A HREF="#partial_deconn">[PREV]</A>
+<A HREF="#passproxy_site">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#pcreate_paranoia">[NEXT]</A>
 <BR>
@@ -12743,6 +16918,23 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#pemit_far_players">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#penn_setq">[NEXT]</A>
+<BR>
+<HR><A NAME="penn_setq"><H3>penn_setq</H3></A><PRE>
+  Config parameter: penn_setq &lt;yes/no&gt;.   Default: no
+  
+  Enables setq/setr compatibility with PennMUSH.  This effectively allows
+  the use of:
+                  setq(label,blah) in addition to setq(1-9/a-z,blah)
+                  setr(label,blah) in addition to setr(1-9/a-z,blah)
+  
+  This effectively mimic's the Rhost built in setq(+,blah,label) option.
+  This will still allow the setq/setq with the + and ! options to work
+  as expected.
+
+</PRE>
+<A HREF="#penn_playercmds">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#penn_switches">[NEXT]</A>
 <BR>
 <HR><A NAME="penn_switches"><H3>penn_switches</H3></A><PRE>
@@ -12753,9 +16945,14 @@ Generated: Wed Jan 13 04:15:57 2016
   use the PENN method, then, like @switch, it will evaluate &lt; and &gt; as 
   a lessthan and greaterthan match conditionals.  The default is to have
   PENN compatibility disabled.
-
+  
+  The default behavior of this is to use integer math only.  If you wish
+  to allow floating point math, float_switches must also be enabled.
+  
+  See Also: float_switches
+  
 </PRE>
-<A HREF="#penn_playercmds">[PREV]</A>
+<A HREF="#penn_setq">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#permissions">[NEXT]</A>
 <BR>
@@ -12779,7 +16976,9 @@ Generated: Wed Jan 13 04:15:57 2016
     no_suspect    - Suspect players (SUSPECT bit) may not use this feature.
     no_guest      - Guest players (GUEST bit) may not use this feature.
     no_wanderer   - Wanderer players (WANDERER bit) may not use this feature.
+  
 { 'wizhelp permissions2' for more }
+
 </PRE>
 <A HREF="#penn_switches">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -12807,6 +17006,9 @@ Generated: Wed Jan 13 04:15:57 2016
     no_code       - The command is disabled from non-coders
     eval          - The function forces evaluation (useful for @function)
     no_eval       - The function forces non-evaluation (useful for @function)
+    bypass        - The function is ignored for sandbox()
+    noparse       - The function does not parse functions (but does subs)
+                    This will only work on @functions/@lfunctions
   
   Restrictions are normally additive (meaning that you must be a member of all
   required groups and not be a member of any excluded group).  The permissions
@@ -12828,7 +17030,8 @@ Generated: Wed Jan 13 04:15:57 2016
   with the mask.  This directive is typically used to enable connections from
   a few selected hosts or subnets that would otherwise be disallowed by a
   forbid_site directive.  The default is all sites permitted, none forbidden.
-  See Also: badsite_file, forbid_site, register_site, SITE LISTS.
+  See Also: badsite_file, forbid_site, register_site, forbidapi_site, 
+            SITE LISTS.
 
 </PRE>
 <A HREF="#permissions2">[PREV]</A>
@@ -13032,6 +17235,8 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#plushelp setup">[NEXT]</A>
 <BR>
 <HR><A NAME="plushelp setup"><H3>plushelp setup</H3></A><PRE>
+  Topic: PLUSHELP SETUP
+  
   The plushelp.txt file is set up like the news.txt file.  To see how this
   file is designed and updated, please refer to 'wizhelp news setup'.
 
@@ -13071,10 +17276,24 @@ Generated: Wed Jan 13 04:15:57 2016
   Config parameter: port &lt;port&gt;.  Default: 6250
   
   Specifies the IP port on which the game listens for new connections.
-  See Also: ip_address.
+  See Also: ip_address, api_port.
 
 </PRE>
 <A HREF="#plushelp_index">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#posesay_funct">[NEXT]</A>
+<BR>
+<HR><A NAME="posesay_funct"><H3>posesay_funct</H3></A><PRE>
+  Config parameter: posesay_funct &lt;yes/no&gt;.  Default: no
+  
+  Specifies if the SPEECH_PREFIX and SPEECH_SUFFIX attributes evaluate
+  functions.  As this could potentially be cpu intensive, by default this
+  is disabled.  If these attributes break cpu alerts, the cpu alerter
+  will stop it then set the attribute NO_COMMAND so it won't be 
+  processed again.
+  
+</PRE>
+<A HREF="#port">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#postdump_message">[NEXT]</A>
 <BR>
@@ -13086,7 +17305,23 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: @dump, dump_message.
 
 </PRE>
-<A HREF="#port">[PREV]</A>
+<A HREF="#posesay_funct">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#power api">[NEXT]</A>
+<BR>
+<HR><A NAME="power api"><H3>POWER API</H3></A><PRE>
+  Power argument: @power[/switch] &lt;user&gt;=[@g|@a|@c] api
+  
+  This power is set/removed with the @api command.  You may specify this
+  through the @power system as well.  This essentially is a toggle power
+  to empower the target from being able to use the API system.
+  
+  Without this power, API will not work on the target.
+  
+  See Also: @api
+  
+</PRE>
+<A HREF="#postdump_message">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#power boot">[NEXT]</A>
 <BR>
@@ -13099,7 +17334,7 @@ Generated: Wed Jan 13 04:15:57 2016
   Valid values are from guildmaster to councilor.
 
 </PRE>
-<A HREF="#postdump_message">[PREV]</A>
+<A HREF="#power api">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#power change_quotas">[NEXT]</A>
 <BR>
@@ -13217,6 +17452,56 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#power examine_full">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#power formatting">[NEXT]</A>
+<BR>
+<HR><A NAME="power formatting"><H3>POWER FORMATTING</H3></A><PRE>
+  Power argument: @power[/switch] &lt;user&gt;=[@g|@a|@c] formatting
+  
+  Unlike other @powers, this power IS NOT INHERITABLE.  However, unlike other
+  powers, this power works through parent trees.  This also works with
+  global parents via global_parent_room/thing/player/obj.
+  
+  This will follow the following chain to check for the FORMATTING power.
+  
+    self -&gt; @parent(s) -&gt; Global Parent -&gt; Zone(s)
+  
+  The NOGLOBPARENT @toggle will stop it inheriting the FORMATTING power from
+  any global parent.  
+  
+  The NOZONEPARENT @toggle will stop it inheriting the FORMATTING power from
+  any zone master.
+  
+  If it fails a @parent/lock check, it will not inherit the FORMATTING power
+  from that parent in question.  No lock means it automatically passes.
+     
+  This power will grant the target the ability to pass %0-%4 (respectively)
+  into the @conformat, @exitformat, and @darkexitformat container
+  formatters.  The substitutions are separated for each type of format.
+  
+  @conformat, @exitformat, @darkexitformat:
+      %0  -- The dbref list (space separated) that the enactor will have
+             seen normally by looking at the location.
+      %1  -- The name list (| separated) that will show the colorized
+             name, flags, altname, captions, and everything else that
+             they normally will have seen by looking.
+  
+  @exitformat, @darkexitformat
+      %2  -- The dbref list (space separated) of just the dark targets that
+             the enactor would normally have been able to see.
+      %3  -- The name list (| separated) that will show the colorized
+             name, flags, altname, and everything else that would normally
+             be seen with the dark targets that the enactor would normally
+             see.
+  
+  See Also: formats_are_local, format_contents, format_exits, 
+            global_parent_obj, global_parent_room, global_parent_thing,
+            global_parent_player
+  
+  See Normal Help on:  @conformat, @exitformat, @darkexitformat
+  
+</PRE>
+<A HREF="#power execscript">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#power free_page">[NEXT]</A>
 <BR>
 <HR><A NAME="power free_page"><H3>POWER FREE_PAGE</H3></A><PRE>
@@ -13228,7 +17513,7 @@ Generated: Wed Jan 13 04:15:57 2016
   this power.
 
 </PRE>
-<A HREF="#power execscript">[PREV]</A>
+<A HREF="#power formatting">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#power free_quota">[NEXT]</A>
 <BR>
@@ -13348,20 +17633,22 @@ Generated: Wed Jan 13 04:15:57 2016
   
   There are various powers available to be set with @power.  These are:
   
-   CHANGE_QUOTAS   CHOWN_ANYWHERE *CHOWN_ME       *WIZ_WHO
-  *CHOWN_OTHER    *EXAMINE_ALL    *NOFORCE         SEE_QUEUE_ALL
-   FREE_QUOTA     *GRAB_PLAYER    *JOIN_PLAYER     LONG_FINGERS
-  *NO_BOOT        *BOOT           *STEAL          *SEE_QUEUE
-  *TEL_ANYWHERE   *TEL_ANYTHING   *STAT_ANY        PCREATE
-   FREE_WALL       FREE_PAGE      *HALT_QUEUE      HALT_QUEUE_ALL
-  *NOKILL         *SEARCH_ANY     *SECURITY       *WHO_UNFIND
-  *WRAITH          SHUTDOWN       *PURGE          *HIDEBIT
-   NOWHO           EXAMINE_FULL   FULLTEL         *EXECSCRIPT
+    API            *BOOT            CHANGE_QUOTAS     CHOWN_ANYWHERE 
+   *CHOWN_ME       *CHOWN_OTHER    *EXAMINE_ALL       EXAMINE_FULL     
+   *EXECSCRIPT      FREE_QUOTA      FORMATTING        FREE_PAGE       
+    FREE_WALL       FULLTEL        *GRAB_PLAYER      *HALT_QUEUE      
+    HALT_QUEUE_ALL *HIDEBIT        *JOIN_PLAYER       LONG_FINGERS   
+    MONITORAPI     *NO_BOOT        *NOFORCE          *NOKILL          
+    NOWHO           PCREATE        *PURGE            *SEARCH_ANY   
+   *SECURITY       *SEE_QUEUE       SEE_QUEUE_ALL     SHUTDOWN     
+   *STAT_ANY       *STEAL          *TEL_ANYWHERE     *TEL_ANYTHING
+   *WHO_UNFIND      WIZ_IDLE       *WIZ_SPOOF        *WIZ_WHO        
+   *WRAITH        
   
   Any powers with a '*' beside it can be power-defined from COUNCILOR 
   down to GUILDMASTER.
 
-  Help is available seperately to explain what each power does by typing:
+  Help is available separately to explain what each power does by typing:
       wizhelp power &lt;power&gt;
 
 </PRE>
@@ -13382,6 +17669,21 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#power list">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#power monitorapi">[NEXT]</A>
+<BR>
+<HR><A NAME="power monitorapi"><H3>POWER MONITORAPI</H3></A><PRE>
+  Power argument: @power[/switch] &lt;user&gt;=[@g|@a|@c] monitorapi
+  
+  This is a filter @power that if set will monitor all API connections
+  to the mush.  This filter was created because it can get VERY VERY
+  spammy.  Upwards to hundreds of connections a minute spammy.
+  But hey, it's useful so it's in here.
+  
+  See Also: MONITOR
+  
+</PRE>
+<A HREF="#power long_fingers">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#power no_boot">[NEXT]</A>
 <BR>
 <HR><A NAME="power no_boot"><H3>POWER NO_BOOT</H3></A><PRE>
@@ -13393,7 +17695,7 @@ Generated: Wed Jan 13 04:15:57 2016
   level, no one councilor powered or lower could @boot them.
 
 </PRE>
-<A HREF="#power long_fingers">[PREV]</A>
+<A HREF="#power monitorapi">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#power noforce">[NEXT]</A>
 <BR>
@@ -13405,6 +17707,8 @@ Generated: Wed Jan 13 04:15:57 2016
   bit level and lower.  For instance, if I set the NOFORCE power
   at councilor level, no one up to and including councilors can
   @force that user or their belongings to do things.
+  
+  This also impacts @sudo.
 
 </PRE>
 <A HREF="#power no_boot">[PREV]</A>
@@ -13529,6 +17833,8 @@ Generated: Wed Jan 13 04:15:57 2016
   the command line.  Royalty and higher can still @force someone
   powered to shutdown, though it's sorta meaningless since they
   can @shutdown themselves.
+  
+  This also impacts @sudo.
 
 </PRE>
 <A HREF="#power see_queue_all">[PREV]</A>
@@ -13604,6 +17910,30 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#power tel_anywhere">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#power wiz_idle">[NEXT]</A>
+<BR>
+<HR><A NAME="power wiz_idle"><H3>POWER WIZ_IDLE</H3></A><PRE>
+  Power argument: @power[/switch] &lt;user&gt;=[@g|@a|@c] wiz_idle
+  
+  This power grants the target player the ability to use the enhanced
+  idle features normally allowable only to wizards.
+ 
+</PRE>
+<A HREF="#power who_unfind">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#power wiz_spoof">[NEXT]</A>
+<BR>
+<HR><A NAME="power wiz_spoof"><H3>POWER WIZ_SPOOF</H3></A><PRE>
+  Power argument: @power[/switch] &lt;user&gt;=[@g|@a|@c] wiz_spoof
+  
+  This power grants the target the ability to spoof as if they were a wizard.
+  The SPOOF flag overrides this @power
+  
+  See Also: SPOOF
+ 
+</PRE>
+<A HREF="#power wiz_idle">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#power wiz_who">[NEXT]</A>
 <BR>
 <HR><A NAME="power wiz_who"><H3>POWER WIZ_WHO</H3></A><PRE>
@@ -13618,7 +17948,7 @@ Generated: Wed Jan 13 04:15:57 2016
   private information, be strict with the use of this power.
 
 </PRE>
-<A HREF="#power who_unfind">[PREV]</A>
+<A HREF="#power wiz_spoof">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#power wraith">[NEXT]</A>
 <BR>
@@ -13677,7 +18007,11 @@ Generated: Wed Jan 13 04:15:57 2016
   If enabled, then non-players will be checked for @powers and @depowers in
   addition to the owner.  The higher power (for @power) or harsher restriction
   (for @depower) between the two will be chosen.
-
+  
+  This is required for the @api command and the API subsystem to function.
+  
+  See Also: @api
+  
 </PRE>
 <A HREF="#power_access">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -13708,6 +18042,66 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#prog toggle">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#protect_addenh">[NEXT]</A>
+<BR>
+<HR><A NAME="protect_addenh"><H3>protect_addenh</H3></A><PRE>
+  Config parameter: protect_addenh &lt;boolean&gt;.  Default: 0
+  
+  If enabled, allows @protect/add to be given an argument to add names to and
+  not just the current player's name.
+  
+</PRE>
+<A HREF="#prog_on_connect toggle">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#proxy setup">[NEXT]</A>
+<BR>
+<HR><A NAME="proxy setup"><H3>PROXY SETUP</H3></A><PRE>
+  RhostMUSH allows you to do site redefinition for proxy connections like
+  SCONNECT or similar site redirection software.  This allows you to use
+  external applications to use SSL/TLS connections to then connect to the
+  mush for encrypted or even high availability or load balanced connections
+  to the mush itself.
+  
+  To enable and allow proxy redefinition of sites for connections you must
+  configure the capability to do so.  This is only used for the connect
+  screen and can not be used for already connected players.  This is only
+  relevant for the current connection of that player.
+  
+  The following parameters are used to handle the PROXY connections.
+  
+    sconnect_reip    -- This is a toggle that must be enabled to allow
+                        the re-definition of the site the connection is
+                        using.
+  
+                        Syntax:  sconnect_reip 1
+  
+    sconnect_host    -- This is the host list of what hosts are allowed
+                        to issue a re-definition of the currently connected
+                        host.  If this is not set, it will default to
+                        localhost only.  Any sites that are not allowed
+                        that manage to issue the redefinition command will
+                        be logged accordingly.  This allows wildcarding.
+  
+                        Syntax: sconnect_host *.comcast.com localhost
+  
+    sconnect_cmd     -- The command (case sensitive) that is used to 
+                        specify the new ip/dns address for that connected
+                        session only.  
+  
+                        Syntax: sconnect_cmd Pr0xY 
+  
+  Assuming that the sconnect_cmd is 'Pr0xY' as above Syntax example, at
+  connect screen you would type:
+    Pr0xY mynewsite.com
+  
+  This will reassign your displayed site as 'mynewsite.com' if the site
+  you are really connected from matches the allowable sites to do so.
+  
+  See Also: sconnect_reip, sconnect_host, sconnect_cmd
+
+</PRE>
+<A HREF="#protect_addenh">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#proxy_checker">[NEXT]</A>
 <BR>
 <HR><A NAME="proxy_checker"><H3>proxy_checker</H3></A><PRE>
@@ -13731,9 +18125,15 @@ Generated: Wed Jan 13 04:15:57 2016
   positives, issuing option 2 or 4 (or an option of 6 which combines them)
   can effectively block innocent players.  The option however, is there
   anyway.
+  
+  You may use the @admin site restrictions 'passproxy_site' and 
+  'passproxy_host' to set up site restrictions that automatically bypass
+  these proxy checks.
+  
+  See Also: passproxy_site, passproxy_host, @site, @admin
 
 </PRE>
-<A HREF="#prog_on_connect toggle">[PREV]</A>
+<A HREF="#proxy setup">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#public_flags">[NEXT]</A>
 <BR>
@@ -13742,7 +18142,9 @@ Generated: Wed Jan 13 04:15:57 2016
   
   If enabled, indicates that players may get the flags of any object with the
   flags() function call.  Otherwise, they may only get the flags for objects
-  that are examinable by them.
+  that are examinable by them.  This parameter also affects ltoggles() and
+  the like as well.
+  
   See Also: flags().
 
 </PRE>
@@ -13996,7 +18398,7 @@ Generated: Wed Jan 13 04:15:57 2016
   
   You may use '@list rlevel' to see the current realities.
   
-  See Also: @txlevel, @rxlevel, @list rlevel, reality_levels
+  See Also: @txlevel, @rxlevel, @leveldefault, @list rlevel, reality_levels
   Normal Help: txlevel(), rxlevel(), hastxlevel(), hasrxlevel(), listrlevels()
             
 
@@ -14051,6 +18453,7 @@ Generated: Wed Jan 13 04:15:57 2016
   a reality lock.  If enabled, the target must be @toggled CHKREALITY so
   that the target knows that any UserLock that is on it will be used as
   a reality level lock enhancement.  Otherwise, without this toggle, the
+  USER lock behaves as expected.
   
   See Also: reality_level, @list rlevel, rxlevel(), txlevel(), reality_locktype
   Normal Help: chkreality()
@@ -14161,7 +18564,7 @@ Generated: Wed Jan 13 04:15:57 2016
          the raw site information that you can use to remove the site.
   
   See Also:  forbid_host, suspect_host, noguest_host, noautoreg_host, 
-             validate_host, @site
+             validate_host, forbidapi_host, @site
 
 </PRE>
 <A HREF="#register_create_file">[PREV]</A>
@@ -14173,7 +18576,8 @@ Generated: Wed Jan 13 04:15:57 2016
   
   Indicates that registration is to be enforced for sites whose address
   matches the specified address when ANDed with the mask.
-  See Also: forbid_site, noguest_site, permit_site, REGISTRATION, SITE LISTS.
+  See Also: forbid_site, forbidapi_site, noguest_site, permit_site, 
+            REGISTRATION, SITE LISTS.
 
 </PRE>
 <A HREF="#register_host">[PREV]</A>
@@ -14637,14 +19041,17 @@ Generated: Wed Jan 13 04:15:57 2016
   Config parameter: safer_passwords &lt;yes/no&gt;.  Default: no
   
   This parameter will enforce harder passwords to be set.  When enabled, all
-  new passwords will have to be at least 5 characters long, have at least one
-  lowercase and uppercase letter, and require a special character which is
-  non-alphanumeric or ', or -.
+  new passwords will have to be at least 5 (for DES) or 14 (for SHA512)  
+  characters long, have at least one lowercase and uppercase letter, and 
+  require a special character which is non-alphanumeric or ', or -.
   
   DES passwords are 8 characters or less.
   
   SHA512 passwords (default) are 160 characters or less.
   
+  Both passwords will use a simplistic entropy check that enforces non
+  sequential passwords of uniqueness.
+ 
   Note:  Guest players still are allowed 'guest' as their password.
 
 </PRE>
@@ -14653,7 +19060,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#safer_ufun">[NEXT]</A>
 <BR>
 <HR><A NAME="safer_ufun"><H3>safer_ufun</H3></A><PRE>
-  Config parameter: safer_ufun &lt;yes/no&gt;.  Default: o
+  Config parameter: safer_ufun &lt;yes/no&gt;.  Default: no
   
   If this is enabled, then any attribute that is evaluated on something that
   you do not control will be evaluated either at your level or the object
@@ -14675,6 +19082,69 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#safer_ufun">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#sconnect_cmd">[NEXT]</A>
+<BR>
+<HR><A NAME="sconnect_cmd"><H3>sconnect_cmd</H3></A><PRE>
+  Config parameter: sconnect_cmd &lt;string&gt;.   Default: (NULL)
+  
+  This will specify the special command that will allow changing the 
+  percevied hostname of the currently connected socket.  This is intended
+  to be used with SCONNECT or similar SSL proxy software to change the
+  IP address of the incoming connection.  The command is CASE SENSITIVE
+  and can be up to 31 characters long.  It is strongly recommended to
+  make this something hard to guess, long, and randomized.
+  
+  Only sites that match the sconnect_host parameter will be able to
+  be matched against this command.  If sconnect_host is not set to
+  anything it will default to localhost.
+  
+  Sites that manage to figure out your sconnect cmd will cause SSL 
+  connectivity to be disabled as it does this for DoS/intrusion protection. 
+  
+  Only sites that pass sconnect_host can attempt to issue your
+  unique key for SCONNECT.
+   
+  This requires sconnect_reip to be enabled.
+  
+  See Also: sconnect_host, sconnect_reip
+
+</PRE>
+<A HREF="#scloak">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#sconnect_host">[NEXT]</A>
+<BR>
+<HR><A NAME="sconnect_host"><H3>sconnect_host</H3></A><PRE>
+  Config parameter: sconnect_host &lt;host(s)&gt;   Default: localhost
+  
+  This specifies the hosts that you wish to be allowed to use
+  the sconnect_cmd command to remap what the displayed IP/DNS
+  address that the connected player is coming from.  This is
+  intended for SCONNECT or proxy connections where you wish
+  to hard-set the real IP of where they are coming from.
+  
+  See Also: sconnect_cmd, sconnect_reip 
+  
+</PRE>
+<A HREF="#sconnect_cmd">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#sconnect_reip">[NEXT]</A>
+<BR>
+<HR><A NAME="sconnect_reip"><H3>sconnect_reip</H3></A><PRE>
+  Config parameter: sconnect_reip &lt;on/off&gt;    Default: off (0)
+  
+  This will enable the ability to use SCONNECT re-iping of the
+  currently connected descriptor.  If this is enabled, then the
+  command matching 'sconnect_cmd' will be used to specify the new
+  IP/DNS address you wish displayed for that currenct connection.
+  
+  This is intended for SCONNECT or similar proxy connections to
+  the mush.
+  
+  See Also: sconnect_cmd, sconnect_host
+
+</PRE>
+<A HREF="#sconnect_host">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#search criteria">[NEXT]</A>
 <BR>
 <HR><A NAME="search criteria"><H3>SEARCH CRITERIA</H3></A><PRE>
@@ -14691,7 +19161,7 @@ Generated: Wed Jan 13 04:15:57 2016
               the invoking player is a wizard.
 { 'wizhelp search criteria2' for more }
 </PRE>
-<A HREF="#scloak">[PREV]</A>
+<A HREF="#sconnect_reip">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#search criteria2">[NEXT]</A>
 <BR>
@@ -14838,6 +19308,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="session"><H3>SESSION</H3></A><PRE>
   Command: SESSION &lt;prefix&gt;
+  
   The SESSION command displays character input and output information for
   all connected players, or just those who match &lt;prefix&gt;.
  
@@ -14864,6 +19335,27 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#see_suspect toggle">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#sha2rounds">[NEXT]</A>
+<BR>
+<HR><A NAME="sha2rounds"><H3>sha2rounds</H3></A><PRE>
+  Config parameter: sha2rounds &lt;value&gt;.    Default: 5000
+  
+  This specifies the rounds of recursion that the SHA2 encryption for
+  passwords will use when encrypting passwords.  Please be aware that
+  this is arthremetically expensive and the larger the value the longer
+  it takes to both encrypt and decrypt passwords.  5000 is generally
+  considered safe and is actually the default standard for UNIX system
+  passwords for the Linux archtype.
+  
+  If you're paranoid you may set a higher range, up to 999999.
+  
+  This requires GLIBC 2.7 or higher.  If you do not have the right
+  version of GLIBC it will fall back to the much less secure, but
+  viable DES encryption method.
+ 
+</PRE>
+<A HREF="#session">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#showother_altname">[NEXT]</A>
 <BR>
 <HR><A NAME="showother_altname"><H3>showother_altname</H3></A><PRE>
@@ -14874,7 +19366,7 @@ Generated: Wed Jan 13 04:15:57 2016
   has that is toggled WORN or WIELDED will show up as Equipment.
 
 </PRE>
-<A HREF="#session">[PREV]</A>
+<A HREF="#sha2rounds">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#shs_reverse">[NEXT]</A>
 <BR>
@@ -14902,23 +19394,28 @@ Generated: Wed Jan 13 04:15:57 2016
   of keywords (i.e. OPEN SET CREATE) or through the use of a bitmask.
   
   The following is a list of keywords and their bitmask equivalents:
+#define SIDE_EXECSCRIPT  0x04000000 /* execscript() sideeffect */
+#define SIDE_ZONE        0x08000000 /* zone() sideeffect function */
+#define SIDE_LSET        0x10000000 /* lset() sideeffect function */
+#define SIDE_TOTEMSET    0x20000000 /* totemset() sideeffect function */
+
   
   none    - 0    OPEN    - 128    WIPE     - 32768    MOVE       - 8388608
   SET     - 1    EMIT    - 256    DESTROY  - 65536    CLUSER_ADD - 16777216
   CREATE  - 2    OEMIT   - 512    ZEMIT    - 131072   MAILSEND   - 33554432
-  LINK    - 4    CLONE   - 1024   NAME     - 262144
-  PEMIT   - 8    PARENT  - 2048   TOGGLE   - 524288
-  TEL     - 16   LOCK    - 4096   TXLEVEL  - 1048576
-  LIST    - 32   LEMIT   - 8192   RXLEVEL  - 2097152
+  LINK    - 4    CLONE   - 1024   NAME     - 262144   EXECSCRIPT - 67108864
+  PEMIT   - 8    PARENT  - 2048   TOGGLE   - 524288   ZONE       - 134217728
+  TEL     - 16   LOCK    - 4096   TXLEVEL  - 1048576  LSET       - 268435456
+  LIST    - 32   LEMIT   - 8192   RXLEVEL  - 2097152  TOTEMSET   - 536870912
   DIG     - 64   REMIT   - 16384  RSET     - 4194304
      
   To enable both SET and OPEN using a bitmask you would set the value
   to '129' (128 + 1).
   
-  To enable all of MUX's side-effects:  131135    (or keyword MUX)
-  To enable all of PENN's side-effects: 458719    (or keyword PENN)
-  To enable all side-effects:           16777215  (or keyword ALL)
-  To disable all side-effects:          0         (or keyword NONE)
+  To enable all of MUX's side-effects:  131135     (or keyword MUX)
+  To enable all of PENN's side-effects: 458719     (or keyword PENN)
+  To enable all side-effects:           1073741823 (or keyword ALL)
+  To disable all side-effects:          0          (or keyword NONE)
   
   When specifying sideeffects using keywords, the '!' operand can be
   used to negate a given sideeffect (i.e. !OPEN)
@@ -15014,15 +19511,15 @@ Generated: Wed Jan 13 04:15:57 2016
                 originated.  Retrying the failed operation should produce
                 a coredump, although the stack may or may not be readable.
   
-  See Also: @admin, signal, signal_object, signal_object_type, signal_cron
+  See Also: @admin, signal, signal_object, signal_object_type, signal_crontab
 
 </PRE>
 <A HREF="#sidefx_returnval">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
-<A HREF="#signal_cron">[NEXT]</A>
+<A HREF="#signal_crontab">[NEXT]</A>
 <BR>
-<HR><A NAME="signal_cron"><H3>signal_cron</H3></A><PRE>
-  Config parameter: signal_cron &lt;bool&gt;  Default: no (0)
+<HR><A NAME="signal_crontab"><H3>signal_crontab</H3></A><PRE>
+  Config parameter: signal_crontab &lt;bool&gt;  Default: no (0)
   
   This parameter specifies if you load in a predefined 'cron' file at the
   signal.  This is useful for tying in outside mush processing into the
@@ -15075,10 +19572,11 @@ Generated: Wed Jan 13 04:15:57 2016
     # kill -SIGUSR1 1234
     I've been rebooted! (seen in room #0)
   
-  See Also: config parameters, signals, @admin, signal_object_type, signal_cron
+  See Also: config parameters, signals, @admin, signal_object_type,
+            signal_crontab
 
 </PRE>
-<A HREF="#signal_cron">[PREV]</A>
+<A HREF="#signal_crontab">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#signal_object_type">[NEXT]</A>
 <BR>
@@ -15093,7 +19591,7 @@ Generated: Wed Jan 13 04:15:57 2016
   question is immortal (or even #1 owned) and can not be modified by anyone
   outside your circle of trust.
   
-  See Also: config parameters, signals, @admin, signal_object, signal_cron
+  See Also: config parameters, signals, @admin, signal_object, signal_crontab
 
 </PRE>
 <A HREF="#signal_object">[PREV]</A>
@@ -15106,14 +19604,15 @@ Generated: Wed Jan 13 04:15:57 2016
   RhostMUSH will react to given signals sent from the unix command line.
   The following signals are available:
   
-         SIGUSR1   - Force a reboot of the server.  This can be reconfigured
-                     to a custom behavior with the signal_object config 
-                     parameter.  The type of execution is handled with the
-                     signal_object_type config parameter.
-         SIGUSR2   - Force a shutdown of the server.
+         SIGUSR1   - Force a reboot (@reboot) of the server.  This can be 
+                     reconfigured to a custom behavior with the signal_object 
+                     config parameter.  The type of execution is handled with 
+                     the signal_object_type config parameter.
+         SIGUSR2   - Force a shutdown (@shutdown) of the server.
          SIGTERM   - Force an IMMEDIATE shutdown of the server.
                      This attempts to dump a flatfile then immediately closes
-                     the game WITHOUT saving to the database.
+                     the game WITHOUT saving to the database.  
+         SIGHUP    - Force a flatfile (@dump/flat) on the system.
                      
   See Also: config parameters, signal_object, signal_object_type
 
@@ -15182,8 +19681,10 @@ Generated: Wed Jan 13 04:15:57 2016
   for those sites), while people connecting from elsewhere on the 135.246
   net are allowed to create their own characters.
  
-  See Also: @admin, @list site_information, forbid_site, permit_site,
-            register_site, suspect_site, trust_site, noguest_site.
+  See Also: @admin, @list site_information, forbid_site, forbidapi_site, 
+            permit_site, register_site, suspect_site, trust_site, 
+            noguest_site, passapi_site
+
 </PRE>
 <A HREF="#site lists">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
@@ -15222,6 +19723,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="slay"><H3>slay</H3></A><PRE>
   Command: slay &lt;player/object&gt;
+  
   Kills the indicated player or object without paying any insurance to the
   victim.  It should be used in places where suicide should not be rewarded.
   
@@ -15232,6 +19734,95 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#slave">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#snoop">[NEXT]</A>
+<BR>
+<HR><A NAME="snoop"><H3>snoop</H3></A><PRE>
+  Command: @snoop[/switch] &lt;target&gt; [=&lt;owner&gt;]
+  
+  See 'snoop history' on reasons for adding this.
+   
+  Note: By adding -DNO_SNOOP to your compile options you can disable @snoop
+        entirely, but this capability exists with @hooking and many other
+        softcode alternatives.  This just is an all-in-one tool for it that
+        allows game owners much better accountability of its use.
+  
+  This can only be ran by IMMORTALS or by #1.  This is a hardcoded limitation.
+  
+  The @snoop command is a monitoring and administrative tool that connects a
+  port listener to the player's descriptor.  Once connected, anything that
+  the target player sees, does, or interacts with is passed along to the
+  watchers who are tagged to montior this user.
+  
+  A player disconnecting automatically turns off the snoop process.  You may
+  optionally set up a log monitoring that can be automated.
+  
+  The following switches exist:
+    /on       -- This is the default switch.  It turns on snooping on the
+                 specific target.
+    /off      -- This turns off all logging on the target, including file
+                 logging.
+    /log      -- Specify that it should make a file log of the target
+                 player.  All logs are timestamped.  The filename will be
+                 snoop&lt;dbref&gt;.txt located in your 'game' directory.
+   /status    -- Show status of all currently active @snoops.
+  
+  Examples: (Assume player Troll is dbref #123)
+    &gt; @snoop Troll            (online monitoring of Troll player)
+    &gt; @snoop Troll=Wizard     (online monitoring of Troll to player Wizard)
+    &gt; @snoop/off Troll        (disable monitoring of Troll player)
+    &gt; @snoop/off Troll=Wizard (disable monitoring of Troll from player wizard)
+    &gt; @snoop/log Troll        (logs in 'game' to snoop123.txt)
+    &gt; @snoop/status           (shows all current active snoops)
+  
+  See Also: @hook, SUSPECT, LOGROOM TOGGLE, log_command_list 
+  
+</PRE>
+<A HREF="#slay">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#snoop history">[NEXT]</A>
+<BR>
+<HR><A NAME="snoop history"><H3>snoop history</H3></A><PRE>
+  Topic: SNOOP HISTORY
+  
+  Snoop was part of the lpmud/diku/mud engine since the late 1980's.  Due to 
+  various moral convictions and security paranoia of various admins, it was 
+  improved upon or deleted out of codebases over the years.  
+  
+  RhostMUSH was one of those that decided to improve upon the feature set and
+  had it added since RhostMUSH's conception in 1989 and improved upon it in
+  1992 during a surge of Trolls and people attempting to hack and damage
+  mushes.
+  
+  At this time there is not nor will be any effort to removing @snoop.
+  It's here, and it's here for life.  We have, however, put in a 
+  method in the hardcode to hard-remove the feature from the codebase at
+  compile time for anyone who feels this violates their beliefs.  We, again,
+  try to be open to everyone's ideals of how they want to run their mush.
+  
+  To date, the snooping ability exists in many main-stream games that are
+  paid for by their playerbase, included, but not limited to Runescape, 
+  World of Warcraft, Everquest, and others.
+  
+  Every MUSH, from TinyMUSH, PennMUSH, MUX, and others allow, through
+  softcode, the ability to duplicate nearly every aspect of @snoop as it
+  stands, including, but not limited to monitoring pages, whispers, all
+  commands entered, all output of all commands, and so forth.  Disabling
+  @snoop does not disable an admin's capability to monitor everything 
+  a player does on the mush.
+  
+  What @snoop does allow is an all-in-one tool that makes it so the staff
+  no longer are required to softcode an alternative tool, which opens up
+  avenues of poorly coded softcode to be accessed by normal players to
+  infiltrate a game.  @snoop gives the staff absolute control of auditing
+  of who uses the command and what goes on their game.  It's a tool,
+  nothing more.
+  
+  We leave it up to each game maintainer to allow or disallow its use
+  within its game.  We provide the tools, not the use-case of using it. 
+  
+</PRE>
+<A HREF="#snoop">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#snuffdark toggle">[NEXT]</A>
 <BR>
 <HR><A NAME="snuffdark toggle"><H3>SNUFFDARK TOGGLE</H3></A><PRE>
@@ -15241,7 +19832,7 @@ Generated: Wed Jan 13 04:15:57 2016
   see by default.
 
 </PRE>
-<A HREF="#slay">[PREV]</A>
+<A HREF="#snoop history">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#space_compress">[NEXT]</A>
 <BR>
@@ -15311,6 +19902,36 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#spam_objmsg">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#special attribs">[NEXT]</A>
+<BR>
+<HR><A NAME="special attribs"><H3>SPECIAL ATTRIBS</H3></A><PRE>
+  There are special attributes you can set on objects that will have
+  special notation based on the purpose.  
+  
+  Currently, the following exist:
+    _NOPOSSESS_MSG    -- When set on a player will give a customized message
+                         upon triggering the event.  This is used with the
+                         NOPOSSESS flag.
+            Arguments Allowed:
+              %0 - Numerical Site/Host
+              %1 - DNS Site/Host Name
+              %2 - Port of connection
+              %3 - Player dbref# or '#-1' if no valid player.
+                       
+    _NOCONNECT_MSG    -- When set on a player will give a customized message
+                         upon triggering the event.  This is used with the
+                         NOCONNECT flag.
+            Arguments Allowed:
+              %0 - Numerical Site/Host
+              %1 - DNS Site/Host Name
+              %2 - Port of connection
+              %3 - Player dbref# or '#-1' if no valid player.
+  
+  See Also: file_object, NOPOSSESS, NOCONNECT
+
+</PRE>
+<A HREF="#spammonitor">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#spoof">[NEXT]</A>
 <BR>
 <HR><A NAME="spoof"><H3>SPOOF</H3></A><PRE>
@@ -15322,7 +19943,7 @@ Generated: Wed Jan 13 04:15:57 2016
   This flag is inheritable to the target's belongings.
 
 </PRE>
-<A HREF="#spammonitor">[PREV]</A>
+<A HREF="#special attribs">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#sqlite_db_path">[NEXT]</A>
 <BR>
@@ -15350,6 +19971,55 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#sqlite_db_path">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#ssl setup">[NEXT]</A>
+<BR>
+<HR><A NAME="ssl setup"><H3>SSL SETUP</H3></A><PRE>
+  RhostMUSH allows you to do site redefinition for proxy connections like
+  SCONNECT or similar site redirection software.  This allows you to use
+  external applications to use SSL/TLS connections to then connect to the
+  mush for encrypted or even high availability or load balanced connections
+  to the mush itself.
+  
+  To enable and allow proxy redefinition of sites for connections you must
+  configure the capability to do so.  This is only used for the connect
+  screen and can not be used for already connected players.  This is only
+  relevant for the current connection of that player.
+  
+  The following parameters are used to handle the PROXY connections.
+  
+    sconnect_reip    -- This is a toggle that must be enabled to allow
+                        the re-definition of the site the connection is
+                        using.
+  
+                        Syntax:  sconnect_reip 1
+  
+    sconnect_host    -- This is the host list of what hosts are allowed
+                        to issue a re-definition of the currently connected
+                        host.  If this is not set, it will default to
+                        localhost only.  Any sites that are not allowed
+                        that manage to issue the redefinition command will
+                        be logged accordingly.  This allows wildcarding.
+  
+                        Syntax: sconnect_host *.comcast.com localhost
+  
+    sconnect_cmd     -- The command (case sensitive) that is used to 
+                        specify the new ip/dns address for that connected
+                        session only.  
+  
+                        Syntax: sconnect_cmd Pr0xY 
+  
+  Assuming that the sconnect_cmd is 'Pr0xY' as above Syntax example, at
+  connect screen you would type:
+    Pr0xY mynewsite.com
+  
+  This will reassign your displayed site as 'mynewsite.com' if the site
+  you are really connected from matches the allowable sites to do so.
+  
+  See Also: sconnect_reip, sconnect_host, sconnect_cmd
+
+</PRE>
+<A HREF="#sqlite_query_limit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#stack_limit">[NEXT]</A>
 <BR>
 <HR><A NAME="stack_limit"><H3>stack_limit</H3></A><PRE>
@@ -15361,7 +20031,7 @@ Generated: Wed Jan 13 04:15:57 2016
   attempts are sent through MONITOR_CPU and logged.
 
 </PRE>
-<A HREF="#sqlite_query_limit">[PREV]</A>
+<A HREF="#ssl setup">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#start_build">[NEXT]</A>
 <BR>
@@ -15440,6 +20110,76 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#status_file">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#string_conn">[NEXT]</A>
+<BR>
+<HR><A NAME="string_conn"><H3>string_conn</H3></A><PRE>
+  Config parameter: string_conn &lt;string&gt;.  Default: connect
+  
+  This parameter specifies the string that will match the 'connect' [co] 
+  string that players need to type to connect to their player.
+  
+  See Also: string_conndark, string_connhide, string_create, string_register,
+            connect_methods
+
+</PRE>
+<A HREF="#stop">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#string_conndark">[NEXT]</A>
+<BR>
+<HR><A NAME="string_conndark"><H3>string_conndark</H3></A><PRE>
+  Config parameter: string_conndark &lt;string&gt;.  Default: cdark
+  
+  This parameter specifies the string that will match the 'cdark' [cd] 
+  string that players need to type to connect DARK to their player.
+  
+  See Also: string_conn, string_connhide, string_create, string_register,
+            connect_methods
+
+</PRE>
+<A HREF="#string_conn">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#string_connhide">[NEXT]</A>
+<BR>
+<HR><A NAME="string_connhide"><H3>string_connhide</H3></A><PRE>
+  Config parameter: string_connhide &lt;string&gt;.  Default: chide
+  
+  This parameter specifies the string that will match the 'chide' [ch] 
+  string that players need to type to connect @hidden to their player.
+  
+  See Also: string_conn, string_conndark, string_create, string_register,
+            connect_methods
+
+</PRE>
+<A HREF="#string_conndark">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#string_create">[NEXT]</A>
+<BR>
+<HR><A NAME="string_create"><H3>string_create</H3></A><PRE>
+  Config parameter: string_create &lt;string&gt;.  Default: create
+  
+  This parameter specifies the string that will match the 'create' [cr] 
+  string that players need to type to create a new player.
+  
+  See Also: string_conn, string_conndark, string_connhide, string_register,
+            connect_methods
+
+</PRE>
+<A HREF="#string_connhide">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#string_register">[NEXT]</A>
+<BR>
+<HR><A NAME="string_register"><H3>string_register</H3></A><PRE>
+  Config parameter: string_register &lt;string&gt;.  Default: register
+  
+  This parameter specifies the string that will match the 'register' [reg] 
+  string that players need to type to do connect screen email registration.
+  
+  See Also: string_conn, string_conndark, string_connhide, string_create,
+            connect_methods
+
+</PRE>
+<A HREF="#string_create">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#sub_include">[NEXT]</A>
 <BR>
 <HR><A NAME="sub_include"><H3>sub_include</H3></A><PRE>
@@ -15487,7 +20227,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: sub_override, @hook, hook_obj, HOOK SETUP
 
 </PRE>
-<A HREF="#stop">[PREV]</A>
+<A HREF="#string_register">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#sub_override">[NEXT]</A>
 <BR>
@@ -15514,7 +20254,7 @@ Generated: Wed Jan 13 04:15:57 2016
     %s ----    32     (0x00000020)    |  %k ---- 16384     (0x00004000)
     %o ----    64     (0x00000040)    |  %w ---- 32768     (0x00008000)
     %p ----   128     (0x00000080)    |  %m ---- 65536     (0x00010000)
-    %a ----   256     (0x00000100)    |
+    %a ----   256     (0x00000100)    |  %: ----131072     (0x00020000)
   ----------------------------------------------------------------------------
   
   You would add the values together and apply to the sub_override 'bitmask'
@@ -15550,7 +20290,7 @@ Generated: Wed Jan 13 04:15:57 2016
     %s ----           SUB_S           |  %k ----           SUB_K
     %o ----           SUB_O           |  %w ----           SUB_W
     %p ----           SUB_P           |  %m ----           SUB_M
-    %a ----           SUB_A           |
+    %a ----           SUB_A           |  %: ----           SUB_COLON
   ----------------------------------------------------------------------------
   
   If the hook object (@admin hook_obj) is NOT defined, or if the attribute 
@@ -15625,7 +20365,7 @@ Generated: Wed Jan 13 04:15:57 2016
             (this clears the suspect_host list)
   
   See Also:  forbid_host, register_host, noguest_host, noautoreg_host, 
-             validate_host, @site
+             validate_host, forbidapi_host, @site
   
 </PRE>
 <A HREF="#suspect">[PREV]</A>
@@ -15633,7 +20373,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#suspect_site">[NEXT]</A>
 <BR>
 <HR><A NAME="suspect_site"><H3>suspect_site</H3></A><PRE>
-  Config parameter: suspect_site &lt;addr&gt; &lt;mask&gt;.
+  Config parameter: suspect_site &lt;addr&gt; &lt;mask&gt;
   
   Indicates that sites whose address matches the specified address when ANDed
   with the mask are to be considered suspect, and any player creates, connects
@@ -15696,6 +20436,71 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#switch_search">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#tagmatch()">[NEXT]</A>
+<BR>
+<HR><A NAME="tagmatch()"><H3>TAGMATCH()</H3></A><PRE>
+  function: tagmatch(&lt;pattern&gt;)
+  
+  This function returns a list of tags that match the specified pattern.
+  Example:
+  &gt; th tagmatch(*bl*) 
+  &gt; bleat blue oblong
+  
+  Using this function with a simple '*' as the pattern will list all tags.
+  
+  This function is limited to wizards by default, in order to prevent normal
+  players from listing sensitive tags and finding the #dbrefs of special
+  objects.
+  
+  Also See: wizhelp tags, wizhelp @tag, wizhelp listtags(), help tag()
+
+</PRE>
+<A HREF="#switch_substitutions">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#tags">[NEXT]</A>
+<BR>
+<HR><A NAME="tags"><H3>TAGS</H3></A><PRE>
+  The Rhost tag system exists to make it easier for coders to avoid having
+  to use hardcoded #dbrefs inside their mushcode.
+  
+  It does this by allowing admins to assign #dbrefs to named 'tags', that
+  then can be used inside mushcode instead of said #dbrefs.
+  
+  For example, instead of using
+    @trigger #4/UPDATE_WEATHER
+  one would use the following line inside mushcode with this system:
+    @trigger [tag(weather_globals)]/UPDATE_WEATHER 
+  
+  An alternative to tag() is actually to use #&lt;tagname&gt; - this will match
+  against existing tag names, in a similiar format to #dbrefs, making it an
+  easy to use replacement.
+  
+  This also makes writing of portable mushcode much easier - old workarounds
+  in such systems included storing the new #dbrefs on creation on special
+  attributes, and then reading those attributes with v() to make us of them
+  inside the mushcode.
+  
+  The tag system has a couple advantages compared to this workaround:
+  
+    * They can be easily added by putting a line like
+        @tag/add weather_globals=[lastcreate(me,t)]
+      at the end of an object's automated creation process in the .txt file.
+    * Tags are available globally - they can be listed with @tag/list, and
+      tag() works independently of any attributes and possible access
+      permissions to those attributes.
+    * Tags are sanity checked - they always point at a valid object or #-1.
+      Object destruction removes the according tag. If a tag returns a
+      valid #dbref, it is ensured that this tag was assigned to this #dbref
+      during the current object's lifetime.
+    * Tags are easy to use on the fly in the client, by entering lines like
+      &quot;ex tag(weather_globals)&quot;, making them also handy for everyday admin
+      maintenance purposes.
+  
+  Also See: wizhelp @tag, wizhelp listtags(), wizhelp tagmatch(), help tag()
+
+</PRE>
+<A HREF="#tagmatch()">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#terse_shows_contents">[NEXT]</A>
 <BR>
 <HR><A NAME="terse_shows_contents"><H3>terse_shows_contents</H3></A><PRE>
@@ -15708,7 +20513,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: look_obey_terse, terse_shows_exits, terse_shows_move_messages.
 
 </PRE>
-<A HREF="#switch_substitutions">[PREV]</A>
+<A HREF="#tags">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#terse_shows_exits">[NEXT]</A>
 <BR>
@@ -15743,25 +20548,28 @@ Generated: Wed Jan 13 04:15:57 2016
 <A HREF="#textfile()">[NEXT]</A>
 <BR>
 <HR><A NAME="textfile()"><H3>TEXTFILE()</H3></A><PRE>
-  Function: textfile(&lt;helpfile&gt;,&lt;topic&gt;[,&lt;parsekey&gt;[,&lt;type&gt;[&lt;sep&gt;]]])
+  Function: textfile(&lt;helpfile&gt;,&lt;topic&gt;[,&lt;parsekey&gt;[,&lt;type&gt;[,&lt;sep&gt;[,&lt;sug&gt;]]]])
+  
+  This function was coded to provide Penn and MUX2 compatibility.
   
   This function works similarilly to dynhelp(), except that the resulting
   string is returned to the controlling command and not as a side-effect.
   This is a possible limitation as the string that it returns has to be
   limited to an LBUF in size, or it will be cut off.
   
-  You may specify a parsekey of '1' to let textfile() know that it needs 
+  You may specify a &lt;parsekey&gt; of '1' to let textfile() know that it needs 
   to parse the input and evaluate it.  A '2' will enable content searches.
-  
-  This function was coded to provide Penn and MUX2 compatibility.
   
   You may specify a &lt;type&gt; of '1' if you wish the function to return the
   wildcarded list of matches without the standard help entry header of
   'Here are the entries which match...'.  Useful for functions.
   
-  You may specify a seperate seperator &lt;sep&gt; to be used for returned
+  You may specify a separate separator &lt;sep&gt; to be used for returned
   arguments for matches.  It will default to two spaces.
   
+  The optional &lt;sug&gt; is for suggestion enabling.  Enabling this will have
+  it return suggestions if a lookup doesn't match.
+   
   Example:
     &gt; think textfile(help,mail)
     (returns the 'mail' topic in the help file)
@@ -15934,15 +20742,21 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="topics"><H3>topics</H3></A><PRE>
   Help available on the following Topics:
  
-  CAUTIONS           CONFIG PARAMETERS  DEBUG FEATURES     FILES
-  FLAGS              INHERITANCE        LOGGING            MASTER ROOM
-  PERMISSIONS        SEARCH CRITERIA    SITE LISTS         TOGGLES
-  POWER LIST         DEPOWER LIST       AUTOREGISTRATION   CLOAKING
-  ALT INVENTORIES    CPU                GUEST SETUP        NEWS SETUP
-  HELP SETUP         PLUSHELP SETUP     HUH SETUP          ELSEFILE SETUP
-  REALITY LEVELS     MAIL ALIASES       HOOK SETUP         FUNCTION OVERLOADING
-  FLAG ALIAS         ATTRIB CONTLOCKS   GLOBAL INHERITANCE ATTRIB FORMATTING
-  SIGNALS            TOR                CONTROL
+  ACCOUNT MEMBERSHIP       ALT INVENTORIES          ANCESTORS              
+  ATTRIB CONTLOCKS         ATTRIB FORMATTING        AUTOREGISTRATION       
+  API                      CAUTIONS                 CLOAKING               
+  CONFIG PARAMETERS        CONTROL                  CPU                    
+  CUSTOMIZED CONNECT       DEBUG FEATURES           DEPOWER LIST           
+  ELSEFILE SETUP           FILES                    FLAGS                  
+  FLAG ALIAS               FUNCTION OVERLOADING     GLOBAL INHERITANCE     
+  GUEST SETUP              HELP SETUP               HOOK SETUP             
+  HUH SETUP                INHERITANCE              LOGGING                
+  MAIL ALIASES             MASTER ROOM              MOGRIFY                
+  NEWS SETUP               PERMISSIONS              PLUSHELP SETUP         
+  POWER LIST               PROXY SETUP              REALITY LEVELS         
+  SEARCH CRITERIA          SIGNALS                  SITE LISTS             
+  SPECIAL ATTRIBS          SSL SETUP                TAGS                   
+  TOGGLES                  TOR                      TOTEMS
 
 </PRE>
 <A HREF="#toggles">[PREV]</A>
@@ -16011,6 +20825,669 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#tor_localhost">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#totem add">[NEXT]</A>
+<BR>
+<HR><A NAME="totem add"><H3>totem add</H3></A><PRE>
+  Command: @totem/add &lt;totem&gt; = &lt;slot&gt; &lt;mask&gt;
+  
+  This option will add the &lt;totem&gt; by name into the given &lt;slot&gt; with the
+  bitwise &lt;mask&gt; specified.  The mask must be a unique bitmask and the
+  slot must not currently be used.   The mask can be either in hex starting
+  with 0x as shown, or the decimal equivelant.  The valid slots are defined
+  to whatever the max slots are for that RhostMUSH.  The default is 0-9.
+  
+  Totem names must be less than 20 characters long.
+  
+  The following are the valid bitmasks:
+  
+    HEX        DECIMAL      HEX        DECIMAL      HEX        DECIMAL
+    ---------- -----------  ---------- -----------  ---------- ----------
+    0x00000001           1  0x00000800        2048  0x0040000      4194304
+    0x00000002           2  0x00001000        4096  0x0080000      8388608     
+    0x00000004           4  0x00002000        8192  0x0100000     16777216    
+    0x00000008           8  0x00004000       16384  0x0200000     33554432    
+    0x00000010          16  0x00008000       32768  0x0400000     67108864    
+    0x00000020          32  0x00010000       65536  0x0800000    134217728   
+    0x00000040          64  0x00020000      131072  0x1000000    268435456   
+    0x00000080         128  0x00040000      262144  0x2000000    536870912   
+    0x00000100         256  0x00080000      524288  0x4000000   1073741824  
+    0x00000200         512  0x00100000     1048576  0x8000000   2147483648  
+    0x00000400        1024  0x00200000     2097152     
+  
+  Examples:
+    &gt; @totem/add mytotem=1 0x00000001
+    &gt; @totem/add anothertotem=2 2
+  
+  Config parameter equivelant:
+    &gt; totem_add mytotem 1 0x00000001
+    &gt; totem_add anothertotem 2 2 
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#tor_paranoid">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem alias">[NEXT]</A>
+<BR>
+<HR><A NAME="totem alias"><H3>totem alias</H3></A><PRE>
+  Command: @totem/alias &lt;totem&gt;=&lt;alias(es)&gt;
+  
+  This command will set the specified aliases for the target totem.  You 
+  may have a maximum of 10 aliases per totem.  This value is hardcoded and
+  can not be changed.  There should not be a reason for more than 10 aliases
+  for a totem.
+  
+  If a totem alias already exists, is invalid, or is the name of an existing
+  totem, the alias will fail for that totem alias name only.  The rest will
+  work, if valid.
+  
+  You may specify multiple aliases at one time.
+  
+  Examples:
+    &gt; @totem/alias mytotem=my myt myto mytot mytote
+    &gt; @totem/alias marker0=0
+
+  Config parameter equivelant:
+    &gt; totem_alias mytotem my myt myto mytot mytote
+    &gt; totem_alias marker0 0
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#totem add">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem clean">[NEXT]</A>
+<BR>
+<HR><A NAME="totem clean"><H3>totem clean</H3></A><PRE>
+  Not currently implemented.
+
+</PRE>
+<A HREF="#totem alias">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem display">[NEXT]</A>
+<BR>
+<HR><A NAME="totem display"><H3>totem display</H3></A><PRE>
+  Command: @totem/display &lt;slot&gt;
+  
+  This command will display all the totems, totem letters, and values for
+  the specified slot.  If slot is not specified, it defaults to slot 0.
+  
+  Examples:
+    &gt; @totem/display
+    &gt; @totem/display 9
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#totem clean">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem fulllist">[NEXT]</A>
+<BR>
+<HR><A NAME="totem fulllist"><H3>totem fulllist</H3></A><PRE>
+  Command: @totem/fulllist [&lt;slot&gt;]
+  
+  This will give a listing of all the totems.  You may optionally specify 
+  a totem slot you wish to see as this may be necessary as the complete
+  totem list can easily exceed the LBUF buffers.
+  
+  The administrative quick-list will show totems in the following format:
+               TOTEMNAME|SLOT-POSITION|SLOT-MASK-VALUE
+  
+  An example output would be:
+               MYTOTEM|1|0x00000001
+  
+  If you wish to see more details on a specific totem, please refer to
+  the @totem/info command.
+  
+  Examples:
+    &gt; @totem/fulllist
+    &gt; @totem/fulllist 0
+  
+  See Also: @totem, @totem/info
+
+</PRE>
+<A HREF="#totem display">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem info">[NEXT]</A>
+<BR>
+<HR><A NAME="totem info"><H3>totem info</H3></A><PRE>
+  Command: @totem/info &lt;totem&gt;
+  
+  This command gives detailed information on the specified totem.
+  Such information will be the bitmask, the slot, it's permanency 
+  level, permissions, and what dbref#'s currently have the particular 
+  totem set.
+  
+  Examples:
+    &gt; @totem/info marker0
+    &gt; @totem/info mytotem 
+  
+  See Also: @totem, @totem/clean
+
+</PRE>
+<A HREF="#totem fulllist">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem letter">[NEXT]</A>
+<BR>
+<HR><A NAME="totem letter"><H3>totem letter</H3></A><PRE>
+  Command: @totem/letter &lt;totem&gt;=&lt;tier-level&gt; &lt;letter&gt;
+  
+  This will define (or redefine) the character associated with a totem.  You
+  may reuse letters on totems.  The default letter '?' for tier-level 0 is 
+  used as a mask to not display letters for the totems.  This is intentional 
+  as some totems you may want to hide the letter value.  
+  
+  There are three tier levels you may use to define a letter.
+    0  - this is the default letter type.
+    1  - characters in tier 1 will be surrounded by []'s
+    2  - characters in tier 2 will be surrounded by {}'s
+  
+  Examples:
+    &gt; @totem/letter mytotem=0 m
+    &gt; @totem/letter mytotem1=1 m
+    &gt; @totem/letter mytotem2=2 m
+    &gt; think totems(me)
+    m[m]{m}
+  
+  Config parameter equivelant:
+    &gt; totem_letter mytotem 0 m
+    &gt; totem_letter mytotem1 1 m
+    &gt; totem_letter mytotem2 2 m
+   
+</PRE>
+<A HREF="#totem info">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem remove">[NEXT]</A>
+<BR>
+<HR><A NAME="totem remove"><H3>totem remove</H3></A><PRE>
+  Command: @totem/remove &lt;totem&gt;
+  
+  This will remove the specified totem.  By default you can only remove
+  temporary or static totems.  A temporary totem is defined as one that
+  is added via the @totem/add command.  A static totem is one that is defined
+  using the .conf file totem_add option.  A permanent totem is one defined
+  through the use of the internal source totem_add() as documented in the
+  source itself.
+
+  Examples:
+    &gt; @totem/remove mytotem
+    &gt; @totem/remove myothertotem    
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#totem letter">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem rename">[NEXT]</A>
+<BR>
+<HR><A NAME="totem rename"><H3>totem rename</H3></A><PRE>
+  Command: @totem/rename &lt;totem&gt;=&lt;newname&gt;
+  
+  This command will rename the totem for the duration of the boot cycle.
+  If you have specified the config parameter 'totem_rename' with the
+  specified override, you may rename static and/or permanent totems.
+  
+  If either the totem name is invalid or the destination totem name is
+  invalid or in use, the command will fail.  
+  
+  Totem names must be less than 20 characters long.
+   
+  Examples:
+    &gt; @totem/rename mytotem=mynewtotem
+    &gt; @totem/rename anothertotem=anothernew
+  
+  Config parameter equivelant:
+    &gt; totem_name mytotem mynewtotem
+    &gt; totem_name anothertotem anothernew
+  
+  See Also: totem_rename, @totem
+
+</PRE>
+<A HREF="#totem remove">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem see">[NEXT]</A>
+<BR>
+<HR><A NAME="totem see"><H3>totem see</H3></A><PRE>
+  Command: @totem/see &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given permissions on the given totem on who may see them.
+  Valid permissions can be seen with 'wizhelp permissions'.  A special 
+  permission of 'mortal' is allowable.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls who may see the given totem.
+  
+  Examples:
+    &gt; @totem/see mytotem=wizard
+    &gt; @totem/see mytotem=!wizard architect
+  
+  Config parameter equivelant:
+    &gt; totem_access_see mytotem wizard
+    &gt; totem_access_see mytotem !wizard architect
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#totem rename">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem set">[NEXT]</A>
+<BR>
+<HR><A NAME="totem set"><H3>totem set</H3></A><PRE>
+  Command: @totem/set &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given permissions on the given totem on who may set them.  
+  Valid permissions can be seen with 'wizhelp permissions'.  A special 
+  permission of 'mortal' is allowable.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls who may set the given totem.
+  
+  Examples:
+    &gt; @totem/set mytotem=wizard
+    &gt; @totem/set mytotem=!wizard architect
+  
+  Config parameter equivelant:
+    &gt; totem_access_set mytotem wizard
+    &gt; totem_access_set mytotem !wizard architect
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#totem see">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem slots">[NEXT]</A>
+<BR>
+<HR><A NAME="totem slots"><H3>totem slots</H3></A><PRE>
+  Command: @totem/slots 
+  
+  This command will list every current active totem slot and the total number
+  of totems assigned to each slot.  It's a quick way to see what slots are 
+  available and how many free spaces are available to each slot.
+  
+  The output will be in the form: [Slot: &lt;slot&gt;:&lt;totems&gt;]
+  
+  Where &lt;slot&gt; is the slot number and &lt;totems&gt; are the number of totems
+  assigned to that specific slot.
+   
+  Exmaple:
+    &gt; @totem/slots
+  
+  See Also: @totem
+  
+</PRE>
+<A HREF="#totem set">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem type">[NEXT]</A>
+<BR>
+<HR><A NAME="totem type"><H3>totem type</H3></A><PRE>
+  Command: @totem/type &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given restrictions on the given totem on who may iset/unset
+  them based on type restrictions.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls a special type-case of what targets are allowable
+  to set or be set.
+  
+  Valid types are: THING, PLAYER, EXIT, ROOM, REGISTERED, GUILDMASTER,
+                   ARCHITECT, COUNCILOR, WIZARD, IMMORTAL
+  
+  If the type is set to THING, then the target can not be a type of THING.
+  If in addition you add COUNCILOR, then only COUNCILOR and higher may set
+  type THING.
+  
+  Examples:
+    &gt; @totem/type mytotem=room
+    &gt; @totem/type mytotem=!room thing wizard
+  
+  Config parameter equivelant:
+    &gt; totem_access_type mytotem room
+    &gt; totem_access_type mytotem !room thing wizard
+  
+  See Also: @totem
+
+
+</PRE>
+<A HREF="#totem slots">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem unalias">[NEXT]</A>
+<BR>
+<HR><A NAME="totem unalias"><H3>totem unalias</H3></A><PRE>
+  Command: @totem/unalias &lt;totem&gt;=&lt;alias(es)&gt;
+  
+  This command will remove the specified aliases from the target totem. 
+  
+  If a totem alias does not exist, is invalid, or is the name of an existing
+  totem, the unalias will fail for that totem unalias only.  The rest will
+  work, if valid.  Aliases that are not part of the target totem will not
+  be removed.
+  
+  You may specify multiple aliases to remove at one time.
+  
+  Examples:
+    &gt; @totem/unalias mytotem=my myt myto mytot mytote
+    &gt; @totem/unalias marker0=0
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#totem type">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem unset">[NEXT]</A>
+<BR>
+<HR><A NAME="totem unset"><H3>totem unset</H3></A><PRE>
+  Command: @totem/unset &lt;totem&gt;=&lt;permission(s)&gt;
+  
+  This sets the given permissions on the given totem on who may unset them.
+  Valid permissions can be seen with 'wizhelp permissions'.  A special 
+  permission of 'mortal' is allowable.  You may specify multiple permissions 
+  at once.  You may preceed a permission with '!' to remove the permission.
+  
+  This permission controls who may unset (ergo clear) the given totem.
+  
+  Examples:
+    &gt; @totem/unset mytotem=wizard
+    &gt; @totem/unset mytotem=!wizard architect
+  
+  Config parameter equivelant:
+    &gt; totem_access_unset mytotem wizard
+    &gt; totem_access_unset mytotem !wizard architect
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#totem unalias">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem validate">[NEXT]</A>
+<BR>
+<HR><A NAME="totem validate"><H3>totem validate</H3></A><PRE>
+  Command: @totem/validate
+  
+  This command will go through all the totems and print out any invalid
+  totems.  Invalid totems are totems that are defined on players that 
+  were undefined or removed.
+  
+  The way totems work is it still saves the bitmask of what the totem
+  was on the player.  This is intentional since totems may dynamically
+  change, and it does no harm.
+  
+  This will display all invalid totem values, what slot they exist in,
+  and a list of every dbref# in the database that currently has defined
+  an unreferenced totem bitmask.
+   
+  Example:
+    &gt; @totem/validate
+  
+  See Also: @totem 
+
+</PRE>
+<A HREF="#totem unset">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem2">[NEXT]</A>
+<BR>
+<HR><A NAME="totem2"><H3>TOTEM2</H3></A><PRE>
+  Totems are all held in memory so the overhead will be based on the
+  total number of slots and the total number of objects in the database.
+  
+  Flag and totem spaces are stored in an attribute space, so the larger
+  your LBUF size, the larger the contents of the attribute and the larger
+  number of totems you can have. 
+  
+  If you shrink the LBUF size to no longer hold the slots, the slots will
+  be cut off and upon loading the game will see it as a slot shrink event
+  and reduce the total slots.
+  
+  Statistically the following is a general guideline with max values:
+    Max values:
+      *** 4K  lbufs -  300 max slots  (for   9600 flags) 
+      *** 8K  lbufs -  600 max slots  (for  19200 flags) 
+      *** 16K lbufs - 1200 max slots  (for  38400 flags) 
+      *** 32K lbufs - 2500 max slots  (for  80000 flags) 
+      *** 64K lbufs - 5000 max slots  (for 160000 flags) 
+ 
+ Overhead: ((slots * 8) * total objects) + (flags * name len) + (slots * 8)
+ 
+ Flags have a hard name length of 20 characters.
+ Slots are defined as a long or 8 bytes of overhead for the declaration.
+  
+ Flags are based on how many are used only.
+ 
+ Memory overhead assuming all flags possible used with max length of name.
+   5000 obj db, 300 slots: ((300 * 8) * 5000) + (9600 * 20) + (300 * 8)
+     --&gt; 12,194,400 (12 MB)
+   20000 obj db, 2500 slots: ((2500 * 8) * 20000) + (80000 * 20) + (2500 * 8)
+     --&gt; 401,620,000 (400 MB)
+   20000 obj db, 40 slots: ((40 * 8) * 20000) + (1280 * 20) + (40 * 8)
+     --&gt; 6,425,920 (6.4 MB)
+   20000 obj db, 10 slots: ((10 * 8) * 20000) + (320 * 20) + (10 * 8) 
+     --&gt; 1,606,480 (1.6 MB)
+  
+ A realistic medium sized game will have about 8000 objects and stick with
+ the default of 10 slots.
+   8000 obj db, 10 slots: ((10 * 8) * 8000) + (320 * 20) + (10 * 8)
+     --&gt; 646,480 (640 KB)
+  
+ And sure, let's assume an obscene sized game with obscene sized totems.
+ You know, just for giggles.
+   100k obj db, 5000 slots: ((5000 * 8) * 100000) + (160000 * 20) + (5000 * 8)
+    --&gt; 4,003,240,000 (4 GB)
+ 
+ Or about the overhead of firefox :) 
+ 
+ But why you'd want or need 160,000 flags is anyone's guess.
+  
+ So as seen, default usage will cause minimal overhead, while maxing out
+ the totems to the obscene will gobble up a bit of memory for very large
+ games.
+  
+</PRE>
+<A HREF="#totem validate">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_access_see">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_access_see"><H3>totem_access_see</H3></A><PRE>
+  Config parameter: totem_access_see &lt;totemname&gt; &lt;permission(s)&gt;
+  
+  Sets an override for see permissions for the specified totem.  This is
+  similiar to issuing @totemdef/see on the specified totem.
+  
+  See Also: totem_access_set, totem_access_unset, totem_access_type, 
+            totem_add, totem_letter, totem_alias, @totemdef, @totem
+
+</PRE>
+<A HREF="#totem2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_access_set">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_access_set"><H3>totem_access_set</H3></A><PRE>
+  Config parameter: totem_access_set &lt;totemname&gt; &lt;permission(s)&gt;
+  
+  Sets an override for set permissions for the specified totem.  This is
+  similiar to issuing @totemdef/set on the specified totem.
+  
+  See Also: totem_access_unset, totem_access_see, totem_access_type, 
+            totem_add, totem_alias, totem_letter, @totemdef, @totem
+  
+</PRE>
+<A HREF="#totem_access_see">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_access_type">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_access_type"><H3>totem_access_type</H3></A><PRE>
+  Config parameter: totem_access_type &lt;totemname&gt; &lt;permission(s)&gt;
+  
+  Sets a type restriction for set/unset permissions for the specified totem.
+  This is similiar to issuing @totemdef/type on the specified totem.
+  
+  See Also: totem_access_set, totem_access_unset, totem_access_see, 
+            totem_add, totem_letter, totem_alias, @totemdef, @totem
+
+</PRE>
+<A HREF="#totem_access_set">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_access_uset">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_access_uset"><H3>totem_access_uset</H3></A><PRE>
+  Config parameter: totem_access_uset &lt;totemname&gt; &lt;permission(s)&gt;
+  
+  Sets an override for unset permissions for the specified totem.  This is
+  similiar to issuing @totemdef/unset on the specified totem.
+  
+  See Also: totem_access_set, totem_access_see, totem_access_type, 
+            totem_add, totem_letter, totem_alias, @totemdef, @totem
+
+</PRE>
+<A HREF="#totem_access_type">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_add">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_add"><H3>totem_add</H3></A><PRE>
+  Config parameter: totem_add &lt;totemname&gt; &lt;slot&gt; &lt;bitvalue&gt;
+  
+  This will add the totem as a static (sticky) value to the mush.  This is
+  assigned a given slot number (by default 0-9) and a default bitvalue.
+  The bitvalue must be a bitwise value.  Examples are: 0x00000001, 0x00000002,
+  1, 2, or so forth.  You may use the HEX value providing it starts with 0x,
+  or the decimal value for the bitwise mask.  The mask must be a unique mask
+  and can not contain a mask of more than one byte.
+  
+  This works like @totem/add, though @totem/add only works for temporary
+  totems.
+   
+  Attempting to add a totem with a name, slot, or bitvalue already taken will
+  return an error.
+  
+  See Also: totem_access_set, totem_access_unset, totem_access_see, 
+            totem_access_type, totem_alias, totem_letter, @totemdef, @totem
+
+</PRE>
+<A HREF="#totem_access_uset">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_alias">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_alias"><H3>totem_alias</H3></A><PRE>
+  Config parameter: totem_alias &lt;totemname&gt; &lt;alias1&gt; [&lt;alias2&gt; ... &lt;aliasN&gt;]
+  
+  This adds one (or more) aliases to the totem.  You can have a maximum 
+  of 10 aliases added per totem name.  You may add aliases to any totem.
+  
+  This is similar to  @totem/alias.
+  
+  See Also: totem_access_unset, totem_access_see, totem_access_type, 
+            totem_access_set, totem_add, @totemdef, @totem
+  
+</PRE>
+<A HREF="#totem_add">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_letter">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_letter"><H3>totem_letter</H3></A><PRE>
+  Config parameter: totem_letter &lt;totemname&gt; &lt;chartier&gt; &lt;character&gt;
+  
+  This assigns the unique character to the totem.  The letter can be
+  any character except (, ), [, ], { or }.  The tier can be 0, 1, or 2.
+  
+  Tier 1 is surrounded by [].
+  Tier 2 is surrounded by {}.
+  
+  You are allowed to have totems with duplicate characters.
+  
+  See Also: totem_access_set, totem_access_unset, totem_access_see, 
+            totem_add, totem_letter, totem_access_type, @totemdef, 
+            @totem
+
+</PRE>
+<A HREF="#totem_alias">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_name">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_name"><H3>totem_name</H3></A><PRE>
+  Config parameter: totem_name &lt;oldname&gt; &lt;newname&gt;
+  
+  This config parameter will allow you to rename a totem to a new name.
+  
+  Both oldname and newname must be under 20 characters in length and
+  be a valid totem name.
+  
+  If you wish to use this to rename totems that are static or 
+  permanent, you must specify the permission value with the config
+  parameter totem_rename.
+  
+  See Also: totem_rename, @totem
+
+</PRE>
+<A HREF="#totem_letter">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_rename">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_rename"><H3>totem_rename</H3></A><PRE>
+  Config parameter: totem_rename &lt;value&gt;    Default: 0
+  
+  This config parameter sets a bitmask on what totem type is allowed to
+  be renamed.  The default of '0' are temporary totems only.  Temporary
+  being totems that are defined in-game and not via config params or 
+  through source.
+  
+      0 -- temporary (defined in-game)
+      1 -- static/sticky (defined in the .conf files)
+      2 -- permanent (defined in the source itself)
+      3 -- both static and permanent.
+  
+  To rename anything but temporary you must specify the level you wish.
+  
+  See Also: @totem
+
+</PRE>
+<A HREF="#totem_name">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totem_types">[NEXT]</A>
+<BR>
+<HR><A NAME="totem_types"><H3>totem_types</H3></A><PRE>
+  Config parameter: totem_types &lt;boolean&gt;    Default: off (0)
+  
+  This enables type detection to totem lists just as flags handle them.
+  This is intended to be enabled if ever totems take over the requirement
+  of flags in the future and to allow easier migration.
+  
+  See Also: @totem
+  
+</PRE>
+<A HREF="#totem_rename">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#totems">[NEXT]</A>
+<BR>
+<HR><A NAME="totems"><H3>TOTEMS</H3></A><PRE>
+  Topic: TOTEMS
+  
+  Totems are a generic overset of flags and toggles.  Eventually this will
+  be the functionality that will take over control of flags and toggles
+  internally to the mush.
+  
+  Totems are unique to flags and toggles in the fact that:
+    1.  They can be defined and removed dynamically without any type
+        of damage to the mush or the database.
+    2.  They can be renamed without any damage to the mush or the
+        database.
+    3.  They can be defined statically via config file entries.
+    4.  They can be defined permanently via source files and compiled in
+        just like a normal flag and toggle.
+    5.  With hardcode only, they can be assigned unique control, power,
+        or similar affect as when toggles and flags.
+    6.  The number of totems can be increased or shrunk dynamically
+        without damaging the database.  Howeber, if hardcoding to
+        a specific slot, it likely won't compile if you shrink to
+        the point that slot no longer exists.
+  
+  A totem 'slot' is a unique flag space that contains 32 unique flags
+  for that slot.  By default there are 10 slots allowing a total of
+  320 flags.  Each flag has a unique slot and flag bitmask for its
+  identifier.
+  
+  { wizhelp totem2 for memory statistics and guidelines }
+   
+</PRE>
+<A HREF="#totem_types">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#trace_output_limit">[NEXT]</A>
 <BR>
 <HR><A NAME="trace_output_limit"><H3>trace_output_limit</H3></A><PRE>
@@ -16029,7 +21506,7 @@ Generated: Wed Jan 13 04:15:57 2016
   evaluations and earlier arguments of outer functions).
 
 </PRE>
-<A HREF="#tor_paranoid">[PREV]</A>
+<A HREF="#totems">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#trace_topdown">[NEXT]</A>
 <BR>
@@ -16132,10 +21609,58 @@ Generated: Wed Jan 13 04:15:57 2016
             (this clears the validate_host list)
  
   See Also:  forbid_host, register_host, noguest_host, noautoreg_host, 
-             suspect_host, goodmail_host, @site
+             suspect_host, goodmail_host, forbidapi_host, @site
 
 </PRE>
 <A HREF="#user_attr_access">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#vattr_command">[NEXT]</A>
+<BR>
+<HR><A NAME="vattr_command"><H3>vattr_command</H3></A><PRE>
+  Config parameter: vattr_command &lt;alias&gt; &lt;user-attribute&gt;
+                    vattr_command &lt;alias&gt; !
+  
+  The &lt;alias&gt; should be entered without a '@' prefix.
+  
+  Will define or delete a @command alias to a user-defined attribute.  This
+  allows you to set a @command sequence to a user-defined attribute.  Once
+  a command is defined, the attribute can not be deleted from the hash tables
+  via @attribute/delete, but may be renamed.  If there is any db rollback
+  or other situation which deletes the attribute in-game, the attribute
+  will be unsettable with this command until the command is deleted then
+  re-defined to the attribute. 
+  
+  The reason for this is that the defined command is linked to the REFERENCE
+  of the attribute and not the name of the attribute itself.  Once an 
+  attribute is deleted and redefined, it will likely have a different
+  reference number.
+  
+  You may specify an unlimited number of command aliases for a single 
+  user defined attribute.  Use '!' as the user-attribute if you wish
+  to delete the command reference to the attribute.
+  
+  You can not set up @command aliases to user-defined attributes if the
+  command already exists in the command table as a command, an alias, or
+  pre-exists in the user-attribute table.
+    
+  The attribute must be pre-defined in the attribute hash table before
+  being able to be made a command.  You may do this by just 
+  typing: &amp;ATTRIBNAME me  (where ATTRIBNAME is the attribute name)
+  
+  netrhost.conf example:
+    &gt; vattr_command pageformat pageformat
+    &gt; vattr_command outpageformat outpageformat
+  
+  In-game example:
+    &gt; @admin vattr_command=pageformat pageformat
+    &gt; @admin vattr_command=outpageformat outpageformat
+  
+  The above will define @pageformat and @outpageformat respectively.
+  
+  See Also: @list commands, @list permissions, @aflags
+  
+</PRE>
+<A HREF="#validate_host">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#vattr_limit_checkwiz">[NEXT]</A>
 <BR>
@@ -16150,7 +21675,24 @@ Generated: Wed Jan 13 04:15:57 2016
             max_vattr_limit, lfunction_max
  
 </PRE>
-<A HREF="#validate_host">[PREV]</A>
+<A HREF="#vattr_command">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#vercustomstr">[NEXT]</A>
+<BR>
+<HR><A NAME="vercustomstr"><H3>vercustomstr</H3></A><PRE>
+  Config parameter: vercustomstr &lt;string&gt;.  Default: (null)
+  
+  This provides an optional suffix for @version and INFO's version for
+  customizing a version string with a personal touch.
+  
+  This is intended for those who want to build custom versions and have
+  an ideal place to put the string.
+  
+  20 characters are allowed for this custom string.  The variable is
+  evaluated so escape out special characters.
+
+</PRE>
+<A HREF="#vattr_limit_checkwiz">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#vlimit">[NEXT]</A>
 <BR>
@@ -16164,7 +21706,7 @@ Generated: Wed Jan 13 04:15:57 2016
   database will be on your hands.
 
 </PRE>
-<A HREF="#vattr_limit_checkwiz">[PREV]</A>
+<A HREF="#vercustomstr">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#wait_cost">[NEXT]</A>
 <BR>
@@ -16184,7 +21726,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <HR><A NAME="wall_cost"><H3>wall_cost</H3></A><PRE>
   Config parameter: wall_cost &lt;ammount&gt;.  Default: 250
   
-  Specifies the cost of using a @wall if you're not privalaged.
+  Specifies the cost of using a @wall if you're not privileged.
   Privalaged is defined of having at least a GUILDMASTER bit.
 
 </PRE>
@@ -16223,6 +21765,7 @@ Generated: Wed Jan 13 04:15:57 2016
 <BR>
 <HR><A NAME="whisper"><H3>whisper</H3></A><PRE>
   Command: whisper[/port] &lt;player&gt; [=&lt;message&gt;] (royalty and higher only)
+  
   This command has the wizard only /port option which allows the whispering
   to specific ports.  A non-connected port or non-existing port will return
   an error.
@@ -16259,7 +21802,7 @@ Generated: Wed Jan 13 04:15:57 2016
                     U - hidden (@hide)  H - unfindable     D - dark
                     * - staff (opt)     W - Wizard (opt)   a - councilor (opt)
                     B - architect (opt) g - GuildMstr(opt) d - idle dark
-                    h - idle unfindable 
+                    h - idle unfindable $ - SSL connected
      Host         - The Internet host name or address from where the player 
                     has connected.  This can be cut off with 'whohost_size'
 
@@ -16519,10 +22062,28 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#wizard_motd_message">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#wizcommand_quota_max">[NEXT]</A>
+<BR>
+<HR><A NAME="wizcommand_quota_max"><H3>wizcommand_quota_max</H3></A><PRE>
+  Config parameter: wizcommand_quota_max &lt;amount&gt;. Default: 100
+  
+  Specifies the maximum value for the command quota for connected wizards+.
+  A wizard's command quota is only increased if it is below this value.
+  Each command a wizard types in (commands executed by machines do not count)
+  decreases the quota by 1, and the wizard's commands are only executed if the
+  quota is greater than zero.
+  
+  See Also: command_quota_increment, command_quota_max, timeslice,
+            @cmdquota
+
+</PRE>
+<A HREF="#wizard_queue_limit">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#wizhelp">[NEXT]</A>
 <BR>
 <HR><A NAME="wizhelp"><H3>wizhelp</H3></A><PRE>
   Command: wizhelp &lt;topic&gt;
+  
   Displays information from the wizard help file.  The information is
   typically of use only to wizards and/or the game maintainer.
   
@@ -16532,7 +22093,7 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: the source code.
 
 </PRE>
-<A HREF="#wizard_queue_limit">[PREV]</A>
+<A HREF="#wizcommand_quota_max">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#wizmax_dest_limit">[NEXT]</A>
 <BR>
@@ -16937,6 +22498,197 @@ Generated: Wed Jan 13 04:15:57 2016
 </PRE>
 <A HREF="#wmail unload">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
+<A HREF="#working with execscript">[NEXT]</A>
+<BR>
+<HR><A NAME="working with execscript"><H3>WORKING WITH EXECSCRIPT</H3></A><PRE>
+  Topic: Working with Execscript
+  
+  The file that will be passed back to the mush is the name of the 
+  executing script with '.set' after it.  With the example 'myscript.sh'
+  the loader file will be 'myscript.sh.set'.
+ 
+  Note1: you may start lines with a '#' for comments.
+  Note2: you may continue content by ending previous line with a &lt;ctrl&gt;M
+         (which is a line feed)
+  Note3: A maximum of 1000 lines are read (including comments)
+  
+  The file loader after the execscript is executed is the name of the
+  script plus '.set' after it.  So if execscript called myscript.sh then
+  the loader script it calls after execution is myscript.sh.set.  This file
+  will be not be triggered if it detects the file existing prior to 
+  the executing of the script.  This is a safty margin.
+  
+  The following registers are passed to the script as environment variables:
+    MUSHQ_&lt;reg&gt;   - Where &lt;reg&gt; is 0-9 or a-z for the SETQ registers.
+    MUSHQN_&lt;reg&gt;  - The label name of the &lt;reg&gt; defined above.
+    MUSHN_&lt;label&gt; - The label contents of the named register.
+  
+  The following variables are passed to the script as environment variables:
+    MUSHL_VARS    - This is the contents of the EXECSCRIPT_VARS mush attribute
+                    that has a space seperated list of attribute names you
+                    wish to pass to the script.
+    MUSHV_&lt;arg&gt;   - Each &lt;arg&gt; is a mush attribute variable from MUSHL_VARS.
+  
+  See 'writing callbacks' for help on writing execscript callbacks.
+  See 'writing scripts' for help on dos and don'ts in writing execscripts.
+  
+{ see 'working with execscript2' for details and examples }
+
+</PRE>
+<A HREF="#wmail wipe">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#working with execscript2">[NEXT]</A>
+<BR>
+<HR><A NAME="working with execscript2"><H3>WORKING WITH EXECSCRIPT2</H3></A><PRE>
+  Topic: Working with Execscript Part 2
+  
+  The list of variables you wish to pass will be from the object issuing
+  the execscript (not the executor, but the container) as a space separated 
+  list stored in the variable EXECSCRIPT_VARS.  Let's assume the execscript
+  is on object #123 so default attributes will be on #123.
+  
+  Example: 
+    &gt; @set #123=SIDEFX INHERIT
+    &gt; @power/counc #123=EXECSCRIPT
+    &gt; &amp;EXECSCRIPT_VARS #123=foo bar baz #0/desc
+    &gt; &amp;FOO #123=This is my foo variable
+    &gt; &amp;BAR #123=This is my bar variable
+    &gt; &amp;BAZ #123=This is my baz variable
+    &gt; @desc #0=This is #0's description
+    &gt; &amp;EXEC_ONE #123=$run1:@pemit %#=[execscript(hi.sh)]
+    &gt; &amp;EXEC_TWO #123=$run2 *:@pemit %#=[setq(0,foo,bar)][execscript(hi.sh,%0)]
+  
+  The EXECSCRIPT_VARS contents as passed as environment variable MUSHL_VARS.
+  This will always be a space delimited list of variables you want your script
+  to see.  The contents of the example is 'foo bar baz' which are then defined
+  as the environment variables with contents:
+     MUSHV_FOO containing 'This is my foo variable' from &amp;FOO #123
+     MUSHV_BAR containing 'This is my bar variable' from &amp;BAR #123
+     MUSHV_BAZ containing 'This is my baz variable' from &amp;BAZ #123
+     MUSHV_D0_DESC containing 'This is #0's description' from @desc #0
+  
+  All registers that are defined are allocated and defined as environments
+  with labels if declared.  It only assigns registers and labels where defined.
+  
+  Based on the above code, when issuing 'run2' with an argument:
+     environment variable MUSHQ_0 containing 'foo' from setq 0 contents
+     environment variable MUSHQN_0 containing 'bar' from setq 0 label
+     environment variable MUSHN_BAR containing 'foo' from setq 0 contents
+  
+  Note: none of the environments will be set with 'run1'
+   
+  Notice the difference between 'run1' and 'run2' above is that run1 just
+  execs the script.  No registers are passed, but EXECSCRIPT_VARS passes
+  three variables that will be seen by your script.  'run2' in addition
+  passes argument 0 (%0) to the script, as well as sets a register and
+  label.  This is done via setq with function setq (help setq):
+                setq(&lt;register&gt;, &lt;content&gt; [,&lt;label&gt;]
+  
+  At the end of the execscript() the mush does house keeping and
+  will remove all environment variables that were originally set.
+  
+  See 'writing callbacks' for help on writing execscript callbacks.
+  See 'writing scripts' for help on dos and don'ts in writing execscripts.
+  
+{ See 'working with execscript3' for passing information back into the mush}
+  
+</PRE>
+<A HREF="#working with execscript">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#working with execscript3">[NEXT]</A>
+<BR>
+<HR><A NAME="working with execscript3"><H3>WORKING WITH EXECSCRIPT3</H3></A><PRE>
+  Topic: Working with Execscript Part 3
+  
+  If you wish to have variables and registers pushed back to the mush,
+  you must stage a file to be read at the end of your script execution.
+  
+  The filename created will be &lt;scriptname&gt;.set.  This file will be removed
+  after the end of processing. 
+  
+  Yes yes, I know, this isn't exactly clean, but it's one of the few
+  'clean' ways a child can refer back to the parent short of writing
+  complex (and not fully platform supported) shared memory or a complex
+  call-back API interface into the handler.  We took the easy way out here.
+  
+  The file that will be read is the name of the script execscript() called
+  with a '.set' appended to it.  
+  
+  So if your script was called 'myscript.sh'.  The file it would read
+  in would be called 'myscript.sh.set'.  Again, this file is removed after
+  it runs.  
+  
+  The syntax of this file will be as follows.
+  
+  To set registers back to the mush you would use:
+    &lt;register&gt; Q      -- This clears the register
+    &lt;register&gt; Q bob  -- This sets the register to contents 'bob'
+    &lt;label&gt;    QN boo -- This sets register with label' &lt;label&gt; 'boo'
+  
+  To set variables back to the mush you would use:
+    &lt;variable&gt; &lt;dbref#&gt;      -- This clears the attribute on dbref#
+    &lt;variable&gt; &lt;dbref#&gt; bob  -- This sets 'bob' to the attribute
+  
+  To execute code use:
+    @exec &lt;dbref#&gt; &lt;commands separated by semicolon&gt;
+  
+  To set flag, toggle, and totem flags use:
+    @set &lt;dbref#&gt; &lt;flag ... !flag&gt;    -- Set/unset flag on dbref#
+    @totem &lt;dbref#&gt; &lt;flag ... !flag&gt;  -- Set/unset totem on dbref#
+    @toggle &lt;dbref#&gt; &lt;flag ... !flag&gt; -- Set/unset toggle on dbref#
+  
+{ see 'working with execscript4' for examples and descriptions }
+
+</PRE>
+<A HREF="#working with execscript2">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#working with execscript4">[NEXT]</A>
+<BR>
+<HR><A NAME="working with execscript4"><H3>WORKING WITH EXECSCRIPT4</H3></A><PRE>
+  Topic: Working with Execscript Part 4
+  
+  To continue, you again would still be using the .set file.  For
+  the example we were using 'myscript.sh.set' because the example
+  execscript() was myscript.sh.
+  
+  Example &lt;script&gt;.set file contents:
+     W Q
+     0 Q Setting Register 0
+     A Q Setting register A
+     @set #123 inherit
+     @totem #123 marker0
+     @toggle #123 variable
+     @exec #123 @wait 10={think 1;think 2};&amp;FOO me=test
+     snork QN Setting register with label snork 
+     BOB #456 This is my BOB attribute
+     SEX #123 Male
+     DESC #123 This is my desc%r%rI like my %crred%cn desc.
+     MULTILINE #123 Multi Line Input^M
+     More for the line^M
+     And the end
+     WIPEATTR #123
+   
+  To describe what the examples do: 
+     W Q  -- this clears register W
+     0 Q &lt;string&gt; -- This sets &lt;string&gt; into register 0 (%q0)
+     A Q &lt;string&gt; -- This sets &lt;String&gt; into register A (%qa)
+     @set #123 &lt;flag&gt; -- Same as @set #123=&lt;flag&gt;
+     @totem #123 &lt;totem&gt; -- Same as @totem #123=&lt;totem&gt;
+     @toggle #123 &lt;toggle&gt; -- Same as @toggle #123=&lt;toggle&gt;
+     Execute as #123 @wait 10={think1 ;think2} and set FOO on #123 to 'test'
+     snork QN &lt;string&gt; -- sets string to register with label 'snork'
+     BOB #456 &lt;string&gt; -- Same as &amp;BOB #456=&lt;string&gt;
+     SEX #123 &lt;string&gt; -- Same as @sex #123=&lt;string&gt;
+     DESC #123 &lt;string&gt; -- Same as @desc #123=&lt;string&gt;
+     MULTILINE #123 &lt;string&gt; -- Each ^M says to keep reading
+                                until no ^M or end of file
+     WIPEATTR #123 -- same as &amp;WIPEATTR #123 or @wipe #123/WIPEATTR
+  
+  See also: execscript(), WRITING SCRIPTS, POWER EXECSCRIPT
+
+</PRE>
+<A HREF="#working with execscript3">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
 <A HREF="#worn toggle">[NEXT]</A>
 <BR>
 <HR><A NAME="worn toggle"><H3>WORN TOGGLE</H3></A><PRE>
@@ -16949,7 +22701,101 @@ Generated: Wed Jan 13 04:15:57 2016
   See Also: WIELDED TOGGLE, @invtype, alt_inventories, altover_inv
 
 </PRE>
-<A HREF="#wmail wipe">[PREV]</A>
+<A HREF="#working with execscript4">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#writing callbacks">[NEXT]</A>
+<BR>
+<HR><A NAME="writing callbacks"><H3>WRITING CALLBACKS</H3></A><PRE>
+  Topic: Working with Execscript Part 3
+  
+  If you wish to have variables and registers pushed back to the mush,
+  you must stage a file to be read at the end of your script execution.
+  
+  The filename created will be &lt;scriptname&gt;.set.  This file will be removed
+  after the end of processing. 
+  
+  Yes yes, I know, this isn't exactly clean, but it's one of the few
+  'clean' ways a child can refer back to the parent short of writing
+  complex (and not fully platform supported) shared memory or a complex
+  call-back API interface into the handler.  We took the easy way out here.
+  
+  The file that will be read is the name of the script execscript() called
+  with a '.set' appended to it.  
+  
+  So if your script was called 'myscript.sh'.  The file it would read
+  in would be called 'myscript.sh.set'.  Again, this file is removed after
+  it runs.  
+  
+  The syntax of this file will be as follows.
+  
+  To set registers back to the mush you would use:
+    &lt;register&gt; Q      -- This clears the register
+    &lt;register&gt; Q bob  -- This sets the register to contents 'bob'
+    &lt;label&gt;    QN boo -- This sets register with label' &lt;label&gt; 'boo'
+  
+  To set variables back to the mush you would use:
+    &lt;variable&gt; &lt;dbref#&gt;      -- This clears the attribute on dbref#
+    &lt;variable&gt; &lt;dbref#&gt; bob  -- This sets 'bob' to the attribute
+  
+  To execute code use:
+    @exec &lt;dbref#&gt; &lt;commands separated by semicolon&gt;
+  
+  To set flag, toggle, and totem flags use:
+    @set &lt;dbref#&gt; &lt;flag ... !flag&gt;    -- Set/unset flag on dbref#
+    @totem &lt;dbref#&gt; &lt;flag ... !flag&gt;  -- Set/unset totem on dbref#
+    @toggle &lt;dbref#&gt; &lt;flag ... !flag&gt; -- Set/unset toggle on dbref#
+  
+{ see 'working with execscript4' for examples and descriptions }
+
+</PRE>
+<A HREF="#worn toggle">[PREV]</A>
+<A HREF="#topic index">[TOP]</A>
+<A HREF="#writing callbacks2">[NEXT]</A>
+<BR>
+<HR><A NAME="writing callbacks2"><H3>WRITING CALLBACKS2</H3></A><PRE>
+  Topic: Working with Execscript Part 4
+  
+  To continue, you again would still be using the .set file.  For
+  the example we were using 'myscript.sh.set' because the example
+  execscript() was myscript.sh.
+  
+  Example &lt;script&gt;.set file contents:
+     W Q
+     0 Q Setting Register 0
+     A Q Setting register A
+     @set #123 inherit
+     @totem #123 marker0
+     @toggle #123 variable
+     @exec #123 @wait 10={think 1;think 2};&amp;FOO me=test
+     snork QN Setting register with label snork 
+     BOB #456 This is my BOB attribute
+     SEX #123 Male
+     DESC #123 This is my desc%r%rI like my %crred%cn desc.
+     MULTILINE #123 Multi Line Input^M
+     More for the line^M
+     And the end
+     WIPEATTR #123
+   
+  To describe what the examples do: 
+     W Q  -- this clears register W
+     0 Q &lt;string&gt; -- This sets &lt;string&gt; into register 0 (%q0)
+     A Q &lt;string&gt; -- This sets &lt;String&gt; into register A (%qa)
+     @set #123 &lt;flag&gt; -- Same as @set #123=&lt;flag&gt;
+     @totem #123 &lt;totem&gt; -- Same as @totem #123=&lt;totem&gt;
+     @toggle #123 &lt;toggle&gt; -- Same as @toggle #123=&lt;toggle&gt;
+     Execute as #123 @wait 10={think1 ;think2} and set FOO on #123 to 'test'
+     snork QN &lt;string&gt; -- sets string to register with label 'snork'
+     BOB #456 &lt;string&gt; -- Same as &amp;BOB #456=&lt;string&gt;
+     SEX #123 &lt;string&gt; -- Same as @sex #123=&lt;string&gt;
+     DESC #123 &lt;string&gt; -- Same as @desc #123=&lt;string&gt;
+     MULTILINE #123 &lt;string&gt; -- Each ^M says to keep reading
+                                until no ^M or end of file
+     WIPEATTR #123 -- same as &amp;WIPEATTR #123 or @wipe #123/WIPEATTR
+  
+  See also: execscript(), WRITING SCRIPTS, POWER EXECSCRIPT
+
+</PRE>
+<A HREF="#writing callbacks">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#writing scripts">[NEXT]</A>
 <BR>
@@ -17008,7 +22854,7 @@ Generated: Wed Jan 13 04:15:57 2016
   Party on.
 
 </PRE>
-<A HREF="#worn toggle">[PREV]</A>
+<A HREF="#writing callbacks2">[PREV]</A>
 <A HREF="#topic index">[TOP]</A>
 <A HREF="#zone_parents">[NEXT]</A>
 <BR>


### PR DESCRIPTION
This adds the configuration file for the AmbrosiaDB into asksource.sh and symlinks the asksource.ambrosia to the one in the minimal dir, and adds a marker.

Considering that this config file has #'d DB objects in it, there may be good reason not to want it there. It will make somethings easier for new people that read documentation, but might cause problems for people that make random selections.

While this includes some specific changes, it's also a suggestion of at least the first step towards integrating the included DBs more easily into the installation workflow.

If you reject or accept this change, please make clear if you want further changes in this direction, want to limit it to this change, are interested when there is more to it, or simply do not want to go in in this direction at all.