### PR TITLE
Audit reliability remainder: debug stack exit, atr_get_raw pool, queue slot refund

### DIFF
--- a/Server/hdrs/debug.h
+++ b/Server/hdrs/debug.h
@@ -28,6 +28,9 @@ Debugmem * shmConnect(int debug_id, int create, int *pShmid);
 #define INITDEBUG(x) { memset(x, 0, sizeof(Debugmem)); x->lastdbfetch = -1; }
 
 #ifndef NODEBUGMONITOR
+/* On overflow/underflow: log once per imbalance and keep running.
+ * exit(1) killed live games when debugmon was attached (issue #256).
+ */
 #define DPUSH   {if(debugmem && debugmem->stacktop < STACKMAX) { \
                   debugmem->callstack[debugmem->stacktop].filenum = \
                     FILENUM; \
@@ -37,15 +40,13 @@ Debugmem * shmConnect(int debug_id, int create, int *pShmid);
                     (debugmem->stacktop > debugmem->stackval ? debugmem->stacktop : debugmem->stackval); \
                 } \
                 else if(debugmem) { \
-                  printf("Debug Stack Overflow! (line %d of fp %d)\n", __LINE__, FILENUM); \
-                  exit(1); \
+                  printf("Debug Stack Overflow! (line %d of fp %d) - not exiting\n", __LINE__, FILENUM); \
                 }}
 #define DPOP    {if(debugmem && debugmem->stacktop > 0) { \
                   debugmem->stacktop--; \
                 } \
                 else if(debugmem) { \
-                  printf("Debug Stack Underflow! (line %d of fp %d)\n",__LINE__, FILENUM); \
-                  exit(1); \
+                  printf("Debug Stack Underflow! (line %d of fp %d) - not exiting\n",__LINE__, FILENUM); \
                 }}
 #define DPOPCONDITIONAL   {if(debugmem && debugmem->stacktop > 0) { \
                   debugmem->stacktop--; \

