### PR TITLE
docs: trust model and intentional design surfaces

### DIFF
--- a/Server/defaults/game/netrhost.conf.default
+++ b/Server/defaults/game/netrhost.conf.default
@@ -731,6 +731,9 @@ include rhost_ingame.conf
 ##### - This is the optional host(s) you wish to set to be allowable to issue the sconnect_cmd
 #       on port connects.  By default it uses 'localhost'.  It accepts multiple sites and 
 #       wildcards such as '*' and '?'.
+#       SECURITY: any matching peer can assert an arbitrary client IP (site checks / logs).
+#       Keep this tight (localhost / 127.0.0.1 / ::1 for local stunnel). Avoid '*' and open
+#       network wildcards unless every host that can reach the port is fully trusted.
 # sconnect_host localhost*
 #
 ##### - Disable connect commands on connect screen.  Add them to combine.

--- a/Server/defaults/game/netrhost.conf.default
+++ b/Server/defaults/game/netrhost.conf.default
@@ -39,6 +39,8 @@ gdbm_database	netrhost.gdbm
 # This is generally wise to keep as it is.  No, it is.  Really.
 # Some OS's will not handle forked dumps to gdbm well (ie: possible corruption)
 # Dump times are very fast anyway, so you shouldn't need forked dumps.
+# QDBM/GDBM paths have no real transactions; forked dump raises corruption risk.
+# See readme/README.DBISCORRUPT and readme/README.TRUST-MODEL.
 fork_dump no
 #
 # Comment these out (or set to empty strings) to remove dump notification

--- a/Server/readme/README.1ST
+++ b/Server/readme/README.1ST
@@ -5,6 +5,9 @@ Admin toggles to configure the WHO, various things you're used to, etc is in the
 'netrhost.conf' file.  descriptions Notes in the autoconf.h file is in the 
 README.AUTOCONF file.
 
+For intentional design surfaces (hash-as-password login, EVAL locks,
+$ pre-eval, EXECSCRIPT/doors, dual conf defaults, etc.) see README.TRUST-MODEL.
+
 
 1)  Note on bits, their levels, and things they do
 	IMMORTAL - They can do anything.  Treat this as #1 and only give to

--- a/Server/readme/README.MYSQL
+++ b/Server/readme/README.MYSQL
@@ -75,7 +75,7 @@ the following files:
 Trust / ops notes
 -----------------
 Wizard SQL is a full MySQL client under the mush process. Conf may hold
-DB passwords — keep rhost_mysql.conf and netrhost.conf unreadable by
+DB passwords -- keep rhost_mysql.conf and netrhost.conf unreadable by
 untrusted local users. Prefer least-privilege DB accounts. The MySQL
 connection is process-global (shared). Treat Immortal + SQL as
 host-adjacent. See also README.TRUST-MODEL.

--- a/Server/readme/README.MYSQL
+++ b/Server/readme/README.MYSQL
@@ -72,3 +72,11 @@ the following files:
 6.  Issue 'make clean' then make confsource to rebuild using the latest
     builder script to build in the mysql changes.
 
+Trust / ops notes
+-----------------
+Wizard SQL is a full MySQL client under the mush process. Conf may hold
+DB passwords — keep rhost_mysql.conf and netrhost.conf unreadable by
+untrusted local users. Prefer least-privilege DB accounts. The MySQL
+connection is process-global (shared). Treat Immortal + SQL as
+host-adjacent. See also README.TRUST-MODEL.
+

--- a/Server/readme/README.SSL
+++ b/Server/readme/README.SSL
@@ -69,6 +69,15 @@ sconnect_host wildcards -- This allows wildcarded sites (one or more) to allow
                            You can verify this by checking your /etc/hosts 
                            file.
 
+SECURITY (critical): Any TCP peer that matches sconnect_host can assert an
+arbitrary client IP via the sconnect secret command or HAProxy-style PROXY
+lines. That rewrites site checks, logs, and bans for that connection.
+Keep sconnect_host as tight as possible -- almost always only the stunnel
+host (localhost / 127.0.0.1 / ::1). Do NOT use broad wildcards such as
+'*' or open network ranges unless you fully trust every host that can
+reach the mush port from those addresses. Prefer local stunnel on the
+same machine so the peer is always loopback.
+
 Note: the sconnect_host is optional.  If you do not specify it, it will
       default to two values:  'localhost' and '127.0.0.1'.
   

