### PR TITLE
Fixed a small typo in wizhelp

### DIFF
--- a/Server/game/txt/wizhelp.txt
+++ b/Server/game/txt/wizhelp.txt
@@ -12237,7 +12237,7 @@
   Config parameter: whereis_notify <value>.  Default: 1
   
   Sets the condition if the targetted player gets notified if someone did
-  a @whois on them.  Note, that cloaked wizards do not give a message to
+  a @whereis on them.  Note, that cloaked wizards do not give a message to
   players who can not normally see them.
 
 & who_comment


### PR DESCRIPTION
small typo fixed in wizhelp WHEREIS_NOTIFY mentions @whois when it means @whereis