### PR TITLE
Added FUN_MONIKER to softfunctions.minmax for compatability.

### DIFF
--- a/Mushcode/softfunctions.minmax
+++ b/Mushcode/softfunctions.minmax
@@ -128,6 +128,7 @@
 &REGEXP.LNUMRANGES SoftFunctions=(-?\d+)-(-?\d+)
 &MINMAX_LNUMRANGES SoftFunctions=1 1
 &FUN_MANSI SoftFunctions=[step(#lambda/[lit([editansi(%1,n,%0)])],%0 %1 %2 %3 %4 %5 %6 %7 %8 %9,2)]
+&FUN_MONIKER SoftFunctions=cname(%0)
 @fo SoftFunctions=&DB me=num(SoftFunctions)
 @tel SFSideFX=softfunctions
 @startup SoftFunctions=@dolist lattr([v(db)]/fun_*)=@function [after(##,_)]=[v(db)]/##;@dolist lattr([v(db)]/funp_*)=@function/priv/pres [after(##,_)]=[v(db)]/##;@dolist lattr([v(DB)]/funpr_*)=@function/pres [after(##,_)]=[v(DB)]/##;@dolist lattr([v(db)]/funpv_*)=@function/priv [after(##,_)]=[v(DB)]/##;@dolist lattr([v(db)]/funpt_*)=@function/priv/notrace [after(##,_)]=[v(db)]/##;@wait 10={@dolist lattr([v(db)]/funflag_*)=@admin function_access=[after(##,_)] [get([v(db)]/##)]};@wait 10=@dolist lattr([v(db)]/minmax_*)={@function/min [after(##,_)]=[first(get([v(db)]/##))];@function/max [after(##,_)]=[rest(get([v(db)]/##))]}


### PR DESCRIPTION
Penn has the moniker() function, and I've noticed it's also in the City of Hope (TinyMUX) codebase I'm working on cleaning up.

Rhost's equivalent is cname() so I added a wrapper.