--- a/Server/readme/README.TRUST-MODEL
+++ b/Server/readme/README.TRUST-MODEL
@@ -1,0 +1,100 @@
+RhostMUSH — trust model & intentional design surfaces
+=====================================================
+
+This note is for game owners and staff. It documents long-standing
+behavior that is **by design** (or by traditional MUSH architecture),
+not accidental bugs. Treat Immortal/Wizard bits and host integrations
+as host-level trust.
+
+Related: SSL/stunnel also see README.SSL and Server/stunnel/README.
+
+
+1. Password hash accepted as password (migration / tooling)
+----------------------------------------------------------
+
+Login validation can accept the **stored password field** (the hash
+string itself) as a successful password, then re-hash that string.
+
+This is intentional for account migration, offline tooling, and
+owner-driven recovery patterns used by many Rhost games. It is **not**
+treated as a "security hole" to remove without an explicit design
+change and compatibility plan.
+
+Operational guidance:
+
+  * Protect DB dumps, backups, and A_PASS attributes like credentials.
+  * Do not grant low-trust softcode the ability to read password attrs.
+  * If you need strict "hash never equals password" policy, that is a
+    future conf/compat switch — discuss with maintainers before changing
+    production games that rely on this.
+
+
+2. Softcode runs in "predicate" and travel paths
+------------------------------------------------
+
+These features intentionally evaluate softcode:
+
+  * **EVAL locks** — lock checks can run softcode as the lock object
+    with the passer as enactor (side effects, CPU, surprise).
+  * **$commands** — the command line is evaluated **before** pattern
+    match so chained `$` softcode works; side-effect functions can
+    fire even when no pattern matches if sideeffects are enabled.
+  * **VariableExit** — EXITTO is evaluated at travel time for dynamic
+    destinations.
+  * **mail_def_object** — softcode hooks on mail paths for +mail wrappers.
+  * **Dynhelp DYN_PARSE / SUBEVAL** — help text can be softcode for the
+    reader; trust = who may edit dynhelp sources.
+
+Prefer const/attr locks and static exits for hard security barriers.
+Keep sideeffects conservative for low-trust builders.
+
+
+3. Host boundary (Immortal / optional integrations)
+---------------------------------------------------
+
+These leave the softcode sandbox when enabled. Ops should treat them as
+"host-adjacent":
+
+  * **EXECSCRIPT** — Immortal + sideeffects; runs host scripts under the
+    mush UID. Leave the bit off unless required; least-privilege user;
+    lock down scripts/.
+  * **Doors** (`door_tcp_connect`) — outbound TCP for inter-MUSH/etc.
+    Never pass player-controlled host:port without an allowlist; OS
+    egress filter recommended.
+  * **Sample scripts** (e.g. web.sh) — free-form args can be SSRF/egress.
+    Do not ship open samples on production with EXECSCRIPT open.
+  * **MySQL / SQLite / Lua** (optional compile-in) — wizard SQL is a full
+    client; conf may hold DB passwords; shared MySQL connection is
+    process-global. Lua can bridge into softcode via rhost.strfunc.
+
+
+4. Persistence / conf defaults (ops)
+------------------------------------
+
+  * **QDBM** path has no real transactions (stubs). Use flat dump
+    discipline, monitor disk, see README.DBISCORRUPT.
+  * **fork_dump** default is off with strong warnings — leave off on
+    fragile backends unless you know your platform.
+  * **Dual config layers**: `cf_init()` historical defaults vs
+    `netrhost.conf.default` recommended overlay. When you say
+    "default is X", specify which layer.
+  * **sconnect_host** must stay tight (usually loopback only). Any
+    matching peer can assert client IPs — see README.SSL.
+
+
+5. Immortal / Royalty
+---------------------
+
+As README.1ST says: Immortal is host-level trust. Royalty is full
+wizard. Do not hand these out lightly. Softcode running as Immortal is
+effectively co-admin of the process.
+
+
+See also
+--------
+
+  README.SSL          SSL / sconnect / PROXY
+  README.MYSQL        MySQL integration
+  README.MODULES      optional modules
+  README.DBISCORRUPT  corruption narratives
+  README.1ST          bit hierarchy basics

