### PR TITLE
4.2 Changes section, with correction for misfiled changes

### DIFF
--- a/Server/readme/RHOST.CHANGES
+++ b/Server/readme/RHOST.CHANGES
@@ -1,3 +1,8 @@
+                         RhostMUSH 4.2 Update File
+SPEECH_PREFIX/SPEECH_SUFFIX didn't handle unicode properly.
+				- Thanks Pres
+
+
                          RhostMUSH 4.0 Update File
 MUX passwords didn't work properly because of a memcmp() bug.
 				- Thanks Locke
@@ -70,8 +75,6 @@ SIDEFX permissions were borked for normal players.
 				- Thanks Alley
 @name/name() if given empty/null arg for new name and ansi mode clears ansi.
 				- Thanks Thenomain
-SPEECH_PREFIX/SPEECH_SUFFIX didn't handle unicode properly.
-				- Thanks Pres
 
 
                          RhostMUSH 3.9.5 Update File


### PR DESCRIPTION
One of Ash's recent additions went to the bottom of the 4.0 Changes section. I created a 4.2 Changes section and moved that to the top. I looked at other commits to this file, but all were pre-4.2/April 20.