### PR TITLE
@tag/list: fix off by one column alignment

### DIFF
--- a/Server/hdrs/patchlevel.h
+++ b/Server/hdrs/patchlevel.h
@@ -4,7 +4,7 @@
 
 #include "copyright.h"
 
-#define MUSH_VERSION            "4.2.2-133"         /* Base version number*/
+#define MUSH_VERSION            "4.2.2-134"         /* Base version number*/
 
 #if defined(ZENTY_ANSI) && defined(REALITY_LEVELS)
 #define EXT_MUSH_VER "RL(A)"
@@ -18,7 +18,7 @@
 
 #define PATCHLEVEL		0		/* Patch sequence number     */
 #define PATCHLEVELEXT		""
-#define	MUSH_RELEASE_DATE	"02/22/2024"	/* Source release date       */
+#define	MUSH_RELEASE_DATE	"02/25/2024"	/* Source release date       */
 
 /* Define if an ALPHA release */
 /* #define ALPHA 0 */

--- a/Server/src/object.c
+++ b/Server/src/object.c
@@ -2912,7 +2912,7 @@ void do_tag(dbref player, dbref cause, int key, char *s_tagname, char *target)
 
                      sprintf(s_hashstr, "%c %-*s | %-8s | #%d",
                              t_warn,
-                             (32 + strlen(t_distag) - strlen(s_buff)),
+                             (31 + strlen(t_distag) - strlen(s_buff)),
                              t_distag,
                              (i_personal ? "- Yes -" : " "), storedtag->tagref);
 


### PR DESCRIPTION
@tag/list column dividers had an off-by-one alignment problem.
This change fixes that.