### PR TITLE
atr_add_raw + set_attrib: fix STORE/A_LIST desync and silent OOM

### DIFF
--- a/Server/src/db.c
+++ b/Server/src/db.c
@@ -3317,11 +3317,33 @@ atr_add_raw(dbref thing, int atr, char *buff)
 	return;
     }
     if ((a = (Attr *) malloc(strlen(buff) + 1)) == (char *) 0) {
+	/* Log so staff can see silent attr loss under memory pressure */
+	STARTLOG(LOG_ALWAYS, "BUG", "ATRADD")
+	    log_text((char *) "atr_add_raw: malloc failed for attribute ");
+	    log_number(atr);
+	    log_text((char *) " on #");
+	    log_number(thing);
+	ENDLOG
 	return;
     }
     strcpy(a, buff);
 
-    STORE(&okey, a);
+    /*
+     * STORE (cache_put) can fail before taking ownership of a
+     * (NULL args, malloc for new Obj, get_free_entry). Never al_add
+     * on failure — that desyncs A_LIST from UDB/cache data.
+     */
+    if (STORE(&okey, a) != 0) {
+	free(a);
+	STARTLOG(LOG_ALWAYS, "BUG", "ATRADD")
+	    log_text((char *) "atr_add_raw: STORE/cache_put failed for attribute ");
+	    log_number(atr);
+	    log_text((char *) " on #");
+	    log_number(thing);
+	    log_text((char *) " (A_LIST not updated)");
+	ENDLOG
+	return;
+    }
     al_add(thing, atr);
     switch (atr) {
     case A_STARTUP:

--- a/Server/src/udb_ocache.c
+++ b/Server/src/udb_ocache.c
@@ -111,7 +111,7 @@ static int cache_write(Cache *cp);
 static void cache_clean(CacheLst *sp);
 
 static Attr *get_attrib(Aname *anam, Obj *obj);
-static void set_attrib(Aname *anam, Obj *obj, Attr *value);
+static int set_attrib(Aname *anam, Obj *obj, Attr *value);
 static void del_attrib(Aname *anam, Obj *obj);
 static void	FDECL(objfree, (Obj *));
 
@@ -539,7 +539,8 @@ cache_put(Aname *nam, Attr *obj)
 
 			/* Right object, set the attribute */
 
-			set_attrib(nam,cp->op,obj);
+			if (set_attrib(nam,cp->op,obj) != 0)
+				RETURN(1); /* #166 */
 
 #ifdef	CACHE_DEBUG
 			printf("cache_put object %d, attr %d -- %d\n",
@@ -558,7 +559,8 @@ cache_put(Aname *nam, Attr *obj)
 
 			/* Right object, set the attribute */
 
-			set_attrib(nam,cp->op,obj);
+			if (set_attrib(nam,cp->op,obj) != 0)
+				RETURN(1); /* #166 */
 
 #ifdef	CACHE_DEBUG
 			printf("cache_put object %d,attr %d -- %d\n",
@@ -575,7 +577,8 @@ cache_put(Aname *nam, Attr *obj)
 
 			/* Right obj. Set the attrib. */
 
-			set_attrib(nam,cp->op,obj);
+			if (set_attrib(nam,cp->op,obj) != 0)
+				RETURN(1); /* #166 */
 
 #ifdef	CACHE_DEBUG
 			printf("cache_put object %d, attr %d -- %d\n",
@@ -594,7 +597,8 @@ cache_put(Aname *nam, Attr *obj)
 
 			/* Right object. Set the attribute. */
 
-			set_attrib(nam,cp->op,obj);
+			if (set_attrib(nam,cp->op,obj) != 0)
+				RETURN(1); /* #166 */
 
 #ifdef	CACHE_DEBUG
 			printf("cache_put %d,%d %d\n",
@@ -633,7 +637,16 @@ cache_put(Aname *nam, Attr *obj)
 
 	/* Now we got the thing, hang the new version of the attrib on it. */
 
-	set_attrib(nam,newobj,obj);
+	if (set_attrib(nam,newobj,obj) != 0) {
+		/*
+		 * get_free_entry already unlinked this Cache slot; park the
+		 * object so the entry is not lost. value ownership remains
+		 * with the caller (set_attrib failed before install).
+		 */
+		cp->op = newobj;
+		INSHEAD(sp->mactive, cp);
+		RETURN(1); /* #166 */
+	}
 
 	cp->op = newobj;
 
@@ -922,7 +935,12 @@ get_attrib(Aname *anam, Obj *obj)
 	RETURN((Attr *)0); /* Not found */ /* #172 */
 }
 
-static void
+/*
+ * Install value on obj. On success (0), takes ownership of value.
+ * On failure (1), does not free value — caller retains ownership so
+ * cache_put can return failure and atr_add_raw can free without double-free.
+ */
+static int
 set_attrib(Aname *anam, Obj *obj, Attr *value)
 {
 	int	i;
@@ -935,10 +953,10 @@ set_attrib(Aname *anam, Obj *obj, Attr *value)
 
 	if(obj->atrs == ATNULL){
 		a = (Attrib *) malloc(sizeof(Attrib));
-		if(a == ATNULL) { /* Fail silently. It's a game. */
-			/* Caller transferred ownership of 'value' to us, free it. */
-			free(value);
-			VOIDRETURN; /* #173 */
+		if(a == ATNULL) {
+			log_db_err(anam->object, anam->attrnum,
+				"allocate attribute vector for");
+			RETURN(1); /* #173 */
                 }
 
 		obj->atrs = a;
@@ -946,7 +964,7 @@ set_attrib(Aname *anam, Obj *obj, Attr *value)
 		a[0].attrnum = anam->attrnum;
 		a[0].data = (char *) value;
 		a[0].size = ATTR_SIZE(value);
-		VOIDRETURN; /* #173 */
+		RETURN(0); /* #173 */
 	}
 
 
@@ -960,7 +978,7 @@ set_attrib(Aname *anam, Obj *obj, Attr *value)
 			free(a[i].data);
 			a[i].data = (char *) value;
 			a[i].size = ATTR_SIZE(value);
-			VOIDRETURN; /* #173 */
+			RETURN(0); /* #173 */
 		}
 	}
 
@@ -969,10 +987,9 @@ set_attrib(Aname *anam, Obj *obj, Attr *value)
 	a = (Attrib *) realloc(obj->atrs, (obj->at_count + 1) * sizeof(Attrib));
 
 	if(!a){
-		/* Silently fail. It's just a game. */
-		/* Caller transferred ownership of 'value' to us, free it. */
-		free(value);
-		VOIDRETURN; /* #173 */
+		log_db_err(anam->object, anam->attrnum,
+			"grow attribute vector for");
+		RETURN(1); /* #173 */
 	}
 
 	a[obj->at_count].data = value;
@@ -980,7 +997,7 @@ set_attrib(Aname *anam, Obj *obj, Attr *value)
 	a[obj->at_count].size = ATTR_SIZE(value);
 	obj->at_count = obj->at_count + 1;
 	obj->atrs = a;
-        VOIDRETURN; /* #173 */
+        RETURN(0); /* #173 */
 }
 
 static void


### PR DESCRIPTION
## Summary

First code fixes from the audit series ([#248](https://github.com/RhostMUSH/trunk/issues/248)) — attribute write integrity under `cache_put` / OOM.

### Commit 1 — Fixes [#249](https://github.com/RhostMUSH/trunk/issues/249), logs [#250](https://github.com/RhostMUSH/trunk/issues/250)
`Server/src/db.c` `atr_add_raw`:
- On `STORE`/`cache_put` failure: free buffer, log `BUG/ATRADD`, **do not** `al_add`
- On malloc failure: log instead of silent return

### Commit 2 — Fixes [#251](https://github.com/RhostMUSH/trunk/issues/251)
`Server/src/udb_ocache.c`:
- `set_attrib` returns `int` (0 success / 1 OOM)
- On OOM: log via `log_db_err`, **do not** free `value` (caller retains ownership — pairs with atr_add_raw free-on-failure)
- On success: still takes ownership (install / replace)
- `cache_put` checks all five `set_attrib` call sites; returns 1 on failure
- New-object path: if `set_attrib` fails after `get_free_entry`, park the Obj so the Cache slot is not lost, still return failure

## Why both commits together

#249 alone still believed success when `set_attrib` dropped the write and freed the value. #251 alone without #249 would leave A_LIST desync on other `cache_put` failures. Together: failure ⇒ no A_LIST claim, buffer freed once, log line.

## Test plan

- [x] Build default QDBM / `CACHE_OBJS` path
- [x] Normal `@set` / attr write still works
- [x] Forced OOM / instrumented malloc failure: log present, no phantom lattr, no double-free crash
- [ ] Optional: standalone/dbconvert still build