--- a/Server/readme/README.TRUST-MODEL
+++ b/Server/readme/README.TRUST-MODEL
@@ -1,4 +1,4 @@
-RhostMUSH — trust model & intentional design surfaces
+RhostMUSH -- trust model & intentional design surfaces
 =====================================================
 
 This note is for game owners and staff. It documents long-standing
@@ -25,7 +25,7 @@ Operational guidance:
   * Protect DB dumps, backups, and A_PASS attributes like credentials.
   * Do not grant low-trust softcode the ability to read password attrs.
   * If you need strict "hash never equals password" policy, that is a
-    future conf/compat switch — discuss with maintainers before changing
+    future conf/compat switch -- discuss with maintainers before changing
     production games that rely on this.
 
 
@@ -34,15 +34,15 @@ Operational guidance:
 
 These features intentionally evaluate softcode:
 
-  * **EVAL locks** — lock checks can run softcode as the lock object
+  * **EVAL locks** -- lock checks can run softcode as the lock object
     with the passer as enactor (side effects, CPU, surprise).
-  * **$commands** — the command line is evaluated **before** pattern
+  * **$commands** -- the command line is evaluated **before** pattern
     match so chained `$` softcode works; side-effect functions can
     fire even when no pattern matches if sideeffects are enabled.
-  * **VariableExit** — EXITTO is evaluated at travel time for dynamic
+  * **VariableExit** -- EXITTO is evaluated at travel time for dynamic
     destinations.
-  * **mail_def_object** — softcode hooks on mail paths for +mail wrappers.
-  * **Dynhelp DYN_PARSE / SUBEVAL** — help text can be softcode for the
+  * **mail_def_object** -- softcode hooks on mail paths for +mail wrappers.
+  * **Dynhelp DYN_PARSE / SUBEVAL** -- help text can be softcode for the
     reader; trust = who may edit dynhelp sources.
 
 Prefer const/attr locks and static exits for hard security barriers.
@@ -55,15 +55,15 @@ Keep sideeffects conservative for low-trust builders.
 These leave the softcode sandbox when enabled. Ops should treat them as
 "host-adjacent":
 
-  * **EXECSCRIPT** — Immortal + sideeffects; runs host scripts under the
+  * **EXECSCRIPT** -- Immortal + sideeffects; runs host scripts under the
     mush UID. Leave the bit off unless required; least-privilege user;
     lock down scripts/.
-  * **Doors** (`door_tcp_connect`) — outbound TCP for inter-MUSH/etc.
+  * **Doors** (`door_tcp_connect`) -- outbound TCP for inter-MUSH/etc.
     Never pass player-controlled host:port without an allowlist; OS
     egress filter recommended.
-  * **Sample scripts** (e.g. web.sh) — free-form args can be SSRF/egress.
+  * **Sample scripts** (e.g. web.sh) -- free-form args can be SSRF/egress.
     Do not ship open samples on production with EXECSCRIPT open.
-  * **MySQL / SQLite / Lua** (optional compile-in) — wizard SQL is a full
+  * **MySQL / SQLite / Lua** (optional compile-in) -- wizard SQL is a full
     client; conf may hold DB passwords; shared MySQL connection is
     process-global. Lua can bridge into softcode via rhost.strfunc.
 
@@ -73,13 +73,13 @@ These leave the softcode sandbox when enabled. Ops should treat them as
 
   * **QDBM** path has no real transactions (stubs). Use flat dump
     discipline, monitor disk, see README.DBISCORRUPT.
-  * **fork_dump** default is off with strong warnings — leave off on
+  * **fork_dump** default is off with strong warnings -- leave off on
     fragile backends unless you know your platform.
   * **Dual config layers**: `cf_init()` historical defaults vs
     `netrhost.conf.default` recommended overlay. When you say
     "default is X", specify which layer.
   * **sconnect_host** must stay tight (usually loopback only). Any
