### PR TITLE
Fixed warnings and some style issues

### DIFF
--- a/Server/src/functions.c
+++ b/Server/src/functions.c
@@ -30840,9 +30840,10 @@ FUNCTION(fun_beep)
     safe_str(tbuf1, buff, bufcx);
 }
 
+#ifdef ZENTY_ANSI
 static const unsigned char AccentCombo2[256] =
 {   
-/*  0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F   */
+//  0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F 
 
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 0
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // 1
@@ -30861,19 +30862,17 @@ static const unsigned char AccentCombo2[256] =
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // D
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  // E
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0   // F
-};  
-
+}; 
+#endif
 
 FUNCTION(fun_accent)
 {
-#ifdef ZENTY_ANSI
-   char *p_ptr, p_oldptr, p_oldptr2, *p_ptr2;
-   int i_inaccent;
-#endif
-
 #ifndef ZENTY_ANSI
    safe_str(fargs[0], buff, bufcx);
 #else
+   char *p_ptr, p_oldptr, p_oldptr2, *p_ptr2;
+   int i_inaccent;
+
    p_ptr2 = fargs[0];
    p_ptr = fargs[1];
    p_oldptr2 = p_oldptr = '\0';


### PR DESCRIPTION
This was causing warnings in certain builds.

AccentCombo2 in functions.c is always defined, but only used if ZENTY_ANSI is defined

The style of commenting made it difficult to comment out the whole thing for testing, so that's fixed too.

The defines at the beginning of the function were also awkwardly worded.

AccentCombo2 appears at four places in the source code, the two in functions.c as mentioned, but also twice in eval.c One of the two times it appears in eval.c appears to be a the exact same definition as in eval.c

It seems like it would probably be better to pull out that redundancy into a header, but I didn't do that in case I'm missing something, plus it seems like if you were to do that, there would be related things to pull with it.