### PR TITLE
nearby/Examinable attr reads honor AF_DARK/MDARK/INTERNAL

### DIFF
--- a/Server/src/functions.c
+++ b/Server/src/functions.c
@@ -14830,8 +14830,15 @@ check_read_perms2(dbref player, dbref thing, ATTR * attr,
     if ( thing == GOING || thing == AMBIGUOUS || !Good_obj(thing))
         return 0;
     see_it = See_attr(player, thing, attr, aowner, aflags, 0);
-    if ((Examinable(player, thing) || nearby(player, thing))) /* && see_it) */
-       return 1;
+    /* Align with check_read_perms: nearby/Examinable still respect
+     * AF_INTERNAL / AF_DARK / AF_MDARK (audit F-0040 / #257). */
+    if (Examinable(player, thing) || nearby(player, thing)) {
+        if ((attr->flags & AF_INTERNAL) ||
+            ((attr->flags & AF_DARK) && !Immortal(player)) ||
+            ((attr->flags & AF_MDARK) && !Wizard(player)))
+           return 0;
+        return 1;
+    }
     /* For any object, we can read its visible attributes, EXCEPT
      * for descs, which are only visible if read_rem_desc is on.
      */
@@ -14868,8 +14875,13 @@ check_readlock_perms(dbref player, dbref thing, ATTR * attr,
     } else {
        see_it = See_attr(player, thing, attr, aowner, aflags, 0);
     }
-    if ((Examinable(player, thing) || nearby(player, thing))) /* && see_it) */
-       return 1;
+    if (Examinable(player, thing) || nearby(player, thing)) {
+        if ((attr->flags & AF_INTERNAL) ||
+            ((attr->flags & AF_DARK) && !Immortal(player)) ||
+            ((attr->flags & AF_MDARK) && !Wizard(player)))
+           return 0;
+        return 1;
+    }
     /* For any object, we can read its visible attributes, EXCEPT
      * for descs, which are only visible if read_rem_desc is on.
      */

--- a/Server/src/mail.c
+++ b/Server/src/mail.c
@@ -184,8 +184,15 @@ mail_check_readlock_perms(dbref player, dbref thing, ATTR * attr,
     } else {
        see_it = See_attr(player, thing, attr, aowner, aflags, 0);
     }
-    if ((Examinable(player, thing) || nearby(player, thing))) /* && see_it) */
-       return 1;
+    /* Nearby/Examinable still must not expose dark/internal attrs.
+     * Match check_read_perms() in functions.c (audit F-0040 / #257). */
+    if (Examinable(player, thing) || nearby(player, thing)) {
+        if ((attr->flags & AF_INTERNAL) ||
+            ((attr->flags & AF_DARK) && !Immortal(player)) ||
+            ((attr->flags & AF_MDARK) && !Wizard(player)))
+           return 0;
+        return 1;
+    }
     /* For any object, we can read its visible attributes, EXCEPT
      * for descs, which are only visible if read_rem_desc is on.
      */
@@ -219,8 +226,13 @@ check_read_perms2(dbref player, dbref thing, ATTR * attr,
     if ( thing == GOING || thing == AMBIGUOUS || !Good_obj(thing))
         return 0;
     see_it = See_attr(player, thing, attr, aowner, aflags, 0);
-    if ((Examinable(player, thing) || nearby(player, thing)))   /* && see_it) */
+    if (Examinable(player, thing) || nearby(player, thing)) {
+        if ((attr->flags & AF_INTERNAL) ||
+            ((attr->flags & AF_DARK) && !Immortal(player)) ||
+            ((attr->flags & AF_MDARK) && !Wizard(player)))
+            return 0;
         return 1;
+    }
     /* For any object, we can read its visible attributes, EXCEPT
      * for descs, which are only visible if read_rem_desc is on.
      */


### PR DESCRIPTION
## Summary

Fixes [#257](https://github.com/RhostMUSH/trunk/issues/257) (audit F-0040).

`mail_check_readlock_perms` and `check_read_perms2` (in both `mail.c` and `functions.c`) treated **nearby** or **Examinable** as an unconditional pass — the `&& see_it` conjunction was commented out.

Canonical `check_read_perms()` already restricted that path with `AF_INTERNAL` / `AF_DARK` / `AF_MDARK`. This PR aligns the siblings.

## Behavior change

Nearby/Examinable players can still read ordinary visible attributes on nearby objects (mail-sharing UX preserved), but **cannot** read:

- `AF_INTERNAL`
- `AF_DARK` (unless Immortal)
- `AF_MDARK` (unless Wizard)

## Test plan

- [ ] Nearby player can still `get()` / mail-related attr paths on public attrs
- [ ] Nearby non-wiz cannot read MDARK/DARK attrs via those helpers
- [ ] Immortal/Wizard dark visibility unchanged

Related: #248