### PR TITLE
tags improvements

### DIFF
--- a/Server/game/txt/help.txt
+++ b/Server/game/txt/help.txt
@@ -6289,12 +6289,12 @@
   The following sanity checks are performed for tags:
   
   * Tagnames cannot be more than 30 characters in length
-  * Tagnames cannot contain whitespace.
+  * Tagnames can only contain alphanumeric, _, -, and unicode characters
+  * Tagnames cannot be all numbers (to avoid conflict with dbrefs)
   * Tags need to be supplied with a valid, existing object's #dbref on
     creation.  This object you must own or control in some manner.
   * Up to 5 tags can reference the same #dbref.  If global tags exceed
     this number, local tags can no longer be assigned.
-  * Unicode is valid in tagnames!
   * On destruction of an object, all referencing tags get also removed.
   * Global tags have precedence over local tags.
   

--- a/Server/hdrs/bst.h
+++ b/Server/hdrs/bst.h
@@ -1,0 +1,24 @@
+#ifndef _BST_H
+#define _BST_H
+
+typedef struct BSTNode {
+    void *data;
+    struct BSTNode *left;
+    struct BSTNode *right;
+    struct BSTNode *parent;
+} BSTNode;
+
+typedef struct {
+    BSTNode *root;
+    int (*comp_func)(const void *, const void *);
+} BST;
+
+BST *bst_create(int (*comp_func)(const void *, const void *));
+void bst_insert(BST *tree, void *data);
+
+void    *bst_delete(BST* tree, void* data, void (*free_func)(void *));
+BSTNode *bst_search(BST* tree, void* data);
+BSTNode *bst_next_node(BST *tree, BSTNode *node);
+void     bst_destroy(BST *tree, void (*free_func)(void *));
+
+#endif

--- a/Server/hdrs/patchlevel.h
+++ b/Server/hdrs/patchlevel.h
@@ -4,7 +4,7 @@
 
 #include "copyright.h"
 
-#define MUSH_VERSION            "4.2.2-102"         /* Base version number*/
+#define MUSH_VERSION            "4.2.2-103"         /* Base version number*/
 
 #if defined(ZENTY_ANSI) && defined(REALITY_LEVELS)
 #define EXT_MUSH_VER "RL(A)"
@@ -18,7 +18,7 @@
 
 #define PATCHLEVEL		0		/* Patch sequence number     */
 #define PATCHLEVELEXT		""
-#define	MUSH_RELEASE_DATE	"12/25/2023"	/* Source release date       */
+#define	MUSH_RELEASE_DATE	"12/26/2023"	/* Source release date       */
 
 /* Define if an ALPHA release */
 /* #define ALPHA 0 */

--- a/Server/src/Makefile
+++ b/Server/src/Makefile
@@ -170,7 +170,7 @@ D_SRC	= door.c shs.c mushcrypt.c news.c mail.c mailfix.c debug.c senses.c \
 	  create.c game.c help.c look.c match.c move.c player.c predicates.c \
 	  rob.c set.c speech.c wiz.c walkdb.c timer.c boolexp.c log.c cque.c \
 	  unparse.c eval.c command.c wild.c netcommon.c functions.c vattr.c \
-	  db.c db_rw.c compress.c stringutil.c object.c conf.c flags.c htab.c \
+	  db.c db_rw.c compress.c stringutil.c bst.c object.c conf.c flags.c htab.c \
 	  compat.c file_c.c player_c.c bsd.c alloc.c autoreg.c levels.c \
           local.c utils.c pcre.c pcre_extensions.c tprintf.c sha1.c 64btime.c \
           sqlite.c websock2.c $(DR_SRC) $(MYSQL_C)
@@ -179,7 +179,7 @@ D_OBJ	= door.o shs.o mushcrypt.o news.o mail.o mailfix.o debug.o senses.o \
 	  create.o game.o help.o look.o match.o move.o player.o predicates.o \
 	  rob.o set.o speech.o wiz.o walkdb.o timer.o boolexp.o log.o cque.o \
 	  unparse.o eval.o command.o wild.o netcommon.o functions.o vattr.o \