-    matching peer can assert client IPs — see README.SSL.
+    matching peer can assert client IPs -- see README.SSL.
 
 
 5. Immortal / Royalty

--- a/Server/stunnel/README
+++ b/Server/stunnel/README
@@ -30,6 +30,11 @@ sconnect_host wildcards    -- This allows wildcarded sites (one or more)
                               as 'localhost' to you.  You can verify this
                               by checking your /etc/hosts file.
 
+SECURITY: Peers matching sconnect_host can rewrite the client IP seen by
+the mush (site lists, logs, bans). Keep this list minimal -- typically
+only localhost / 127.0.0.1 / ::1 for local stunnel. Broad wildcards
+("*") are an open invitation to IP spoofing of site policy.
+
 Note: the sconnect_host is optional.  If you do not specify it, it will
       default to two values:  'localhost' and '127.0.0.1'.
   


### PR DESCRIPTION
## Summary

Docs batch for the audit series ([#248](https://github.com/RhostMUSH/trunk/issues/248)). Documentation only — **no code changes**, no behavior changes. Merges clean onto current `ambrosia`.

| Issue | Content |
|-------|---------|
| [#264](https://github.com/RhostMUSH/trunk/issues/264) | Intentional design: hash-as-password login (**feature**, not CVE framing), EVAL locks, `$` pre-eval, VariableExit, mail_def, dynhelp |
| [#265](https://github.com/RhostMUSH/trunk/issues/265) | Host boundary: EXECSCRIPT, doors, sample scripts |
| [#266](https://github.com/RhostMUSH/trunk/issues/266) | QDBM / fork_dump / dual conf notes |
| [#267](https://github.com/RhostMUSH/trunk/issues/267) | MySQL/SQL trust note |
| [#259](https://github.com/RhostMUSH/trunk/issues/259) | `sconnect_host` SECURITY notes (folded in -- see below) |

### Files

- **New** `Server/readme/README.TRUST-MODEL` (+100)
- Pointer in `README.1ST`
- Ops note at end of `README.MYSQL`
- Stronger `fork_dump` comment in `netrhost.conf.default`

Total: 4 files, +113, −0.

## Status after the `ambrosia` batch

This branch predates the fix batch, so its merge base is `ebefe6d7`. That is only a base-point artifact — the three-dot diff GitHub shows is the four doc files above, and merging preserves everything in 486aa08d / d116c063 / ec451996 / d9e6e38c. I have re-read `README.TRUST-MODEL` against current `ambrosia`: it documents intentional design surfaces and ops posture, not the specific defects from the batch, so nothing in it went stale. Happy to rebase onto `ambrosia` if you would rather the base point be tidy.

## #259 folded in

The sconnect docs are now **in this PR**. They were written on `fix/sconnect-reip-double-negotiate` alongside the code fix; that branch was closed after the code half landed independently in d9e6e38c, which touches only `Server/src/netcommon.c` -- so the documentation never made it in.

Restored here, since this is the docs PR:

- `Server/readme/README.SSL` (+9) -- SECURITY note that any peer matching `sconnect_host` can assert an arbitrary client IP via the sconnect secret command or HAProxy-style PROXY lines, rewriting site checks, logs and bans for that connection
- `Server/stunnel/README` (+5) -- shorter form of the same warning
- `Server/defaults/game/netrhost.conf.default` (+3) -- comment next to the `sconnect_host` setting itself

This matters now that the re-IP code path is in: a loose `sconnect_host` makes the reported client IP attacker-controlled, and there was nothing next to the setting saying so. The notes interlock with the existing `sconnect_host` bullet in `README.TRUST-MODEL`, which already points at `README.SSL` for the detail.

## ASCII normalization

This branch's docs are normalized to plain ASCII (em-dashes to `--`, curly quotes to straight). The rest of `Server/readme` and `Server/stunnel` is pure ASCII and these files get read over telnet; the non-ASCII was all mine, introduced by this branch.

## Non-goals

- No change to hash-login behavior
- No removal of EVAL locks / softcode-as-predicate features

Related: [#248](https://github.com/RhostMUSH/trunk/issues/248), [#259](https://github.com/RhostMUSH/trunk/issues/259)