--- a/Server/src/cque.c
+++ b/Server/src/cque.c
@@ -1704,6 +1704,9 @@ setup_que(dbref player, dbref cause, char *command,
 	}
 	if (tpid > last_pid) {
 	  notify(Owner(player), "Unable to queue command.");
+	  /* Refund the queue slot charged by a_Queue() above; this
+	   * return path never queues anything. */
+	  a_Queue(Owner(player), -1);
 	  STARTLOG(LOG_ALWAYS, "QUEUE", "PIDEXHAUST")
 	      log_text("setup_que: pid_table exhausted; queue request dropped.");
 	  ENDLOG
@@ -1718,6 +1721,8 @@ setup_que(dbref player, dbref cause, char *command,
       }
       if (tpid > MUMAXPID) {
 	notify(Owner(player), "Unable to queue command.");
+	/* Refund the queue slot charged by a_Queue() above. */
+	a_Queue(Owner(player), -1);
 	STARTLOG(LOG_ALWAYS, "QUEUE", "PIDEXHAUST")
 	    log_text("setup_que: pid_table exhausted; queue request dropped.");
 	ENDLOG

--- a/Server/src/db.c
+++ b/Server/src/db.c
@@ -3412,16 +3412,28 @@ atr_set_flags(dbref thing, int atr, dbref flags)
  * atr_get_raw, atr_get_str, atr_get: Get an attribute from the database.
  */
 
-// Global LBUF size static buffer for large LBUF -> small LBUF conversion.
-// HARD RULE: the pointer returned for an oversized attribute is valid only
-// until the next atr_get_raw() call. Callers must copy it immediately and
-// must never hold it across another fetch or combine two oversized results.
-static Attr tmp_lbuf[LBUF_SIZE];
-//
+/*
+ * Truncation buffers for attributes longer than this binary's LBUF_SIZE
+ * (for example a flatfile written by a larger-LBUF build).
+ *
+ * A single static buffer meant that two live oversized results could not
+ * coexist: any nested or successive atr_get_raw() clobbered the pointer the
+ * previous caller was still holding.  Rotating over a small pool gives each
+ * of the last TMP_LBUF_POOL fetches its own storage.
+ *
+ * HARD RULE (unchanged, just relaxed): the returned pointer is only valid
+ * until TMP_LBUF_POOL further oversized fetches have happened.  Callers
+ * should still copy it immediately rather than rely on the depth.
+ */
+#define TMP_LBUF_POOL 4
+static Attr tmp_lbuf_pool[TMP_LBUF_POOL][LBUF_SIZE];
+static int tmp_lbuf_idx = 0;
+
 char *
 atr_get_raw(dbref thing, int atr)
 {
     Attr *a;
+    Attr *dst;
     Aname okey;
 
 #ifndef STANDALONE
@@ -3435,9 +3447,11 @@ atr_get_raw(dbref thing, int atr)
       {
         if (atr == A_LIST)
             return a;
-        memset(tmp_lbuf, '\0', LBUF_SIZE);
-        strncpy(tmp_lbuf,a,LBUF_SIZE-1);
-        return tmp_lbuf;
+        dst = tmp_lbuf_pool[tmp_lbuf_idx];
+        tmp_lbuf_idx = (tmp_lbuf_idx + 1) % TMP_LBUF_POOL;
+        memset(dst, '\0', LBUF_SIZE);
+        strncpy(dst, a, LBUF_SIZE - 1);
+        return dst;
       }
     return a;
 }


### PR DESCRIPTION
## Summary

**Rebased onto `ambrosia` and narrowed.** Most of the original batch landed independently in d116c063 and ec451996, so those commits are dropped here. What remains is the part that is still unfixed, plus one follow-up on the PID-exhaustion fix.

| Issue | Change | Status |
|-------|--------|--------|
| [#256](https://github.com/RhostMUSH/trunk/issues/256) | `DPUSH`/`DPOP`: log overflow/underflow, **do not** `exit(1)` | Still unfixed on `ambrosia` |
| [#255](https://github.com/RhostMUSH/trunk/issues/255) | `atr_get_raw`: 4-deep rotating truncation pool | Reworked on top of the `ambrosia` version |
| [#253](https://github.com/RhostMUSH/trunk/issues/253) | Refund the queue slot on the PID-exhaustion return paths | Follow-up to d116c063 |

### Dropped as already fixed

- **[#254](https://github.com/RhostMUSH/trunk/issues/254)** (`munge_space_for_match` bounds) — the fix in d116c063 is byte-for-byte what this branch had.
- **[#252](https://github.com/RhostMUSH/trunk/issues/252)** (`force_halt`) — the per-`BQUE` `allow_halted` field in ec451996 is a better fix than the `QUEUE_FORCE_HALT` bitmask proposed here, and it is propagated through the freeze/thaw/wait copy sites, which this branch missed.

## Notes on what is left

**#256** was not touched by the batch; `Server/hdrs/debug.h` is unchanged on `ambrosia`. An imbalance in the debug monitor still takes the whole process down.

**#255** was addressed in 486aa08d as documentation: the buffer was marked `static` and given a "HARD RULE: copy immediately" comment. That is a correct description of the hazard, but the hazard itself is unchanged — callers still have to obey a comment. This gives the last `TMP_LBUF_POOL` oversized fetches distinct storage so the rule is hard to violate by accident. Since the buffer is now `static`, the legacy single-symbol mirror this branch previously carried is gone. The HARD RULE comment is kept, just relaxed to reflect the pool depth. Still mitigation, not elimination: nesting deeper than 4 can overlap; prefer `atr_get` / caller buffers for long-lived use.

**#253** — dropping `halt_que_all()` was the right call. But both PID-exhaustion paths now `return NULL` without undoing the `a_Queue(Owner(player), 1)` charged at the top of `setup_que`, so every exhaustion failure permanently leaks a slot from that owner's quota. The over-quota path ~20 lines earlier already refunds exactly this way; this matches it. (As before, this does not refund money paid via `payfor` — same as the old halt path.)

## Verification

`db.c` and `cque.c` compile clean to objects under `-Wall`. Not link-tested — this tree has no `custom.defs`.

## Test plan

- [ ] Build default profile
- [ ] Debugmon attached: intentional DPUSH imbalance should not kill the process
- [ ] Oversized-attr fetches (flatfile from a larger-LBUF build) still read correctly
- [ ] Instrument PID-full path: one notify + log, other queues intact, owner's queue count unchanged after the failure

Related: [#248](https://github.com/RhostMUSH/trunk/issues/248)
