### PR TITLE
Reference to help instead of wizhelp

### DIFF
--- a/Server/game/txt/wizhelp.txt
+++ b/Server/game/txt/wizhelp.txt
@@ -9322,7 +9322,7 @@ Example:
   Config parameter: icmd_obj <dbref>. Default: -1
   
   Sets the dbref of the ICMD Object, usable with @icmd/eval.
-  See 'help @icmd'
+  See 'wizhelp @icmd'
 
 & idle_interval
   Config parameter: idle_interval <secs>.  Default: 60


### PR DESCRIPTION
references in 'help @icmd' instead of 'wizhelp @icmd'