-	  db.o db_rw.o compress.o stringutil.o object.o conf.o flags.o htab.o \
+	  db.o db_rw.o compress.o stringutil.o bst.o object.o conf.o flags.o htab.o \
           compat.o file_c.o player_c.o bsd.o alloc.o autoreg.o levels.o \
           local.o utils.o pcre.o pcre_extensions.o tprintf.o sha1.o 64btime.o \
           sqlite.o websock2.o $(DR_OBJ) $(MYSQL_O) $(HSPACE_O)
@@ -377,6 +377,13 @@ UDB_F	= $(UDBO_FLG)
 NET_S	= bsd.c
 NET_O	= bsd.o
 
+OS := $(shell uname -s)
+ifeq ($(OS),Darwin)
+	# ----- macos
+	DEFS += -I/opt/homebrew/include -L/opt/homebrew/lib
+	MORELIBS += -lssl -lcrypto
+endif
+
 # ================== END OF CONFIGURATION SECTION =================
 
 
@@ -473,7 +480,7 @@ debugmon.o: debugmon.c $(incdir)/debug.h
 	$(CC) -g $(ALLCFLAGS) -c debugmon.c
 
 $(bindir)/netrhost.debugmon: debugmon.o debug.o
-	$(CC) -o $(bindir)/netrhost.debugmon debugmon.o debug.o $(MORELIBS)
+	$(CC) -o $(bindir)/netrhost.debugmon debugmon.o debug.o $(DEFS) $(MORELIBS)
 
 $(bindir)/netrhost: $(OBJ) $(LIBOBJS)
 	$(CC) $(ALLCFLAGS) $(VER_FLG) -c $(VER_SRC)

