### PR TITLE
Removed dead link and fixed and error in downloading CSV

### DIFF
--- a/Server/game/tor_pull.sh
+++ b/Server/game/tor_pull.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 #
-wget http://torstatus.blutmagie.de/ip_list_exit.php/Tor_ip_list_EXIT.csv
-if [ $? -ne 0 ]
-then
-   wget http://torstatus.rueckgr.at/ip_list_exit.php/Tor_ip_list_EXIT.csv
-fi
+wget -O Tor_ip_list_EXIT.csv http://torstatus.rueckgr.at/ip_list_exit.php/Tor_ip_list_EXIT.csv
 if [ -f Tor_ip_list_EXIT.csv ]
 then
   mv -f blacklist.txt blacklist.tor


### PR DESCRIPTION
The tor script tries two different URLs for getting the CSV. The initial URL no longer exists, so it was removed.

In addition, if the script doesn't finish running for whatever reason, when it runs against it will download the CSV with a .1 (or other .#) add the end, and then process the previous CSV. This makes sure it downloads and processes a fresh CSV file everytime, rather than downloading a new one and processing the old.