### PR TITLE
sconnect: boot double-negotiate without killing re-IP; tighten host docs

### DIFF
--- a/Server/defaults/game/netrhost.conf.default
+++ b/Server/defaults/game/netrhost.conf.default
@@ -729,6 +729,9 @@ include rhost_ingame.conf
 ##### - This is the optional host(s) you wish to set to be allowable to issue the sconnect_cmd
 #       on port connects.  By default it uses 'localhost'.  It accepts multiple sites and 
 #       wildcards such as '*' and '?'.
+#       SECURITY: any matching peer can assert an arbitrary client IP (site checks / logs).
+#       Keep this tight (localhost / 127.0.0.1 / ::1 for local stunnel). Avoid '*' and open
+#       network wildcards unless every host that can reach the port is fully trusted.
 # sconnect_host localhost*
 #
 ##### - Disable connect commands on connect screen.  Add them to combine.

--- a/Server/readme/README.SSL
+++ b/Server/readme/README.SSL
@@ -69,6 +69,15 @@ sconnect_host wildcards -- This allows wildcarded sites (one or more) to allow
                            You can verify this by checking your /etc/hosts 
                            file.
 
+SECURITY (critical): Any TCP peer that matches sconnect_host can assert an
+arbitrary client IP via the sconnect secret command or HAProxy-style PROXY
+lines. That rewrites site checks, logs, and bans for that connection.
+Keep sconnect_host as tight as possible — almost always only the stunnel
+host (localhost / 127.0.0.1 / ::1). Do NOT use broad wildcards such as
+'*' or open network ranges unless you fully trust every host that can
+reach the mush port from those addresses. Prefer local stunnel on the
+same machine so the peer is always loopback.
+
 Note: the sconnect_host is optional.  If you do not specify it, it will
       default to two values:  'localhost' and '127.0.0.1'.
   

--- a/Server/src/netcommon.c
+++ b/Server/src/netcommon.c
@@ -5717,11 +5717,15 @@ do_command(DESC * d, char *command)
              log_text("[HACKING] ");
              log_text(s_rollback);
           ENDLOG
-          /* We're disabling the SSL handler at this point as it's been compromised */
+          /*
+           * Double negotiate: boot this descriptor only.
+           * Do not clear mudconf.sconnect_reip — that disabled SSL
+           * re-IP for the whole process until conf reload/restart and
+           * degraded site ACLs/logs for everyone (audit F-0024 / #260).
+           */
           STARTLOG(LOG_ALWAYS, "NET", "SSL");
-             log_text("SSL handler [sconnect_reip] has been disabled as secret [sconnect_cmd] was guessed");
+             log_text("SSL double-negotiate from allowed host; booting descriptor (sconnect_reip left enabled)");
           ENDLOG
-          mudconf.sconnect_reip = 0;
           shutdownsock(d, R_BOOT);
           free_lbuf(s_rollback);
           RETURN(0); /* #147 */

--- a/Server/stunnel/README
+++ b/Server/stunnel/README
@@ -30,6 +30,11 @@ sconnect_host wildcards    -- This allows wildcarded sites (one or more)
                               as 'localhost' to you.  You can verify this
                               by checking your /etc/hosts file.
 
+SECURITY: Peers matching sconnect_host can rewrite the client IP seen by
+the mush (site lists, logs, bans). Keep this list minimal — typically
+only localhost / 127.0.0.1 / ::1 for local stunnel. Broad wildcards
+("*") are an open invitation to IP spoofing of site policy.
+
 Note: the sconnect_host is optional.  If you do not specify it, it will
       default to two values:  'localhost' and '127.0.0.1'.
   


### PR DESCRIPTION
## Summary

Second audit-series batch after the attr-write PR (#268).

### Code — Fixes [#260](https://github.com/RhostMUSH/trunk/issues/260)
`Server/src/netcommon.c`: on SSL double-negotiate (`DS_SSL` already set when PROXY/sconnect_cmd arrives):
- Still boot the descriptor and log/monitor `SCONNECT PROXY [HACKING]`
- **Stop** setting `mudconf.sconnect_reip = 0` for the whole process
- Log that re-IP remains enabled

Fail-closed on that socket is kept; global availability hit is removed.

### Docs — Addresses [#259](https://github.com/RhostMUSH/trunk/issues/259)
Explicit SECURITY notes that any TCP peer matching `sconnect_host` can assert client IPs (site checks / logs / bans). Keep list loopback-tight.

- `Server/readme/README.SSL`
- `Server/stunnel/README`
- `Server/defaults/game/netrhost.conf.default` comments

## Test plan

- [ ] With stunnel/local sconnect: single re-IP still works
- [ ] Second sconnect on same descriptor: boot, monitor/log fire, **subsequent** SSL connects still re-IP
- [ ] Docs read OK to maintainers

Related: #248