--- a/Server/src/bst.c
+++ b/Server/src/bst.c
@@ -1,0 +1,290 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "bst.h"
+/*
+* Simple implementation of a binary search tree (BST)
+*
+* This implementation can store nodes of any type.
+*
+* The user must provide a comparison function to compare two nodes.
+* The comparison function should return:
+*   a negative number if the first node is less than the second node
+*   a positive number if the first node is greater than the second node
+*   0 if the two nodes are equal
+*
+* This implementation does not handle duplicates. More complex use cases may
+* require additional consideration.
+*
+* PRIMARY FUNCTIONS:
+*
+* bst_create()      // Create a new BST
+* bst_insert()      // Insert a new node into the BST
+* bst_next_node()   // Get the next node in the in-order sequence
+* bst_search()      // Search for a node in the BST, returning the node if found
+* bst_delete()      // Delete a node from the BST
+* bst_destroy()     // Destroy the BST
+*
+* EXAMPLES:
+*
+* bst_create(): Creates a new BST using the provided comparison function.
+*   int compare(const void *a, const void *b) {
+*       return (*(int*)a - *(int*)b);
+*   }
+*   BST* tree_of_ints = bst_create(compare);
+*
+* bst_insert(): Inserts a new node into the BST.
+*   int value = 7;
+*   bst_insert(tree_of_ints, &value);
+*
+* bst_next_node(): Gets the next node in the in-order sequence.
+*
+*   int x = 11;
+*   int y = 13;
+*   int x = 7;
+*   bst_insert(tree_of_ints, &x);
+*   bst_insert(tree_of_ints, &y);
+*   bst_insert(tree_of_ints, &z);
+*   BSTNode *node = bst_next_node(tree_of_ints, NULL);
+*   printf("value %d\n", *(int*)node->data);    // "value 7"
+*   node = bst_next_node(tree_of_ints, node);
+*   printf("value %d\n", *(int*)node->data);    // "value 11"
+*   node = bst_next_node(tree_of_ints, node);
+*   printf("value %d\n", *(int*)node->data);    // "value 13"
+*
+* bst_search(): Searches for a node in the BST.
+*
+*   BSTNode *node = bst_search(tree_of_ints, &value);
+*   printf("value %d\n", *(int*)node->data);    // "value 7"
+*
+*
+* See test/bst_test.c for more examples.
+*/
+
+// local helper function declarations
+static BSTNode *_create_bst_node(void *data);
+static void _bst_destroy(BSTNode* node, void (*free_func)(void *));
+
+// bst_create creates a new binary search tree.  The supplied comparison
+// function will be used for inserts, deletes, and searches.
+BST *bst_create(int (*comp_func)(const void *, const void *)) {
+    if (!comp_func) { return NULL; }
+
+    BST *tree = malloc(sizeof(BST));
+    if (!tree) { return NULL; }
+
+    tree->root = NULL;
+    tree->comp_func = comp_func;
+    return tree;
+}
+
+// bst_insert inserts a new node into the BST
+void bst_insert(BST *tree, void *data) {
+    if (!tree || !tree->comp_func || !data) {
+        return;
+    }
+
+    BSTNode *node = _create_bst_node(data);
+    if (!node) { return; };
+
+    if (tree->root == NULL) {
+        tree->root = node;
+        return;
+    }
+
+    BSTNode *current = tree->root;
+    BSTNode *parent = NULL;
+
+    while (current != NULL) {
+        parent = current;
+        if (tree->comp_func(data, current->data) < 0) {
+            current = current->left;
+        } else {
+            current = current->right;
+        }
+    }
+    node->parent = parent;
+
+    if (!parent) {
+        // should never happen, but just in case
+        return;
+    }
+
+    if (tree->comp_func(data, parent->data) < 0) {
+        parent->left = node;
+    } else {
+        parent->right = node;
+    }
+}
+
+// bst_search searches for a node in the BST
+BSTNode *bst_search(BST* tree, void* data) {
+    int comparison;
+
+    if (!tree || !tree->comp_func || !tree->root || !data) {
+        return NULL;
+    }
+
+    BSTNode *current = tree->root;
+    while (current != NULL && (comparison = tree->comp_func(data, current->data)) != 0) {
+        if (comparison < 0) {
+            current = current->left;
+        } else {
+            current = current->right;
+        }
+    }
+
+    return current ? current->data : NULL;
+}
+
+// bst_delete looks for a node based on the given data and deletes it.
+// If the optional free_func is provided, it will be called on the data of the
+// freed node and bst_delete will return NULL.
+// If the optional free_func is is NULL, bst_delete will return a pointer to
+// the data that was in the deleted node.
+void *bst_delete(BST *tree, void *data, void (*free_func)(void *)) {
+    if (!tree || !tree->root) {
+        return NULL;
+    }
+
+    BSTNode *current = tree->root;
+    BSTNode *parent = NULL;
+    int cmp;
+
+    // Find the node to delete
+    while (current != NULL && (cmp = tree->comp_func(data, current->data)) != 0) {
+        parent = current;
+        current = cmp < 0 ? current->left : current->right;
+    }
+
+    if (current == NULL) {
+        // Node not found
+        return NULL;
+    }
+
+    // save this so we can return to the calling function
+    void *deleted_data = current->data;
+
+    if (current->left != NULL && current->right != NULL) {
+        // Node with two children
+        BSTNode *successor = current->right;
+        BSTNode *successor_parent = current;
+
+        // Find the in-order successor (leftmost child of right subtree)
+        while (successor->left != NULL) {
+            successor_parent = successor;
+            successor = successor->left;
+        }
+
+        // Swap data
+        current->data = successor->data;
+        current = successor; // Now delete the successor
+        parent = successor_parent;
+    }
+
+    // Now current has at most one child
+    BSTNode *child = (current->left != NULL) ? current->left : current->right;
+
+    if (parent == NULL) {
+        // Deleting the root node
+        tree->root = child;
+    } else if (parent->left == current) {
+        parent->left = child;
+    } else {
+        parent->right = child;
+    }
+
+    if (child != NULL) {
+        child->parent = parent;
+    }
+
+    if (free_func && deleted_data) {
+        free_func(deleted_data);
+        deleted_data = NULL;
+    }
+    free(current);
+
+    return deleted_data;
+}
+
+// bst_destroy takes a BST * and destroys the entire BST via _bst_destroy.
+// the optional 'free_func' is called on each node's data before the node is freed.
+void bst_destroy(BST *tree, void (*free_func)(void *)) {
+    if (!tree) {
+        return;
+    }
+    _bst_destroy(tree->root, free_func);
+    free(tree);
+}
+
+// bst_next returns the next node in the in-order sequence
+BSTNode* bst_next_node(BST *bst, BSTNode *node)
+{
+    if (!bst) {
+        return NULL;
+    }
+
+    if(!node)
+    {
+        // return the leftmost/smallest node
+        node = bst->root;
+        while(node && node->left) { node = node->left; }
+        return node;
+    }
+
+    // Finding the next node in the in-order sequence: the successor
+    if(node->right)
+    {
+        node = node->right;
+        while(node && node->left) { node = node->left; }
+        return node;
+    }
+
+    BSTNode* y = node->parent;
+    while (y && node == y->right)
+    {
+        node = y;
+        if (node) {
+            y = node->parent;
+        }
+    }
+    return y;
+}
+
+
+/*
+* Helper Functions
+*/
+
+// Helper function to create a new BST node
+static BSTNode *_create_bst_node(void *data) {
+    BSTNode *node = malloc(sizeof(BSTNode));
+    if (!node) { return NULL; };
+
+    memset(node, 0, sizeof(BSTNode));
+    node->data = data;
+    node->left = NULL;
+    node->right = NULL;
+
+    return node;
+}
+
+// bst_destroy destroys the entire BST
+static void _bst_destroy(BSTNode* node, void (*free_func)(void *)) {
+    if(node == NULL) {
+        // Base case
+        return;
+    }
+
+    // first delete subtrees (children)
+    _bst_destroy(node->left, free_func);
+    _bst_destroy(node->right, free_func);
+
+    if (free_func) {
+        free_func(node->data);
+    }
+
+    // then delete the node
+    free(node);
+}

