### PR TITLE
missing + and some stylistic consistency

### DIFF
--- a/Server/game/txt/help.txt
+++ b/Server/game/txt/help.txt
@@ -23,7 +23,7 @@
   
   You may use the /query switch for detailed searching.  Eg: help/query *mail*
   
-  Command syntax help is available by issuing /syntax. Eg: @emit/syntax
+  Command syntax help is available by issuing /syntax.   Eg: @emit/syntax
   
   If there are any errors in the help text, please notify a Wizard.
   An HTML version of all the help contained here is available at
@@ -36,8 +36,8 @@
   and is disabled by default.
   
   The following switches work for +help:
-    /search -- allow wildcard patterning for searches (Eg: help/search *@mail*)
-    /query  -- allow detailed searching and return (Eg: help/query *@mail*)
+    /search -- allow wildcard pattern for searches.  Eg: +help/search *@mail*
+    /query  -- allow detailed searching and return.  Eg: +help/query *@mail*
   
   See Also: help 
 

--- a/Server/game/txt/wizhelp.txt
+++ b/Server/game/txt/wizhelp.txt
@@ -16,7 +16,7 @@
   
   You may use the /search switch for content.  Eg: wizhelp/search *mail*
   
-  Command syntax help is available by issuing /syntax. Eg: @emit/syntax
+  Command syntax help is available by issuing /syntax.  Eg: @emit/syntax
   
   The multi-tier bit order can be seen with 'help control'
   


### PR DESCRIPTION
in help.txt the entry for '+help' had examples that only used 'help' so the '+' was added.

minor stylistic changes and consistency in three entries that use 'Eg:'

NOTE: The main 'wizhelp' lacks a line about '/query' which 'help' and '+help' have. I didn't add in such a line, but you might want to do so, or poke me to put in another pull request with it. Wasn't sure if it was an oversight or something else.