### PR TITLE
mushexec: private ANSI strip buffer; safe_copy contract + strmax

### DIFF
--- a/Server/hdrs/alloc.h
+++ b/Server/hdrs/alloc.h
@@ -116,6 +116,12 @@ extern void  bigpool_free(void *);
 #define free_zlistnode(b)	if (b) free(b)
 #endif
 
+/*
+ * Buffer-append helpers (see stringutil.c):
+ *   safe_copy_str / safe_str: partial ok; returns *remaining* src length
+ *     (not a 0/1 overflow flag — that is safe_copy_chr).
+ *   safe_copy_strmax / safe_strmax: all-or-nothing; 0 if would not fully fit.
+ */
 #define	safe_str(s,b,p)		safe_copy_str(s,b,p,(LBUF_SIZE-2))
 #define safe_strmax(s,b,p)	safe_copy_strmax(s,b,p,(LBUF_SIZE-8))
 #define	safe_chr(c,b,p)		safe_copy_chr(c,b,p,(LBUF_SIZE-2))

--- a/Server/src/eval.c
+++ b/Server/src/eval.c
@@ -1756,7 +1756,7 @@ mushexec(dbref player, dbref cause, dbref caller, int eval, char *dstr,
 #define NFARGS 30
 #endif
 
-    char *fargs[NFARGS], *sub_txt, *sub_buf, *sub_txt2, *sub_buf2, *orig_dstr, sub_char;
+    char *fargs[NFARGS], *sub_txt, *sub_buf, *sub_txt2, *sub_buf2, *orig_dstr, *dstr_ansi, sub_char;
     char *buff, *bufc, *tstr, tbuf_stack[SBUF_SIZE], *tbuf, *tbufc, *savepos, *atr_gotten, *savestr, *s_label;
     char savec, ch, *ptsavereg, *savereg[MAX_GLOBAL_REGS + MAX_GLOBAL_BOOST], *t_bufa, *t_bufb, *t_bufc, c_last_chr,
          *nptsavereg, *saveregname[MAX_GLOBAL_REGS + MAX_GLOBAL_BOOST], c_allargs;
@@ -1794,6 +1794,7 @@ mushexec(dbref player, dbref cause, dbref caller, int eval, char *dstr,
 
     DPUSH; /* #67 */
 		
+    dstr_ansi = NULL;
     i_ansinorm = 0;
     i_start = feval = sub_delim = sub_cntr = sub_value = sub_valuecnt = 0;
     inumext = prefeval = preeval = i_capansi = 0;
@@ -1904,8 +1905,15 @@ mushexec(dbref player, dbref cause, dbref caller, int eval, char *dstr,
 	   strcpy(s_label, t_label[LABEL_MAX - 1]);
         }
     }
+    /*
+     * Never strcpy over caller's dstr with strip_ansi()'s static buffer —
+     * that can corrupt atr_get_raw / cache pointers and other shared data
+     * (audit F-0015 / #258). Work on a private LBUF when ANSI is present.
+     */
     if (index(dstr, ESC_CHAR)) {
-	strcpy(dstr, strip_ansi(dstr));
+	dstr_ansi = alloc_lbuf("mushexec.ansi");
+	strcpy(dstr_ansi, strip_ansi(dstr));
+	dstr = dstr_ansi;
     }
 
 /* Debugging only
@@ -3884,6 +3892,8 @@ mushexec(dbref player, dbref cause, dbref caller, int eval, char *dstr,
        safe_str(ANSI_NORMAL, buff, &bufc);
 #endif
     }
+    if (dstr_ansi)
+	free_lbuf(dstr_ansi);
     RETURN(buff); /* #67 */
 }
 

--- a/Server/src/stringutil.c
+++ b/Server/src/stringutil.c
@@ -1660,6 +1660,12 @@ int safe_copy_buf(const char *src, int nLen, char *buff, char **bufc)
     return nLen;
 }
 
+/*
+ * safe_copy_str: copy src into buff starting at *bufp, stopping at max
+ * offset from buff. Advances *bufp. Returns length of *remaining*
+ * uncopied source (0 if fully copied) — NOT a boolean overflow flag
+ * (unlike safe_copy_chr). Callers that ignore the return silently truncate.
+ */
 int safe_copy_str(char *src, char *buff, char **bufp, int max)
 {
 char	*tp;
@@ -1674,20 +1680,32 @@ char	*tp;
 	return strlen(src);
 }
 
+/*
+ * safe_copy_strmax: all-or-nothing copy — if src does not fully fit in
+ * the remaining room to 'max', copy nothing and return 0. On success
+ * return 0 (historical remainder-after-full-copy). Does not scan past
+ * avail+1 of src (avoids full strlen on huge sources with no room).
+ */
 int safe_copy_strmax(char *src, char *buff, char **bufp, int max)
 {
 char	*tp;
-int	left;
+int	avail, n;
+
 	tp = *bufp;
 	if (src == NULL) return 0;
-        left = (buff + max) - tp - strlen(src);
-	if ( left < 1 )
-           return 0;
-	while (*src && ((tp - buff) < max))
-		*tp++ = *src++;
-	*tp = '\0';
-	*bufp = tp;
-	return strlen(src);
+	avail = max - (int)(tp - buff);
+	if (avail < 1)
+	   return 0;
+	for (n = 0; src[n]; n++) {
+	   if (n >= avail)
+	      return 0;	/* will not fully fit — do not partial-copy */
+	}
+	/* n == strlen(src) and n <= avail */
+	if (n > 0)
+	   memcpy(tp, src, n);
+	tp[n] = '\0';
+	*bufp = tp + n;
+	return 0;
 }
 
 int safe_copy_chr(char src, char *buff, char **bufp, int max)


### PR DESCRIPTION
## Summary

| Issue | Change |
|-------|--------|
| [#258](https://github.com/RhostMUSH/trunk/issues/258) | `mushexec`: if input contains ESC, copy `strip_ansi` result into a private LBUF and evaluate that — never `strcpy` over the caller pointer with the static strip buffer |
| [#263](https://github.com/RhostMUSH/trunk/issues/263) | Document `safe_copy_str` / `safe_strmax` contracts in `alloc.h` + `stringutil.c`; `safe_copy_strmax` early-outs without full `strlen` of huge sources when there is no room |

## Notes

- `#258` does **not** make full copy-on-eval for every call (perf); only when ANSI is present.
- `parse_to` still mutates its input by design (existing contract).
- `safe_copy_str` return value semantics are **unchanged** (remainder length).

## Test plan

- [x] Softcode with ANSI in attrs evaluates correctly
- [x] Nested get/eval of colored attrs does not corrupt attribute store
- [x] Ordinary (no-ANSI) eval path unchanged
- [x] Build clean

Related: #248