--- a/Server/test/Makefile
+++ b/Server/test/Makefile
@@ -1,0 +1,34 @@
+CC=gcc
+CFLAGS=-c -g
+
+# add header directory of ../hdrs to include path
+CFLAGS+=-I../hdrs
+
+SRC_DIR=../src
+HDR_DIR=../hdrs
+
+# directory to drop object files
+OBJ_DIR=obj
+
+all: $(OBJ_DIR) bst_test
+
+test: $(OBJ_DIR) bst_test
+	./bst_test
+
+$(OBJ_DIR):
+	mkdir -p $(OBJ_DIR)
+
+#
+# bst_test
+#
+bst_test: $(OBJ_DIR)/bst_test.o $(OBJ_DIR)/bst.o
+	$(CC) $(OBJ_DIR)/bst_test.o $(OBJ_DIR)/bst.o -o bst_test
+
+$(OBJ_DIR)/bst_test.o: bst_test.c $(HDR_DIR)/bst.h
+	$(CC) $(CFLAGS) bst_test.c -o $(OBJ_DIR)/bst_test.o
+
+$(OBJ_DIR)/bst.o: $(SRC_DIR)/bst.c $(HDR_DIR)/bst.h
+	$(CC) $(CFLAGS) $(SRC_DIR)/bst.c -o $(OBJ_DIR)/bst.o
+
+clean:
+	rm -rf $(OBJ_DIR)/*.o bst_test

--- a/Server/test/bst_test.c
+++ b/Server/test/bst_test.c
@@ -1,0 +1,217 @@
+#include "../hdrs/bst.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <assert.h>
+
+// foo_struct is a dummy struct for acting as a data node and testing the bst
+// logic.  It contains a string.
+typedef struct {
+	char *str;
+} foo_struct;
+
+// me is a global string set to 'bst_test' to be used in logging statements
+char *me = "bst_test";
+
+
+int compare_func(const void *a, const void *b);
+void short_address(void *addr, char *buf);
+void check_tree(BST *tree, char *fruitsAlphabetical[], char dump);
+void dump_tree(BST *tree);
+char *remove_from_array(char *arr[], int index, int len);
+void remove_from_array_by_name(char **fruitsAlphabetical, char *str, int len);
+void delete_from_tree(BST *tree, char *str);
+
+#define arr_len(arr) (sizeof(arr) / sizeof(arr[0]))
+
+int main() {
+    BST *tree = bst_create(compare_func);
+    assert(tree != NULL);
+
+    // values to insert into the tree
+    char* fruitsRandom[26] = {
+        "Jackfruit", "Watermelon", "Apple", "Raspberry", "Fig",
+        "Orange", "Kiwi", "Lemon", "Yellow passionfruit", "Elderberry",
+        "Ugli fruit", "Honeydew", "Banana", "Xigua", "Grape",
+        "Indian plum", "Cherry", "Strawberry", "Nectarine", "Voavanga",
+        "Mango", "Zucchini", "Date", "Papaya", "Quince", "Tomato"
+    };
+
+    // the same values, but in alphabetical order.  used to check walking the tree in order.
+    char* fruitsAlphabetical[26] = {
+        "Apple", "Banana", "Cherry", "Date", "Elderberry",
+        "Fig", "Grape", "Honeydew", "Indian plum", "Jackfruit",
+        "Kiwi", "Lemon", "Mango", "Nectarine", "Orange",
+        "Papaya", "Quince", "Raspberry", "Strawberry", "Tomato",
+        "Ugli fruit", "Voavanga", "Watermelon", "Xigua",
+        "Yellow passionfruit", "Zucchini"
+    };
+
+    // loop over fruitsRandom and insert each into the tree
+    printf(":: building BST\n");
+    for (int i = 0; i < 26; i++) {
+        foo_struct *foo = malloc(sizeof(foo_struct));
+        foo->str = fruitsRandom[i];
+        bst_insert(tree, foo);
+    }
+
+    // dump_tree(tree);
+    check_tree(tree, fruitsAlphabetical, 0);
+
+    // remove element 5 from fruitsAlphabetical and the tree
+    delete_from_tree(tree, remove_from_array(fruitsAlphabetical, 5,arr_len(fruitsAlphabetical)));
+
+    // dump_tree(tree);
+    check_tree(tree, fruitsAlphabetical, 0);
+
+    // remove indexes 3, 12, and 20 from fruitsAlphabetical and the tree
+    delete_from_tree(tree, remove_from_array(fruitsAlphabetical, 3,arr_len(fruitsAlphabetical)));
+    delete_from_tree(tree, remove_from_array(fruitsAlphabetical, 12,arr_len(fruitsAlphabetical)));
+    delete_from_tree(tree, remove_from_array(fruitsAlphabetical, 20,arr_len(fruitsAlphabetical)));
+
+    check_tree(tree, fruitsAlphabetical, 0);
+
+    // try deleting a node that doesn't exist
+    printf(":: attempt to delete a node that doesn't exist\n");
+    foo_struct foo;
+    foo.str = "foo";
+    void *old_data = bst_delete(tree, &foo, free);
+    assert(old_data == NULL);
+
+    // delete the root node
+    printf(":: delete the root node\n");
+    old_data = bst_delete(tree, tree->root->data, NULL);
+    assert(old_data != NULL);
+    remove_from_array_by_name(fruitsAlphabetical, ((foo_struct *)old_data)->str, arr_len(fruitsAlphabetical));
+    free(old_data);
+
+    // one more check of the tree for integrity
+    check_tree(tree, fruitsAlphabetical, 0);
+
+    // destroy the tree, using free() to free each foo_struct in the tree
+    bst_destroy(tree, free);
+
+    printf("\n%s: All tests passed successfully.\n", me);
+
+    return 0;
+}
+
+// compare_func is a comparison function for btree logic.  It compares the
+// string values in two foo_structs.
+int compare_func(const void *a, const void *b) {
+	foo_struct *fooA = (foo_struct *)a;
+	foo_struct *fooB = (foo_struct *)b;
+
+	return strcmp(fooA->str, fooB->str);
+}
+
+// short_address is a helper function for determining the last 8 characters of an address.
+// it takes two arguments, a pointer address and a buffer to write the last 8 characters to.
+// makes for less verbose logging
+void short_address(void *addr, char *buf) {
+    char tmpbuf[20];
+    int len = 0;
+
+    snprintf(tmpbuf, sizeof(tmpbuf), "%p", addr);
+    while(tmpbuf[len] != '\0') {
+        len++;
+    }
+
+    if (len > 8) {
+        strncpy(buf, tmpbuf + len - 8, 8);
+        buf[8] = 0;
+    } else {
+        strncpy(buf, tmpbuf, len);
+        buf[len] = 0;
+    }
+}
+
+// remove_from_array is a helper function for removing an element from an array.
+// given an array and an index, it will remove the element at that index and
+// shift the remaining elements down. the function will return the string it
+// removed.
+char *remove_from_array(char *arr[], int index, int len) {
+    char *removed = arr[index];
+    // shift everything down
+    for (int i = index; i < len - 1; i++) {
+        arr[i] = arr[i + 1];
+    }
+    return removed;
+}
+
+void remove_from_array_by_name(char **fruitsAlphabetical, char *str, int len) {
+    int i = 0;
+    while (strcmp(str, fruitsAlphabetical[i]) != 0) {
+        i++;
+    }
+    remove_from_array(fruitsAlphabetical, i, len);
+}
+
+void delete_from_tree(BST *tree, char *str) {
+    foo_struct foo;
+    foo.str = str;
+
+    printf(":: delete %s\n", foo.str);
+    bst_delete(tree, &foo, free);
+}
+
+// check_tree walks the entire tree and compares the values to the supplied array.
+// if dump is true, it will print out the entire tree as it goes.
+void check_tree(BST *tree, char *fruitsAlphabetical[], char dump) {
+    BSTNode *node;
+    int i = 0;
+
+    printf("\n:: CHECK_TREE\n");
+    for (node = bst_next_node(tree, NULL);
+         node;
+         node = bst_next_node(tree, node))
+    {
+        if (dump) {
+            char nodeAddr[9];
+            char dataAddr[9];
+            char strAddr[9];
+            char leftAddr[9];
+            char rightAddr[9];
+            char parentAddr[9];
+            short_address(node, nodeAddr);
+            short_address(node->data, dataAddr);
+            short_address(((foo_struct *)node->data)->str, strAddr);
+            short_address(node->left, leftAddr);
+            short_address(node->right, rightAddr);
+            short_address(node->parent, parentAddr);
+            char *str = ((foo_struct *)node->data)->str;
+            printf("::\tnode: %8s, node->data: %8s, node->data->str: %-8.8s, node->left: %8s, node->right: %8s, node->parent: %8s\n", nodeAddr, dataAddr, str, leftAddr, rightAddr, parentAddr);
+        }
+        // printf(":: check_tree: comparing node value %s to %s\n", ((foo_struct *)node->data)->str, fruitsAlphabetical[i]);
+        assert(strcmp(((foo_struct *)node->data)->str, fruitsAlphabetical[i]) == 0);
+        i++;
+    }
+    printf("\n");
+}
+
+void dump_tree(BST *tree) {
+    BSTNode *node;
+
+    printf("\n:: DUMP_TREE\n");
+    for (node = bst_next_node(tree, NULL);
+         node;
+         node = bst_next_node(tree, node))
+    {
+        char nodeAddr[9];
+        char dataAddr[9];
+        char strAddr[9];
+        char leftAddr[9];
+        char rightAddr[9];
+        char parentAddr[9];
+        short_address(node, nodeAddr);
+        short_address(node->data, dataAddr);
+        short_address(((foo_struct *)node->data)->str, strAddr);
+        short_address(node->left, leftAddr);
+        short_address(node->right, rightAddr);
+        short_address(node->parent, parentAddr);
+        char *str = ((foo_struct *)node->data)->str;
+        printf("::\tnode: %8s, node->data: %8s, node->data->str: %-8.8s, node->left: %8s, node->right: %8s, node->parent: %8s\n", nodeAddr, dataAddr, str, leftAddr, rightAddr, parentAddr);
+    }
+    printf("\n");
+}


### PR DESCRIPTION
`@tag/list` is sorted
new tag names now have a more sane validation:
- only alphanumeric, _, -, and unicode characters allowed
- new tag names can no longer be all numeric (to avoid collisions with real debrefs)

fixed an off by one error for tag listings
removed duplicate code in tag listing logic

added simple binary search tree functionality to allow for efficient sorting of tags
added `Server/test` subdir with tests for the new BST code
minor tweaks to `Server/src/Makefile` to allow compilation on macOS