### PR TITLE
removed unneeded whitespace in define for cleaner code

### DIFF
--- a/Server/hdrs/pcre.h
+++ b/Server/hdrs/pcre.h
@@ -17,7 +17,7 @@
 #define PCRE_DATE           14-Apr-2003
 
 #ifndef PCRE_DATA_SCOPE
-#  define PCRE_DATA_SCOPE     extern
+#define PCRE_DATA_SCOPE     extern
 #endif
 
 /* Have to include stdlib.h in order to ensure that size_t is defined;


### PR DESCRIPTION
fixed whitespace in #define, would be fine in linker as is, but this is cleaner