### PR TITLE
DESC account_rawpass: redact on reboot dump, clear temp buffers

### DIFF
--- a/Server/src/functions.c
+++ b/Server/src/functions.c
@@ -25869,6 +25869,9 @@ FUNCTION(fun_account_su)
          if (check_connect_ex(d, s_buff, 1, i_attr))
             ;
          D_LAST_TIME(d) = mudstate_hot.now;
+         /* Clear password material from temporary buffers */
+         memset(s_tmp, '\0', LBUF_SIZE);
+         memset(s_buff, '\0', LBUF_SIZE);
          free_lbuf(s_buff);
          free_lbuf(s_tmp);
          free_lbuf(s_tmp2);
@@ -25970,6 +25973,7 @@ FUNCTION(fun_account_login)
          } else {
             ival(buff, bufcx, 0);
          }
+         memset(s_buff, '\0', LBUF_SIZE);
          free_lbuf(s_buff);
          return;
       }

--- a/Server/src/netcommon.c
+++ b/Server/src/netcommon.c
@@ -1136,7 +1136,11 @@ int dump_reboot_db( void )
     }
     /* Null telnet pointer before writing cold struct (stale across processes) */
     void *saved_telnet = d->cold->telnet;
+    char saved_rawpass[sizeof(d->cold->account_rawpass)];
     d->cold->telnet = NULL;
+    /* Do not persist plaintext account passwords across reboot */
+    memcpy(saved_rawpass, d->cold->account_rawpass, sizeof(saved_rawpass));
+    memset(d->cold->account_rawpass, '\0', sizeof(d->cold->account_rawpass));
     /* Write hot fields individually (SoA format v4) */
     if( !fwrite(&D_DESCRIPTOR(d), sizeof(int), 1, rebootfile) ||
         !fwrite(&D_FLAGS(d), sizeof(int), 1, rebootfile) ||
@@ -1154,6 +1158,8 @@ int dump_reboot_db( void )
         !fwrite(&D_LAST_TIME(d), sizeof(time_t), 1, rebootfile) ||
         !fwrite(d->cold, sizeof(DESC_COLD), 1, rebootfile) ) {
       d->cold->telnet = saved_telnet;
+      memcpy(d->cold->account_rawpass, saved_rawpass, sizeof(saved_rawpass));
+      memset(saved_rawpass, '\0', sizeof(saved_rawpass));
       STARTLOG(LOG_PROBLEMS, "RBT", "DUMP")
         log_text((char *) "Error writing to reboot file.");
       ENDLOG
@@ -1169,8 +1175,10 @@ int dump_reboot_db( void )
         fclose(slnptr->sfile);
       }
     }
-    /* Restore telnet pointer (was nulled for serialization) */
+    /* Restore telnet pointer and in-process rawpass (was redacted for dump) */
     d->cold->telnet = saved_telnet;
+    memcpy(d->cold->account_rawpass, saved_rawpass, sizeof(saved_rawpass));
+    memset(saved_rawpass, '\0', sizeof(saved_rawpass));
   }
 
   /* Pass 2 — close API connections. SAFEITER handles compaction safely:


### PR DESCRIPTION
## Summary

**Rebased onto `ambrosia` and narrowed to [#262](https://github.com/RhostMUSH/trunk/issues/262).** The NDBM half landed independently in d116c063, so it is dropped here.

| Issue | Change |
|-------|--------|
| [#262](https://github.com/RhostMUSH/trunk/issues/262) | Reboot dump: zero `account_rawpass` in the serialized cold DESC; restore in-process after the write. Clear password temp LBUFs after `account_su` / `account_login`. |

### Dropped as already fixed

**[#261](https://github.com/RhostMUSH/trunk/issues/261)** (NDBM create modes) — d116c063 changed all 11 `dbm_open` sites across `mail.c`, `mailfix.c`, `news.c` and `autoreg.c` from `00664` to `0660`. I checked; none were missed. That is more permissive than the `0600` proposed here — the files stay group-writable — but it clears the world-readable bit, which was the actual finding, and `0660` is the reasonable choice if the game is expected to run under a shared group. No reason to relitigate it.

## Notes on what is left

`account_rawpass` is untouched on `ambrosia` — no commit in the range references the symbol.

The plaintext account password is transient auth material and does not need to survive a reboot. This zeroes it for the duration of the `fwrite` only and restores the in-process copy afterward, including on the write-error path. The reboot **load** path `memcpy`s the field back verbatim, so it simply restores a zeroed buffer — no load-side change needed.

Multi-account softcode still stores rawpass on the live DESC between uses; this only stops it being written to the `.reboot` file on disk.

## Verification

`netcommon.c` compiles clean to an object under `-Wall`. `functions.c` does not compile in this tree, but fails identically on pristine `ambrosia` (missing `custom.defs`/`CUSTDEFS`) — unrelated to this change; the diff there is two `memset` calls.

## Test plan

- [ ] `@reboot` with an active account session: no plaintext password in the `.reboot` file; game comes back with sessions intact
- [ ] `account_su` / account login still work after the buffer clears

Related: [#248](https://github.com/RhostMUSH/trunk/issues/248)
