### PR TITLE
Switch relied on bangs and did not check if defined

### DIFF
--- a/Server/src/eval.c
+++ b/Server/src/eval.c
@@ -2209,6 +2209,7 @@ mushexec(dbref player, dbref cause, dbref caller, int eval, char *dstr,
                  break;
              case 'I':       /* itext */
              case 'i':
+#ifdef BANGS
                  dstr++;
                  inumext = 0;
                  if ( dstr && (*dstr == '_' ) ) {
@@ -2275,9 +2276,11 @@ mushexec(dbref player, dbref cause, dbref caller, int eval, char *dstr,
                         safe_str( "#-1 ARGUMENT OUT OF RANGE", buff, &bufc );
                     dstr--;
                  }
+#endif
                  break;
             case 'd':		/* dtext */
             case 'D':
+#ifdef BANGS
                  dstr++;
                  if ( dstr && *dstr ) {
                     setup_bangs(&regbang_not, &regbang_yes, &regbang_string, &regbang_truebool, &dstr);
@@ -2315,6 +2318,7 @@ mushexec(dbref player, dbref cause, dbref caller, int eval, char *dstr,
                        safe_str( "#-1 ARGUMENT OUT OF RANGE", buff, &bufc );
                     dstr--;
                  }
+#endif
                  break;
             case 'w':
             case 'W':		/* TwinkLock enactor */


### PR DESCRIPTION
These two switch cases were causing errors when BANGS was not defined. Both of the cases relied heavily on BANGS.

IMPORTANT: Consider these #ifdefs as the markers for 'problem here' they may be all that's needed, but all of the various implications of this code are beyond my current understanding of the codebase.