### PR TITLE
Fixed safe ansi for %m, looked like a copy paste error

### DIFF
--- a/Server/hdrs/rhost_ansi.h
+++ b/Server/hdrs/rhost_ansi.h
@@ -287,10 +287,10 @@
 #define SAFE_ANSI_UNDERSCORE "%mu"
 
 
-//#define SAFE_ANSI_INV_BLINK         "%c"
-//#define SAFE_ANSI_INV_HILITE        "%c"
-//#define SAFE_ANSI_BLINK_HILITE      "%c"
-//#define SAFE_ANSI_INV_BLINK_HILITE  "%c"
+//#define SAFE_ANSI_INV_BLINK         "%m"
+//#define SAFE_ANSI_INV_HILITE        "%m"
+//#define SAFE_ANSI_BLINK_HILITE      "%m"
+//#define SAFE_ANSI_INV_BLINK_HILITE  "%m"
 
 /* Foreground colors */
 


### PR DESCRIPTION
SAFE_ANSI_* is defined and by default commented out once each for %c %m and %x

It looks like these comments had been copy and pasted from %c to %m