### PR TITLE
Simplifiedmogrify

### DIFF
--- a/Mushcode/Mogrify
+++ b/Mushcode/Mogrify
@@ -18,6 +18,6 @@
 @@
 @@ This simplified variant highlights every occurrence of the name of a currently connected player in any pose/say/@emit.
 @@ For say and pose the initial name of the player enacting the say/pose will use their cname if it exists, and otherwise leaves it unadorned.
-@@ &M_SAY DATA: @hook=[ifelse(hastoggle(%2,variable),%k,%n)] [default(%2/saystring,says%,)] [localize([setq(z,%1)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(h,$1)])),,)]"%qz")]
-@@ &M_POSE DATA: @hook=[localize([setq(z,%0)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(h,$1)])),,)]%qz)]
-@@ &M_@EMIT DATA: @hook=[localize([setq(z,%1)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(h,$1)])),,)]%qz)]
+@@ &M_SAY #HOOKOBJ=[ifelse(hastoggle(%2,variable),%k,%n)] [default(%2/saystring,says%,)] [localize([setq(z,%1)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(h,$1)])),,)]"%qz")]
+@@ &M_POSE #HOOKOBJ=[localize([setq(z,%0)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(h,$1)])),,)]%qz)]
+@@ &M_@EMIT #HOOKOBJ=[localize([setq(z,%1)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(h,$1)])),,)]%qz)]

--- a/Mushcode/Mogrify
+++ b/Mushcode/Mogrify
@@ -15,3 +15,9 @@
 @@ &M_@EMIT #HOOKOBJ=[parsestr([localize([setq(z,%1)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(ifelse(!hasattr(%i0,NOCOLOR),get(me/namecolor)),$1)])),,)]%qz)],editansi(%0,N,h),",")]
 @@ global color of namesis cyan
 &NAMECOLOR #HOOKOBJ=c
+@@
+@@ This simplified variant highlights every occurrence of the name of a currently connected player in any pose/say/@emit.
+@@ For say and pose the initial name of the player enacting the say/pose will use their cname if it exists, and otherwise leaves it unadorned.
+@@ &M_SAY DATA: @hook=[ifelse(hastoggle(%2,variable),%k,%n)] [default(%2/saystring,says%,)] [localize([setq(z,%1)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(h,$1)])),,)]"%qz")]
+@@ &M_POSE DATA: @hook=[localize([setq(z,%0)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(h,$1)])),,)]%qz)]
+@@ &M_@EMIT DATA: @hook=[localize([setq(z,%1)][iter(lwho(),setq(z,regeditalli(%qz,%(%\b[name(%i0)]%\b%),[ansi(h,$1)])),,)]%qz)]


### PR DESCRIPTION
This modifies adds an additional option to the Mogrify code, which only highlights names of connected players. It's commented out an exists as an option.