### PR TITLE
Edits to example jobs on MyrddinCRON

### DIFF
--- a/Mushcode/MyrddinCRON
+++ b/Mushcode/MyrddinCRON
@@ -26,8 +26,13 @@
 &CREDITS mushcron=mushcron was coded by Myrddin (merlin@firstmagic.com). Permission is granted to distribute the code freely as long as the initial CREDIT attribute is kept intact. This code is located at www.firstmagic.com/~merlin/mushcode
 
 @switch strmatch(version(),*Rhost*)=1,{&CRON_TIME_BACKUP mushcron=|||06|00|;&CRON_JOB_BACKUP mushcron={wmail/unload;@areg/unload;@dump/flat;@purge/time 30}}
-&CRON_TIME_TIMECLOCK mushcron=||||00 02 04 06 08 10 12 14 16 18 20 22 24 26 28 30 32 34 36 38 40 42 44 46 48 50 52 54 56 58|
-&CRON_JOB_TIMECLOCK mushcron=@dolist lwho()={@timeonweek ##=[add(get(##/timeonweek),2)]; @timeon ##=[add(get(##/timeon),2)]}
+
+@@ Commented out as these will cause frequent silent errors without matching code and were always intended as examples.
+@@
+@@ &CRON_TIME_TIMECLOCK mushcron=||||00 02 04 06 08 10 12 14 16 18 20 22 24 26 28 30 32 34 36 38 40 42 44 46 48 50 52 54 56 58|
+@@ &CRON_JOB_TIMECLOCK mushcron=@dolist lwho()={@timeonweek ##=[add(get(##/timeonweek),2)]; @timeon ##=[add(get(##/timeon),2)]}
+@@ &CRON_TIME_TIMEONWEEK-PURGE mushcron=||Sun|03|01|
+@@ &CRON_JOB_TIMEONWEEK-PURGE mushcron=@dolist [setq(0,first(stats()))][iter(lnum(add(fdiv(%q0,1000),or(0,mod(%q0,1000)))),##)]={@trigger #1/TR_TIMEONWEEK-PURGE=[add(mul(##,1000),1)],[mul(add(##,1),1000)]}
 
 &CRON_TIME_BBTIMEOUT mushcron=|||04|15|
 &CRON_JOB_BBTIMEOUT mushcron=@@ Change This to the Right Dbref# -- @trigger #25/tr_timeout


### PR DESCRIPTION
MyrddinCRON usually comes with there example cron jobs. Two of those jobs are connected, but one had been removed. Added the removed example back to the MushCode object, but since both will cause silent errors (one quite frequently), both were commented out.